### PR TITLE
Fix overload of operator<< for std::vector

### DIFF
--- a/src/ekat/std_meta/ekat_std_utils.hpp
+++ b/src/ekat/std_meta/ekat_std_utils.hpp
@@ -38,21 +38,6 @@ int count (const ContainerType& c, const T& value) {
   return std::count(c.begin(), c.end(), value);
 }
 
-template<typename T>
-std::ostream& operator<< (std::ostream& out, const std::vector<T>& v) {
-  const int n = v.size();
-  if (n==0) {
-    return out;
-  }
-
-  for (int i=0; i<n-1; ++i) {
-    out << v[i] << std::string(" ");
-  }
-  out << v.back();
-
-  return out;
-}
-
 } // namespace util
 
 // A set of weak_ptr would not compile, due to the lack of operator<.
@@ -70,5 +55,29 @@ template<typename T>
 using WeakPtrSet = std::set<std::weak_ptr<T>,WeakPtrLess<T>>;
 
 } // namespace ekat
+
+// Note: this *must* be in the std namespace if you want ADL lookup to work
+//       when doing something like
+//          os << my_vec
+//       with os of type std::ostream, and my_vec a std::vector<T>.
+
+namespace std {
+
+template<typename T>
+ostream& operator<< (ostream& out, const vector<T>& v) {
+  const int n = v.size();
+  if (n==0) {
+    return out;
+  }
+
+  for (int i=0; i<n-1; ++i) {
+    out << v[i] << std::string(" ");
+  }
+  out << v.back();
+
+  return out;
+}
+
+} // namespace std
 
 #endif // EKAT_STD_UTILS_HPP


### PR DESCRIPTION
The overload must be placed in the std namespace, in order for the ADL rule to kick in, and find the overload.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The operator was already overloaded, but the overload was placed in the `ekat::util` namespace. In order for ADL (Augmented Dependent Lookup) rule to work with something like a simple `std::cout << my_vector`, the overload for op<< must be in the std namespace.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Additional Information
Note: I still think the way it was before should have worked, since the overload was provided in the same namespace where it was used. However, putting it in the std namespace seems like a safe solution.