### PR TITLE
Tridiag: Fix 512-thread test on GPU in debug build.

### DIFF
--- a/tests/algorithm/tridiag_tests_correctness.cpp
+++ b/tests/algorithm/tridiag_tests_correctness.cpp
@@ -107,7 +107,8 @@ struct Solve<true, APack, DataPack> {
     assert(nprob > 1 || APack::n == 1);
     assert(nprob > 1 || A.extent_int(2) == 1);
 
-    using TeamPolicy = Kokkos::TeamPolicy<Kokkos::DefaultExecutionSpace>;
+    using TeamPolicy = Kokkos::TeamPolicy<Kokkos::DefaultExecutionSpace,
+                                          Kokkos::LaunchBounds<512,2> >;
     using MT = typename TeamPolicy::member_type;
     TeamPolicy policy(1, tc.n_kokkos_thread, tc.n_kokkos_vec);
 


### PR DESCRIPTION
Use Kokkos::LaunchBounds<512,2> in the TeamPolicy decl. nvcc responds by
decreasing register usage. In turn, at runtime, all the kernels launch w/o
hitting the "Kokkos ... requested too large team size."  error. This affected
only a few of the kernels, but it's fine to specify launch bounds with these
parameters for all of them.
