### PR TITLE
Fix to EkatCreateUnitTest

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -46,7 +46,7 @@ function(EkatCreateUnitTest target_name target_srcs)
   string(STRIP "${ecut_LIBS}" ecut_LIBS)
   string(STRIP "${ecut_COMPILER_DEFS}" ecut_COMPILER_DEFS)
   string(STRIP "${ecut_LIBS_DIRS}" ecut_LIBS_DIRS)
-  string(STRIP "${ecut_INCLUDE_DIRS}" ecut_LIBS_DIRS)
+  string(STRIP "${ecut_INCLUDE_DIRS}" ecut_INCLUDE_DIRS)
 
   # Set link directories (must be done BEFORE add_executable is called)
   if (ecut_LIBS_DIRS)
@@ -71,7 +71,7 @@ function(EkatCreateUnitTest target_name target_srcs)
   )
 
   # Set all target properties
-  target_include_directories(${target_name} PUBLIC ${TEST_INCLUDE_DIRS})
+  target_include_directories(${target_name} PUBLIC "${TEST_INCLUDE_DIRS}")
 
   if (ecut_LIBS)
     target_link_libraries(${target_name} PUBLIC "${ecut_LIBS}")


### PR DESCRIPTION
Copy+paste gone wrong, pluse missing quotes around a list

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The Autotester for SCREAM was getting an odd error on white. Upon digging, it turned out that there was a mistake in EkatCreateUnitTest. It is odd that on other machines the error went undetected, but it is a legitimate error.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Detected while testing E3SM-Project/scream#510

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
No additional functions/structures have been introduced. Current testing should cover everything, and downstream PR testing in SCREAM will confirm everything is fixed. To be safe, I manually checked the new version inside SCREAM, and it seems to have fixed the issue.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
