### PR TITLE
fixes CMake bug for make install

### DIFF
--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -44,7 +44,7 @@ set(EKAT_STD_META_HEADERS
   std_meta/ekat_std_utils.hpp
 )
 install(FILES ${EKAT_STD_META_HEADERS} DESTINATION include/ekat/std_meta)
-set(EKAT_STD_UTIL_HEADERS
+set(EKAT_UTIL_HEADERS
   util/ekat_feutils.hpp
   util/ekat_rational_constant.hpp
   util/ekat_test_utils.hpp


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation

Fixes CMake bug that prevented `ekat/util` headers from being installed, which in turn prevented client codes from being able to find them at `${CMAKE_INSTALL_PREFIX}/include`
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Closes #28 


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Tested on Mac OS X.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
