### PR TITLE
add view_reduction

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -327,7 +327,7 @@ void reduce_sum (const PackType& p, typename PackType::scalar& sum) {
 // return sum = p[0]+p[1]+...
 template <bool Serialize, typename PackType> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<PackType, typename PackType::scalar> reduce_sum (const PackType& p) {
-  typename PackType::scalar sum = PackType::scalar();
+  typename PackType::scalar sum = typename PackType::scalar(0);
   reduce_sum<Serialize>(p,sum);
   return sum;
 }

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -38,7 +38,7 @@ struct Mask {
   enum { n = PackSize };
 
   KOKKOS_FORCEINLINE_FUNCTION
-  explicit Mask () {}
+  Mask () {}
 
   // Init all slots of the Mask to 'init'.
   KOKKOS_FORCEINLINE_FUNCTION explicit Mask (const bool& init) {
@@ -156,7 +156,7 @@ struct Pack {
   typedef typename std::remove_const<ScalarType>::type scalar;
 
   KOKKOS_FORCEINLINE_FUNCTION
-  explicit Pack () {
+  Pack () {
     vector_simd for (int i = 0; i < n; ++i) {
       d[i] = ScalarTraits<scalar>::invalid();
     }

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -314,6 +314,22 @@ OnlyPackReturn<PackType, typename PackType::scalar> max (const PackType& p) {
   return v;
 }
 
+// return a+p[0]+p[1]+...
+template <bool Serialize, typename PackType, typename Scalar> KOKKOS_INLINE_FUNCTION
+OnlyPackReturn<PackType, typename PackType::scalar> reduce_sum (const PackType& p, const Scalar a=Scalar()) {
+  Scalar return_val = Scalar(a);
+  if (Serialize) {
+    for (int i = 0; i < PackType::n; ++i) {
+      return_val += p[i];
+    }
+  } else {
+    typename PackType::scalar sum = p[0];
+    vector_simd for (int i = 1; i < PackType::n; ++i) sum += p[i];
+    return_val += sum;
+  }
+  return return_val;
+}
+
 // min(init, min(p(mask)))
 template <typename PackType> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<PackType, typename PackType::scalar>

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -314,20 +314,22 @@ OnlyPackReturn<PackType, typename PackType::scalar> max (const PackType& p) {
   return v;
 }
 
-// return a+p[0]+p[1]+...
-template <bool Serialize, typename PackType, typename Scalar> KOKKOS_INLINE_FUNCTION
-OnlyPackReturn<PackType, typename PackType::scalar> reduce_sum (const PackType& p, const Scalar a=Scalar()) {
-  Scalar return_val = Scalar(a);
+// sum = sum+p[0]+p[1]+...
+template <bool Serialize, typename PackType> KOKKOS_INLINE_FUNCTION
+void reduce_sum (const PackType& p, typename PackType::scalar& sum) {
   if (Serialize) {
-    for (int i = 0; i < PackType::n; ++i) {
-      return_val += p[i];
-    }
+    for (int i = 0; i < PackType::n; ++i) sum += p[i];
   } else {
-    typename PackType::scalar sum = p[0];
-    vector_simd for (int i = 1; i < PackType::n; ++i) sum += p[i];
-    return_val += sum;
+    vector_simd for (int i = 0; i < PackType::n; ++i) sum += p[i];
   }
-  return return_val;
+}
+
+// return sum = p[0]+p[1]+...
+template <bool Serialize, typename PackType> KOKKOS_INLINE_FUNCTION
+OnlyPackReturn<PackType, typename PackType::scalar> reduce_sum (const PackType& p) {
+  typename PackType::scalar sum = PackType::scalar();
+  reduce_sum<Serialize>(p,sum);
+  return sum;
 }
 
 // min(init, min(p(mask)))

--- a/src/ekat/kokkos/ekat_kokkos_types.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_types.hpp
@@ -71,4 +71,13 @@ struct KokkosTypes
 
 } // namespace ekat
 
+// Kokkos-compatible reduction identity for arbitrary packs
+namespace Kokkos {
+template<typename PackType>
+struct reduction_identity {
+  KOKKOS_FORCEINLINE_FUNCTION
+  static PackType sum()  {return PackType(typename PackType::scalar(0));}
+};
+}
+
 #endif // EKAT_KOKKOS_TYPES_HPP

--- a/src/ekat/kokkos/ekat_kokkos_types.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_types.hpp
@@ -71,13 +71,4 @@ struct KokkosTypes
 
 } // namespace ekat
 
-// Kokkos-compatible reduction identity for arbitrary packs
-namespace Kokkos {
-template<typename PackType>
-struct reduction_identity {
-  KOKKOS_FORCEINLINE_FUNCTION
-  static PackType sum()  {return PackType(0);}
-};
-}
-
 #endif // EKAT_KOKKOS_TYPES_HPP

--- a/src/ekat/kokkos/ekat_kokkos_types.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_types.hpp
@@ -76,7 +76,7 @@ namespace Kokkos {
 template<typename PackType>
 struct reduction_identity {
   KOKKOS_FORCEINLINE_FUNCTION
-  static PackType sum()  {return PackType(typename PackType::scalar(0));}
+  static PackType sum()  {return PackType(0);}
 };
 }
 

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -24,6 +24,20 @@
 // that are probably not generic enough to appear in kokkos any time soon
 // (or ever), and are more app-specific.
 
+// Kokkos-compatible reduction identity for arbitrary packs
+namespace Kokkos {
+template<typename S, int N>
+struct reduction_identity<ekat::Pack<S,N>> {
+  using PackType = ekat::Pack<S,N>;
+
+  // Provide only sum, since that's our only use case, for now
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr static PackType sum() {
+    return PackType (reduction_identity<S>::sum());
+  }
+};
+} // namespace Kokkos
+
 namespace ekat {
 
 namespace impl {

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -32,11 +32,12 @@ namespace impl {
 // one element in order, useful for BFB testing with serial routines.
 // If Serialize=false, this function simply calls Kokkos::parallel_reduce().
 // If result contains a value, the output is result+reduction
+// For typical application, begin and end are pack indices.
 template <bool Serialize, typename TeamMember, typename Lambda, typename ValueType>
 static KOKKOS_INLINE_FUNCTION
 void parallel_reduce (const TeamMember& team,
-                      const int& begin,
-                      const int& end,
+                      const int& begin, // pack index
+                      const int& end, // pack index
                       const Lambda& lambda,
                       ValueType& result)
 {
@@ -119,7 +120,7 @@ void view_reduction (const TeamMember& team,
           ekat::reduce_sum<Serialize>(input(k),local_sum);
       }, result);
     } else {
-      PackType packed_result(typename PackType::scalar(0));
+      PackType packed_result(0);
       impl::parallel_reduce<Serialize>(team, pack_loop_begin, pack_loop_end,
                                        [&](const int k, PackType& local_packed_sum) {
           // Sum packs
@@ -201,8 +202,8 @@ struct ExeSpaceUtils {
   template <typename TeamMember, typename Lambda, typename ValueType>
   static KOKKOS_INLINE_FUNCTION
   void parallel_reduce (const TeamMember& team,
-                        const int& begin,
-                        const int& end,
+                        const int& begin, // pack index
+                        const int& end, // pack index
                         const Lambda& lambda,
                         ValueType& result)
   {

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -250,8 +250,8 @@ TEST_CASE("parallel_reduce", "[kokkos_utils]")
 }
 
 
-template<typename Scalar, bool Serialize, int TotalSize, int VectorSize>
-void test_view_reduction(const Scalar a=Scalar(0.0), const int begin=0, const int end=TotalSize, bool use_lambda=false)
+template<typename Scalar, bool Serialize, bool UseLambda, int TotalSize, int VectorSize>
+void test_view_reduction(const Scalar a=Scalar(0.0), const int begin=0, const int end=TotalSize)
 {
   using Device = ekat::DefaultDevice;
   using MemberType = typename ekat::KokkosTypes<Device>::MemberType;
@@ -294,7 +294,7 @@ void test_view_reduction(const Scalar a=Scalar(0.0), const int begin=0, const in
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     Scalar team_result = Scalar(a);
 
-    if (use_lambda) {
+    if (UseLambda) {
       ekat::ExeSpaceUtils<Serialize,ExeSpace>::view_reduction(team, begin, end,
                                                               [&] (const int k) -> PackType {
                                                                 return data(k);
@@ -320,31 +320,43 @@ TEST_CASE("view_reduction", "[kokkos_utils]")
   // VectorSize = 1
 
   // Sum all entries
-  test_view_reduction<Real, true,8,1> ();
-  test_view_reduction<Real,false,8,1> ();
+  test_view_reduction<Real, true,true,8,1> ();
+  test_view_reduction<Real,false,true,8,1> ();
+  test_view_reduction<Real, true,false,8,1> ();
+  test_view_reduction<Real,false,false,8,1> ();
 
   // Sum subset of entries, non-zero starting value, lambda data representation
-  test_view_reduction<Real, true,8,1> (1.0/3.0,2,5,true);
-  test_view_reduction<Real,false,8,1> (1.0/3.0,2,5,true);
+  test_view_reduction<Real, true,true,8,1> (1.0/3.0,2,5);
+  test_view_reduction<Real,false,true,8,1> (1.0/3.0,2,5);
+  test_view_reduction<Real, true,false,8,1> (1.0/3.0,2,5);
+  test_view_reduction<Real,false,false,8,1> (1.0/3.0,2,5);
 
 #ifndef KOKKOS_ENABLE_CUDA
   // VectorSize > 1
 
   // Full packs, sum all entries
-  test_view_reduction<Real, true,8,4> ();
-  test_view_reduction<Real,false,8,4> ();
+  test_view_reduction<Real, true,true,8,4> ();
+  test_view_reduction<Real,false,true,8,4> ();
+  test_view_reduction<Real, true,false,8,4> ();
+  test_view_reduction<Real,false,false,8,4> ();
 
   // Last pack not full, sum all entries
-  test_view_reduction<Real, true,7,4> ();
-  test_view_reduction<Real,false,7,4> ();
+  test_view_reduction<Real, true,true,7,4> ();
+  test_view_reduction<Real,false,true,7,4> ();
+  test_view_reduction<Real, true,false,7,4> ();
+  test_view_reduction<Real,false,false,7,4> ();
 
   // Only pack not full, sum all entries
-  test_view_reduction<Real, true,3,4> ();
-  test_view_reduction<Real,false,3,4> ();
+  test_view_reduction<Real, true,true,3,4> ();
+  test_view_reduction<Real,false,true,3,4> ();
+  test_view_reduction<Real, true,false,3,4> ();
+  test_view_reduction<Real,false,false,3,4> ();
 
   // Sum subset of entries, non-zero starting value
-  test_view_reduction<Real, true,16,3> (1.0/3.0,2,11);
-  test_view_reduction<Real,false,16,3> (1.0/3.0,2,11);
+  test_view_reduction<Real, true,true,16,3> (1.0/3.0,2,11);
+  test_view_reduction<Real,false,true,16,3> (1.0/3.0,2,11);
+  test_view_reduction<Real, true,false,16,3> (1.0/3.0,2,11);
+  test_view_reduction<Real,false,false,16,3> (1.0/3.0,2,11);
 #endif
 }
 

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -157,6 +157,25 @@ struct TestPack {
       REQUIRE(p[i] == static_cast<scalar>(42 + i));
   }
 
+  template<bool Serialize>
+  static void test_reduce_sum () {
+    const scalar a = 0.5;
+    scalar serial_result = scalar(a);
+    Pack p;
+    for (int i=0; i<Pack::n; ++i) {
+      p[i] = 1.0/(i+1);
+      serial_result += p[i];
+    }
+
+    scalar result = ekat::reduce_sum<Serialize>(p, a);
+
+    if (Serialize) {
+      REQUIRE(result== serial_result);
+    } else {
+      REQUIRE(std::abs(result - serial_result) <= 10*std::numeric_limits<Scalar>::epsilon());
+    }
+  }
+
 #define test_pack_gen_assign_op_all(op) do {        \
     Pack a, b;                                      \
     scalar c;                                       \
@@ -291,6 +310,9 @@ struct TestPack {
     test_conversion();
     test_unary_min_max();
     test_range();
+
+    test_reduce_sum<true>();
+    test_reduce_sum<false>();
   }
 };
 

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -159,7 +159,7 @@ struct TestPack {
 
   template<bool Serialize>
   static void test_reduce_sum () {
-    const scalar a = 0.5;
+    scalar a = 0.5;
     scalar serial_result = scalar(a);
     Pack p;
     for (int i=0; i<Pack::n; ++i) {
@@ -167,12 +167,12 @@ struct TestPack {
       serial_result += p[i];
     }
 
-    scalar result = ekat::reduce_sum<Serialize>(p, a);
+    ekat::reduce_sum<Serialize>(p, a);
 
     if (Serialize) {
-      REQUIRE(result== serial_result);
+      REQUIRE(a == serial_result);
     } else {
-      REQUIRE(std::abs(result - serial_result) <= 10*std::numeric_limits<Scalar>::epsilon());
+      REQUIRE(std::abs(a - serial_result) <= 10*std::numeric_limits<Scalar>::epsilon());
     }
   }
 


### PR DESCRIPTION
## Motivation
From the discussion in https://github.com/E3SM-Project/EKAT/issues/26, this adds a `view_reduction()` function which computes a complete reduction over a view of packs, with both a serial and parallel implementation. 

For this pull request, a `reduce_sum()` function was also added which computes `a+sum(pack)`. 

Tests for each of these functions were also added.

## Related Issues
This is to address a need in scream, e.g., this pull request: https://github.com/E3SM-Project/scream/pull/536

## Testing
Tests were written for both functions which confirm bfb-ness.
