### PR TITLE
Added utility for string similarity check.

### DIFF
--- a/src/ekat/ekat_parse_yaml_file.cpp
+++ b/src/ekat/ekat_parse_yaml_file.cpp
@@ -1,6 +1,5 @@
 #include "ekat/ekat_parse_yaml_file.hpp"
 #include "ekat/ekat_assert.hpp"
-#include "ekat/ekat_assert.hpp"
 
 #include <yaml-cpp/yaml.h>
 

--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -1,4 +1,5 @@
 #include "ekat/util/ekat_string_utils.hpp"
+#include "ekat/ekat_assert.hpp"
 
 #include <algorithm>
 #include <sstream>
@@ -57,6 +58,73 @@ std::string upper_case (const std::string& s) {
                 );
   return s_up;
 }
+
+double jaro_similarity (const std::string& s1, const std::string& s2) {
+  // Two equal strings always have similarity of 1, regardless of whether they are empty or not
+  if (s1==s2) {
+    return 1;
+  }
+
+  const int len1 = s1.size();
+  const int len2 = s2.size();
+  const int max_dist = std::max(len1,len2)/2 - 1;
+
+  double matches = 0;
+  std::vector<int> s1_matches(len1,0);
+  std::vector<int> s2_matches(len2,0);
+  for (int i=0; i<len1; ++i) {
+    for (int j=std::max(0,i-max_dist); j<std::min(len2,i+max_dist+1); ++j) {
+      if (s1[i]==s2[j] && s2_matches[j]==0) {
+        matches += 1.0;
+        s1_matches[i] = 1;
+        s2_matches[j] = 1;
+        break;
+      }
+    }
+  }
+
+  // If no matches, we're done
+  if (matches==0) {
+    return 0;
+  }
+
+  // There are matches. Count transpositions
+  double transp = 0;
+  for (int i=0, k=0; i<len1; ++i) {
+    if (s1_matches[i]==1) {
+      while (s2_matches[k]==0) {
+        ++k;
+      }
+      if (s1[i]!=s2[k]) {
+        transp += 0.5;
+      }
+      ++k;
+    }
+  }
+
+  return ( matches/len1 + matches/len2 + (matches-transp)/matches ) / 3.0;
+}
+
+double jaro_winkler_similarity (const std::string& s1, const std::string& s2,
+                                const int l, const double p, const double thresh) {
+  EKAT_ASSERT_MSG (l>=0 && l<=4, "Error! Jaro-Winkler similarity requries 0<=L<=4.\n");
+  EKAT_ASSERT_MSG (p>=0 && p<=1.0/l, "Error! Jaro-Winkler similarity requries 0<=p<=1/L.\n");
+  EKAT_ASSERT_MSG (thresh>0 && thresh<1.0, "Error! Jaro-Winkler boosh thresholt requries 0<thresh<1.\n");
+
+  double sim_j = jaro_similarity(s1,s2);;
+
+  if (sim_j>thresh) {
+    const int end = std::min(static_cast<int>(std::min(s1.size(),s2.size())),l);
+    int common_prefix_len = 0;
+    while (s1[common_prefix_len]==s2[common_prefix_len] && common_prefix_len<end) {
+      ++common_prefix_len;
+    }
+    sim_j += common_prefix_len*p*(1-sim_j);
+  }
+  return sim_j;
+}
+
+// ===================== Case Insensitive String ================== //
 
 bool caseInsensitiveEqualString (const std::string& s1, const std::string& s2) {
   auto charComp = [](const char c1, const char c2)->bool{

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -37,6 +37,21 @@ std::string strint (const std::string& s, const int i);
 // Conver the string to all upper case
 std::string upper_case (const std::string& s);
 
+// Computing similarity index between s1 and s2 using Jaro algorithm
+double jaro_similarity (const std::string& s1, const std::string& s2);
+
+// Computing similarity index between s1 and s2 using Jaro-Winkler algorithm
+// For meaning and bounds for the optional arguments l, p, see e.g.
+//      https://en.wikipedia.org/wiki/Jaro-Winkler_distance
+// This routine computes jaro similarity (sj), and if sj>thresholds,
+// it performs the winkler adjustment, otherwise returns sj.
+double jaro_winkler_similarity (const std::string& s1, const std::string& s2,
+                                const int l = 4,
+                                const double p = 0.1,
+                                const double threshold = 0.7);
+
+// ==================== Case Insensitive string =================== //
+
 // A no-overhead class that inherits from std::string, which we only
 // use to trigger different behavior in the ==,!=,<,<= operators.
 class CaseInsensitiveString final : public std::string

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -38,9 +38,16 @@ std::string strint (const std::string& s, const int i);
 std::string upper_case (const std::string& s);
 
 // Computing similarity index between s1 and s2 using Jaro algorithm
+// For a quick description of the Jaro similarity index, see, e.g.,
+//   https://en.wikipedia.org/wiki/Jaro-Winkler_distance#Jaro_Similarity
+// This utility can be used to provide feedback to the user, when
+// a wrong string keyword is used, but the code has a pool of valid
+// strings to check the input against, and provide potential matches,
+// like with "string 'balh' not found; did you mean 'blah'?"
 double jaro_similarity (const std::string& s1, const std::string& s2);
 
-// Computing similarity index between s1 and s2 using Jaro-Winkler algorithm
+// Computing similarity index between s1 and s2 using Jaro-Winkler algorithm,
+// which is an "adjusted" version of the Jaro one.
 // For meaning and bounds for the optional arguments l, p, see e.g.
 //      https://en.wikipedia.org/wiki/Jaro-Winkler_distance
 // This routine computes jaro similarity (sj), and if sj>thresholds,

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -112,6 +112,49 @@ TEST_CASE("string","string") {
   REQUIRE(items[0]=="item1");
   REQUIRE(items[1]=="item2");
   REQUIRE(items[2]=="item3");
+
+  // Jaro and Jaro-Winkler similarity tests
+
+  // Benchmark list (including expected similarity values) from Winkler paper
+  //  https://www.census.gov/srd/papers/pdf/rrs2006-02.pdf
+  // Note: Winkler clamps all values below 0.7 to 0. I don't like that,
+  //       so I had to remove some entries.
+
+  //                          LHS         RHS       JARO   JARO-WINKLER
+  using entry_type = std::tuple<std::string,std::string,double, double>;
+
+  std::vector<entry_type> benchmark =
+    {
+      entry_type{ "shackleford", "shackelford", 0.970, 0.982 },
+      entry_type{ "dunningham" , "cunnigham"  , 0.896, 0.896 },
+      entry_type{ "nichleson"  , "nichulson"  , 0.926, 0.956 },
+      entry_type{ "jones"      , "johnson"    , 0.790, 0.832 },
+      entry_type{ "massey"     , "massie"     , 0.889, 0.933 },
+      entry_type{ "abroms"     , "abrams"     , 0.889, 0.922 },
+      entry_type{ "jeraldine"  , "geraldine"  , 0.926, 0.926 },
+      entry_type{ "marhta"     , "martha"     , 0.944, 0.961 },
+      entry_type{ "michelle"   , "michael"    , 0.869, 0.921 },
+      entry_type{ "julies"     , "julius"     , 0.889, 0.933 },
+      entry_type{ "tanya"      , "tonya"      , 0.867, 0.880 },
+      entry_type{ "dwayne"     , "duane"      , 0.822, 0.840 },
+      entry_type{ "sean"       , "susan"      , 0.783, 0.805 },
+      entry_type{ "jon"        , "john"       , 0.917, 0.933 },
+    };
+
+  const double tol = 0.005;
+  for (const auto& entry : benchmark) {
+    const auto& s1 = std::get<0>(entry);
+    const auto& s2 = std::get<1>(entry);
+    double sj  = util::jaro_similarity(s1,s2);
+    double sjw = util::jaro_winkler_similarity(s1,s2);
+
+    const double sj_ex = std::get<2>(entry);
+    const double sjw_ex = std::get<3>(entry);
+
+    REQUIRE (std::fabs(sj-sj_ex)<tol);
+    REQUIRE (std::fabs(sjw-sjw_ex)<tol);
+  }
+
 }
 
 } // empty namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

This PR implements a string similarity algorithm, using the Jaro (and Jaro-Winkler) algorithm.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We are already talking about forcing standard names for fields in SCREAM. If we move forward with it (and it seems very likely), users might get errors if their field names are not conforming to a standard. But it would be nice to "suggest" similar names, which is also handy if the user simply makes a typo (e.g., 'atm_presure' instead of 'atm_pressure').

A string similarity check can help us find the "correct" name in a database.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
See E3SM-Project/scream#528

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I implemented tests of the algorithm against exact values, taken from [Winkler's paper](https://www.census.gov/srd/papers/pdf/rrs2006-02.pdf), page 12. I removed a couple of entries cause Winkler truncated to 0 all similarities under 0.7.
