### PR TITLE
add parallel_reduce

### DIFF
--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -114,7 +114,7 @@ void WorkspaceManager<T, D>::init(const WorkspaceManager<T, D>& wm, const view_2
 {
   Kokkos::parallel_for(
     "WorkspaceManager ctor",
-    ExeSpaceUtils<ExeSpace>::get_default_team_policy(max_ws_idx, max_used),
+    ExeSpaceUtils<false,ExeSpace>::get_default_team_policy(max_ws_idx, max_used),
     KOKKOS_LAMBDA(const MemberType& team) {
       Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, max_used), [&] (int i) {

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -28,7 +28,7 @@ namespace ekat {
 
 namespace impl {
 
-  template <typename TeamMember, class Lambda, typename ValueType, bool Serialize>
+template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
 static KOKKOS_INLINE_FUNCTION
 void parallel_reduce (const TeamMember& team,
                       const int& begin,
@@ -125,13 +125,7 @@ struct ExeSpaceUtils {
     return TeamPolicy(ni, team_size);
   }
 
-  template <typename TeamMember, class Lambda, typename ValueType, bool Serialize =
-#ifdef EKAT_TEST_STRICT_FP
-      true
-#else
-      true //This is a hack for now since EKAT_TEST_STICT_FP is not recognized in src/
-#endif
-      >
+  template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
 			const int& begin,
@@ -139,7 +133,7 @@ struct ExeSpaceUtils {
                         const Lambda& lambda,
                         ValueType& result)
   {
-    impl::parallel_reduce<TeamMember, Lambda, ValueType, Serialize>(team, begin, end, lambda, result);
+    impl::parallel_reduce<Serialize, TeamMember, Lambda, ValueType>(team, begin, end, lambda, result);
   }
 
   template<typename PackType, typename ValueType, bool Serialize =
@@ -186,13 +180,7 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
 
 
 
-  template <typename TeamMember, class Lambda, typename ValueType, bool Serialize =
- #ifdef EKAT_TEST_STRICT_FP
-        true
- #else
-        true //This is a hack for now since EKAT_TEST_STICT_FP is not recognized in src/
- #endif
-        >
+  template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
 			const int& begin,
@@ -200,7 +188,7 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
                         const Lambda& lambda,
                         ValueType& result)
   {
-    impl::parallel_reduce<TeamMember, Lambda, ValueType, Serialize>(team, begin, end, lambda, result);
+    impl::parallel_reduce<Serialize, TeamMember, Lambda, ValueType>(team, begin, end, lambda, result);
   }
 
   template<typename PackType, typename ValueType, bool Serialize =

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -95,7 +95,6 @@ struct ExeSpaceUtils {
   {
     if (Serialize)
     {
-      std::cout << "Serialize" << std::endl;
       // We want to get C++ on GPU to match F90 on CPU. Thus, need to
       // serialize parallel reductions.
 
@@ -124,7 +123,6 @@ struct ExeSpaceUtils {
       result = local_tmp;
     }
     else {
-      std::cout << "Not Serialize" << std::endl;
       Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, begin, end), lambda, result);
     }
   }

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -106,7 +106,7 @@ reshape (Kokkos::View<DataTypeIn,Props...> view_in,
  * for a parallel kernel. On non-GPU archictures, we will generally have
  * thread teams of 1.
  */
-  template <bool Serialize, typename ExeSpace = Kokkos::DefaultExecutionSpace>
+template <bool Serialize, typename ExeSpace = Kokkos::DefaultExecutionSpace>
 struct ExeSpaceUtils {
   using TeamPolicy = Kokkos::TeamPolicy<ExeSpace>;
 
@@ -144,7 +144,7 @@ struct ExeSpaceUtils {
  */
 #ifdef KOKKOS_ENABLE_CUDA
 template <bool Serialize>
-struct ExeSpaceUtils<Kokkos::Cuda> {
+struct ExeSpaceUtils<Serialize,Kokkos::Cuda> {
   using TeamPolicy = Kokkos::TeamPolicy<Kokkos::Cuda>;
 
   static TeamPolicy get_default_team_policy (Int ni, Int nk) {

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -139,7 +139,7 @@ struct ExeSpaceUtils {
                         const Lambda& lambda,
                         ValueType& result)
   {
-    impl::parallel_reduce<TeamMember, Lambda, ValueType, Serialize>(team, begin, end, lambda, Serialize, result);
+    impl::parallel_reduce<TeamMember, Lambda, ValueType, Serialize>(team, begin, end, lambda, result);
   }
 
   template<typename PackType, typename ValueType, bool Serialize =

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -135,28 +135,6 @@ struct ExeSpaceUtils {
   {
     impl::parallel_reduce<Serialize, TeamMember, Lambda, ValueType>(team, begin, end, lambda, result);
   }
-
-  template<typename PackType, typename ValueType, bool Serialize =
-#ifdef EKAT_TEST_STRICT_FP
-      true
-#else
-      true //This is a hack for now since EKAT_TEST_STICT_FP is not recognized in src/
-#endif
-      >
-  static KOKKOS_INLINE_FUNCTION
-  void reduce_add (const PackType& p,
-                   ValueType& result)
-  {
-    if (Serialize) {
-      for (int i = 0; i < PackType::n; ++i) {
-        result += p[i];
-      }
-    } else {
-      typename PackType::scalar sum = p[0];
-      vector_simd for (int i = 1; i < PackType::n; ++i) sum += p[i];
-      result += sum;
-    }
-  }
 };
 
 /*
@@ -178,8 +156,6 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
     return TeamPolicy(ni, team_size);
   }
 
-
-
   template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
@@ -189,20 +165,6 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
                         ValueType& result)
   {
     impl::parallel_reduce<Serialize, TeamMember, Lambda, ValueType>(team, begin, end, lambda, result);
-  }
-
-  template<typename PackType, typename ValueType, bool Serialize =
-#ifdef EKAT_TEST_STRICT_FP
-       true
-#else
-       true //This is a hack for now since EKAT_TEST_STICT_FP is not recognized in src/
-#endif
-                >
-  static KOKKOS_INLINE_FUNCTION
-  void reduce_add (const PackType& p,
-                   ValueType& result)
-  {
-    ExeSpaceUtils<Kokkos::DefaultExecutionSpace>::reduce_add(p, result);
   }
 };
 #endif

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -27,7 +27,7 @@ namespace ekat {
 
 namespace impl {
 
-template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
+template <typename TeamMember, typename Lambda, typename ValueType, bool Serialize>
 static KOKKOS_INLINE_FUNCTION
 void parallel_reduce (const TeamMember& team,
                       const int& begin,
@@ -106,7 +106,7 @@ reshape (Kokkos::View<DataTypeIn,Props...> view_in,
  * for a parallel kernel. On non-GPU archictures, we will generally have
  * thread teams of 1.
  */
-template <typename ExeSpace = Kokkos::DefaultExecutionSpace>
+  template <bool Serialize, typename ExeSpace = Kokkos::DefaultExecutionSpace>
 struct ExeSpaceUtils {
   using TeamPolicy = Kokkos::TeamPolicy<ExeSpace>;
 
@@ -124,7 +124,7 @@ struct ExeSpaceUtils {
     return TeamPolicy(ni, team_size);
   }
 
-  template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
+  template <typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
                         const int& begin,
@@ -132,7 +132,7 @@ struct ExeSpaceUtils {
                         const Lambda& lambda,
                         ValueType& result)
   {
-    impl::parallel_reduce<Serialize, TeamMember, Lambda, ValueType>(team, begin, end, lambda, result);
+    impl::parallel_reduce<TeamMember, Lambda, ValueType, Serialize>(team, begin, end, lambda, result);
   }
 };
 
@@ -143,7 +143,7 @@ struct ExeSpaceUtils {
  * threads than the main kernel loop has indices.
  */
 #ifdef KOKKOS_ENABLE_CUDA
-template <>
+template <bool Serialize>
 struct ExeSpaceUtils<Kokkos::Cuda> {
   using TeamPolicy = Kokkos::TeamPolicy<Kokkos::Cuda>;
 
@@ -155,7 +155,7 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
     return TeamPolicy(ni, team_size);
   }
 
-  template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
+  template <typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
                         const int& begin,
@@ -163,7 +163,7 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
                         const Lambda& lambda,
                         ValueType& result)
   {
-    impl::parallel_reduce<Serialize, TeamMember, Lambda, ValueType>(team, begin, end, lambda, result);
+    impl::parallel_reduce<TeamMember, Lambda, ValueType, Serialize>(team, begin, end, lambda, result);
   }
 };
 #endif

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -9,6 +9,7 @@
 #include "ekat/ekat_assert.hpp"
 #include "ekat/ekat_type_traits.hpp"
 #include "ekat/ekat.hpp"
+#include "ekat/ekat_macros.hpp"
 
 #include "Kokkos_Random.hpp"
 
@@ -77,6 +78,60 @@ struct ExeSpaceUtils {
   static TeamPolicy get_team_policy_force_team_size (Int ni, Int team_size) {
     return TeamPolicy(ni, team_size);
   }
+
+  template <typename TeamMember, class Lambda, typename ValueType>
+  static KOKKOS_INLINE_FUNCTION
+  void parallel_reduce (const TeamMember& team,
+			const int& begin,
+			const int& end,
+                        const Lambda& lambda,
+                        const bool serialize,
+                        ValueType& result)
+  {
+    if (serialize)
+    {
+      // We want to get C++ on GPU to match F90 on CPU. Thus, need to
+      // serialize parallel reductions.
+
+      // All threads init result.
+      // NOTE: we *need* an automatic temporary, since we do not know
+      //       where 'result' comes from. If result itself is an automatic
+      //       variable, using it would be fine (only one vector lane would
+      //       actually have a nonzero value after the single). But if
+      //       result is taken from a view, then all vector lanes would
+      //       see the updated value before the vector_reduce call,
+      //       which will cause the final answer to be multiplied by the
+      //       size of the warp.
+      auto local_tmp = Kokkos::reduction_identity<ValueType>::sum();
+
+      Kokkos::single(Kokkos::PerThread(team),[&] {
+      for (int k=begin; k<end; ++k)
+        lambda(k, local_tmp);
+        });
+
+      result = local_tmp;
+    }
+    else
+      Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, begin, end), lambda, result);
+  }
+
+  template<typename PackType, typename ValueType, bool Serialize=false>
+  static KOKKOS_INLINE_FUNCTION
+  void reduce_add (const PackType& p,
+                   ValueType& result)
+  {
+    if (Serialize)
+    {
+      for (int i = 0; i < PackType::n; ++i)
+        result += p[i];
+    }
+    else
+    {
+      typename PackType::scalar sum = p[0];
+      vector_simd for (int i = 1; i < PackType::n; ++i) sum += p[i];
+      result += sum;
+    }
+  }
 };
 
 /*
@@ -96,6 +151,66 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
 
   static TeamPolicy get_team_policy_force_team_size (Int ni, Int team_size) {
     return TeamPolicy(ni, team_size);
+  }
+
+
+
+  template <typename TeamMember, class Lambda, typename ValueType/*, bool Serialize=true*/>
+  static KOKKOS_INLINE_FUNCTION
+  void parallel_reduce (const TeamMember& team,
+			const int& begin,
+			const int& end,
+                        const Lambda& lambda,
+                        const bool serialize,
+                        ValueType& result)
+  {
+    if (serialize)
+    {
+      // We want to get C++ on GPU to match F90 on CPU. Thus, need to
+      // serialize parallel reductions.
+
+      // All threads init result.
+      // NOTE: we *need* an automatic temporary, since we do not know
+      //       where 'result' comes from. If result itself is an automatic
+      //       variable, using it would be fine (only one vector lane would
+      //       actually have a nonzero value after the single). But if
+      //       result is taken from a view, then all vector lanes would
+      //       see the updated value before the vector_reduce call,
+      //       which will cause the final answer to be multiplied by the
+      //       size of the warp.
+      auto local_tmp = Kokkos::reduction_identity<ValueType>::sum();
+
+      Kokkos::single(Kokkos::PerThread(team),[&] {
+      for (int k=begin; k<end; ++k)
+        lambda(k, local_tmp);
+        });
+
+      // Broadcast result to all threads by doing sum of one thread's
+      // non-0 value and the rest of the 0s.
+      Kokkos::Impl::CudaTeamMember::vector_reduce(Kokkos::Sum<ValueType>(local_tmp));
+
+      result = local_tmp;
+    }
+    else
+      Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, begin, end), lambda, result);
+  }
+
+  template<typename PackType, typename ValueType, bool Serialize=false>
+  static KOKKOS_INLINE_FUNCTION
+  void reduce_add (const PackType& p,
+                   ValueType& result)
+  {
+    if (Serialize)
+    {
+      for (int i = 0; i < PackType::n; ++i)
+        result += p[i];
+    }
+    else
+    {
+      typename PackType::scalar sum = p[0];
+      vector_simd for (int i = 1; i < PackType::n; ++i) sum += p[i];
+      result += sum;
+    }
   }
 };
 #endif

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -9,7 +9,6 @@
 #include "ekat/ekat_assert.hpp"
 #include "ekat/ekat_type_traits.hpp"
 #include "ekat/ekat.hpp"
-#include "ekat/ekat_macros.hpp"
 
 #include "Kokkos_Random.hpp"
 
@@ -128,8 +127,8 @@ struct ExeSpaceUtils {
   template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
-			const int& begin,
-			const int& end,
+                        const int& begin,
+                        const int& end,
                         const Lambda& lambda,
                         ValueType& result)
   {
@@ -159,8 +158,8 @@ struct ExeSpaceUtils<Kokkos::Cuda> {
   template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
-			const int& begin,
-			const int& end,
+                        const int& begin,
+                        const int& end,
                         const Lambda& lambda,
                         ValueType& result)
   {

--- a/src/ekat/util/ekat_lin_interp_impl.hpp
+++ b/src/ekat/util/ekat_lin_interp_impl.hpp
@@ -14,7 +14,7 @@ LinInterp<ScalarT, PackSize, DeviceT>::LinInterp(int ncol, int km1, int km2, Sca
   m_km1_pack(ekat::npack<Pack>(km1)),
   m_km2_pack(ekat::npack<Pack>(km2)),
   m_minthresh(minthresh),
-  m_policy(ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_km2_pack)),
+  m_policy(ExeSpaceUtils<false,ExeSpace>::get_default_team_policy(ncol, m_km2_pack)),
   m_indx_map("m_indx_map", ncol, ekat::npack<IntPack>(km2))
 {}
 

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -196,7 +196,7 @@ TEST_CASE("team_utils_large_ni", "[kokkos_utils]")
   test_utils_large_ni(.5);
 }
 
-template<typename Scalar, int length, int CheckResult>
+template<typename Scalar, int length, bool Serialize>
 void test_parallel_reduce()
 {
   using Device = ekat::DefaultDevice;
@@ -233,7 +233,7 @@ void test_parallel_reduce()
 
     const int begin = 0;
     const int end = length;
-    ekat::ExeSpaceUtils<ExeSpace>::parallel_reduce(team, begin, end, 
+    ekat::ExeSpaceUtils<ExeSpace>::parallel_reduce<Serialize>(team, begin, end,
         [&] (const int k, Scalar& reduction_value) {
               reduction_value += data[k];
         }, team_result);
@@ -242,20 +242,15 @@ void test_parallel_reduce()
     });
 
   Kokkos::deep_copy(results_h, results);
-  if (CheckResult) { 
+  if (Serialize) {
     REQUIRE(results_h(0) == serial_result);
   }
 }
 
 TEST_CASE("parallel_reduce", "[kokkos_utils]")
 {
-  test_parallel_reduce<Real, 15,
-#ifdef EKAT_TEST_STRICT_FP
-      true
-#else
-      false
-#endif
-      >();
+  test_parallel_reduce<Real,15,true> ();
+  test_parallel_reduce<Real,15,false> ();
 }
 
 template<typename Scalar>

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -4,8 +4,6 @@
 #include "ekat/kokkos/ekat_kokkos_types.hpp"
 #include "ekat/util/ekat_arch.hpp"
 
-#include "ekat/ekat_pack.hpp"
-
 #include "ekat_test_config.h"
 
 #include <thread>

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -196,7 +196,7 @@ TEST_CASE("team_utils_large_ni", "[kokkos_utils]")
   test_utils_large_ni(.5);
 }
 
-template<typename Scalar, int n_teams, int work_per_team>
+template<typename Scalar, int length>
 void test_parallel_reduce()
 {
   using Device = ekat::DefaultDevice;
@@ -213,50 +213,40 @@ void test_parallel_reduce()
   }
 #endif
 
-  const int length = n_teams*work_per_team;
   Kokkos::View<Scalar*, ExeSpace> data("data", length);
   const auto data_h = Kokkos::create_mirror_view(data);
   auto raw = data_h.data();
   for (int i = 0; i < length; ++i)
-    raw[i] = 1.0/(i+1);
+    raw[i] = std::pow(0.5,i);
   Kokkos::deep_copy(data, data_h);
 
-  Kokkos::View<Scalar*> results ("results", n_teams);
+  Kokkos::View<Scalar*> results ("results", 1);
   const auto results_h = Kokkos::create_mirror_view(results);
 
-  std::vector<Real> serial_results(n_teams);
-  for (unsigned int t=0; t<n_teams; ++t)
-    for (unsigned int w=0; w<work_per_team; ++w)
-    {
-      const int i = t*work_per_team + w;
-      serial_results[t] += 1.0/(i+1);
-    }
+  const Scalar serial_result = (1.0-std::pow(0.5,length))/(1.0-0.5);
 
   const auto policy =
-    ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(n_teams, work_per_team);
+    ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, length);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-    const int t = team.league_rank();
     Scalar team_result = Scalar();
 
-    const int begin = t*work_per_team;
-    const int end = begin + work_per_team;
+    const int begin = 0;
+    const int end = length;
     ekat::ExeSpaceUtils<ExeSpace>::parallel_reduce(team, begin, end,
         [&] (const int k, Scalar& reduction_value) {
                  reduction_value += data[k];
-               }, true/*serialize*/, team_result);
+               }, team_result);
 
-    results(t) = team_result;
+    results(0) = team_result;
     });
 
   Kokkos::deep_copy(results_h, results);
-
-  for (unsigned int t=0; t<n_teams; ++t)
-    REQUIRE(results_h(t) == serial_results[t]);
+  REQUIRE(results_h(0) == serial_result);
 }
 
 TEST_CASE("parallel_reduce", "[kokkos_utils]")
 {
-  test_parallel_reduce<Real, 5, 10>();
+  test_parallel_reduce<Real, 20>();
 }
 
 template<typename Scalar>

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -253,43 +253,4 @@ TEST_CASE("parallel_reduce", "[kokkos_utils]")
   test_parallel_reduce<Real,15,false> ();
 }
 
-template<typename Scalar>
-void test_reduce_add()
-{
-  using Device = ekat::DefaultDevice;
-  using ExeSpace = typename ekat::KokkosTypes<Device>::ExeSpace;
-  
-#ifdef KOKKOS_ENABLE_OPENMP
-  const int n = omp_get_max_threads();
-  // test will not work with more than 16 threads
-  if (n > 16)
-  {
-    WARN("Skipped because this test doesn't support more than 16 threads");
-    return;
-  }
-#endif  
-    
-  Scalar start = Scalar(0.5);
-  Scalar serial_result = start;
-  Scalar reduce_add_result = start;
-  REQUIRE(reduce_add_result == serial_result);
-   
-  using PackType = ekat::Pack<Scalar,8>;
-  PackType pack;
-  for (int i=0; i<PackType::n; ++i)
-  {
-    Scalar pack_val = 1.0/(i+1);
-    serial_result += pack_val;
-    pack[i] = pack_val;		 
-  }
-
-  ekat::ExeSpaceUtils<ExeSpace>::reduce_add<PackType,Scalar,true/*serialize*/>(pack,reduce_add_result);
-  REQUIRE(reduce_add_result == serial_result);
-}
-
-TEST_CASE("reduce_add", "[kokkos_utils]")
-{
-  test_reduce_add<Real>();
-}
-
 } // anonymous namespace

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -201,15 +201,6 @@ void test_parallel_reduce()
   using MemberType = typename ekat::KokkosTypes<Device>::MemberType;
   using ExeSpace = typename ekat::KokkosTypes<Device>::ExeSpace;
 
-#ifdef KOKKOS_ENABLE_OPENMP
-  const int n = omp_get_max_threads();
-  // test will not work with more than 16 threads
-  if (n > 16) {
-    WARN("Skipped because this test doesn't support more than 16 threads");
-    return;
-  }
-#endif
-
   Kokkos::View<Scalar*, ExeSpace> data("data", length);
   const auto data_h = Kokkos::create_mirror_view(data);
   auto raw = data_h.data();
@@ -242,6 +233,8 @@ void test_parallel_reduce()
   Kokkos::deep_copy(results_h, results);
   if (Serialize) {
     REQUIRE(results_h(0) == serial_result);
+  } else {
+    REQUIRE(std::abs(results_h(0) - serial_result) <= 10*std::numeric_limits<Scalar>::epsilon());
   }
 }
 

--- a/tests/kokkos/workspace_tests.cpp
+++ b/tests/kokkos/workspace_tests.cpp
@@ -35,7 +35,7 @@ static void unittest_workspace_overprovision()
   const int max_threads = ExeSpace::concurrency();
   const int nk = OnGpu<ExeSpace>::value ? 128 : (max_threads < 7 ? max_threads : 7);
 
-  const auto temp_policy = ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(1, nk);
+  const auto temp_policy = ExeSpaceUtils<false,ExeSpace>::get_team_policy_force_team_size(1, nk);
   TeamUtils<Real,ExeSpace> tu_temp(temp_policy);
   const int num_conc = tu_temp.get_max_concurrent_threads() / temp_policy.team_size();
 
@@ -49,7 +49,7 @@ static void unittest_workspace_overprovision()
   const int ni_over    = num_conc * (explicit_op_fact + .5);
 
   for (const int ni_item : {ni_under, ni_conc, ni_between, ni_exact, ni_over}) {
-    TeamPolicy policy(ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(ni_item, nk));
+    TeamPolicy policy(ExeSpaceUtils<false,ExeSpace>::get_team_policy_force_team_size(ni_item, nk));
     WSM wsm(4, 4, policy);
 
     if (ni_item <= ni_exact) {
@@ -64,7 +64,7 @@ static void unittest_workspace_overprovision()
   }
 
   for (const int ni_item : {ni_under, ni_conc, ni_between, ni_exact, ni_over}) {
-    TeamPolicy policy(ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(ni_item, nk));
+    TeamPolicy policy(ExeSpaceUtils<false,ExeSpace>::get_team_policy_force_team_size(ni_item, nk));
     WSM wsm(4, 4, policy, explicit_op_fact);
 
     if (ni_item <= ni_exact) {
@@ -91,7 +91,7 @@ static void unittest_workspace()
   const int ni = 128;
   const int nk = 128;
 
-  TeamPolicy policy(ExeSpaceUtils<ExeSpace>::get_default_team_policy(ni, nk));
+  TeamPolicy policy(ExeSpaceUtils<false,ExeSpace>::get_default_team_policy(ni, nk));
 
   {
     WorkspaceManager<double, Device> wsmd(17, num_ws, policy);
@@ -121,7 +121,7 @@ static void unittest_workspace()
   // Test host-explicit WorkspaceMgr
   {
     using HostDevice = Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
-    typename KokkosTypes<HostDevice>::TeamPolicy policy_host(ExeSpaceUtils<typename KokkosTypes<HostDevice>::ExeSpace>::get_default_team_policy(ni, nk));
+    typename KokkosTypes<HostDevice>::TeamPolicy policy_host(ExeSpaceUtils<false, typename KokkosTypes<HostDevice>::ExeSpace>::get_default_team_policy(ni, nk));
     WorkspaceManager<short, HostDevice> wsmh(16, num_ws, policy_host);
     wsmh.m_data(0, 0) = 0; // check on cuda machine
   }

--- a/tests/pack/pack_kokkos_tests.cpp
+++ b/tests/pack/pack_kokkos_tests.cpp
@@ -230,7 +230,7 @@ TEST_CASE("kokkos_packs", "ekat::pack") {
 
   typename KokkosTypes<DefaultDevice>::template view_1d<TestBigPack> test_k_array("test_k_array", num_bigs);
   Kokkos::parallel_reduce("unittest_pack",
-                          ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, 1),
+                          ExeSpaceUtils<false,ExeSpace>::get_default_team_policy(1, 1),
                           KOKKOS_LAMBDA(const MemberType& team, int& total_errs) {
 
     int nerrs_local = 0;


### PR DESCRIPTION
## Motivation
`ExeSpaceUtils::parallel_reduce()` discussed in Issue https://github.com/E3SM-Project/EKAT/issues/32. Allows for a serial implementation for `parallel_reduce()` for the purpose of matching bfb to fortran.

`ExeSpaceUtils::reduce_add()` discussed in Issue https://github.com/E3SM-Project/EKAT/issues/26. Provides a function which gives the sum over an `ekat::Pack`. Also allows for a serial implementation for the purpose of matching bfb to fortran.


## Testing
I created 2 tests in **tests/kokkos/kokkos_utils_tests.cpp**:  `parallel_reduce` and `reduce_add`, which compare some simple serial computation done in for loops (like in fortran) with the serialized version of the implemented functions. Each test, when tested on the GPU, passes *only* when `serialize=true`. On the CPU, `parallel_reduce` passes with  `serialize=false`, but that may be expected.

## Additional Information
A few comments/questions:

- Ideally `bool serialize` would be a template parameter in both functions, however for `parallel_reduce()` I was unsure how I would call the function given that I do not know the explicit Lambda type and am relying on the compiler to detect it for me. Also, the src directory does not seem to know the correct value of `EKAT_TEST_STRICT_FP`, so I couldn't use that as in [this example (line 321)](https://github.com/E3SM-Project/E3SM/blob/7d36ff4b568044b80d1dc5aba4194c9563e88396/components/homme/src/share/cxx/ExecSpaceDefs.hpp#L260). Open to suggestions.
- For both functions, I basically have a completely identical copy for Cuda and CPU implementation. Is there a way I can avoid this? 
- In `reduce_add()`, I'm guessing that `PackType::n`return the potential size of the pack, and does not account for garbage if it is not completely full? Which could be an issue if I'm summing up all entries.. From [here](https://github.com/E3SM-Project/E3SM/blob/b7b269b3cfaca869e861fa01e6d65e201dc588a3/components/homme/src/share/cxx/ColumnOps.hpp#L474), they were able to access `ColInfo<LENGTH>::LastPackLen` to test if the final pack was full. Do I have something similar available here?
- I'm open to all suggestions, criticisms, etc. Let me know too if the formatting/indenting is acceptable. 