### PR TITLE
Add PackInfo struct for pack index arithmetics.

### DIFF
--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -1,13 +1,13 @@
 set(EKAT_SOURCES
-  mpi/ekat_comm.cpp
   ekat_assert.cpp
-  ekat_session.cpp
   ekat_parameter_list.cpp
   ekat_parse_yaml_file.cpp
+  ekat_session.cpp
+  mpi/ekat_comm.cpp
+  util/ekat_arch.cpp
   util/ekat_array_io.cpp
   util/ekat_array_io_mod.f90
   util/ekat_string_utils.cpp
-  util/ekat_arch.cpp
   util/ekat_test_utils.cpp
 )
 
@@ -16,18 +16,19 @@ install(TARGETS ekat DESTINATION lib)
 
 # Make sure headers can be installed.
 set(EKAT_HEADERS
-  ekat_pack.hpp
-  ekat_parse_yaml_file.hpp
-  ekat_workspace.hpp
-  ekat_pack_kokkos.hpp
-  ekat_scalar_traits.hpp
-  ekat_workspace_impl.hpp
-  ekat_assert.hpp
   ekat.hpp
-  ekat_parameter_list.hpp
-  ekat_session.hpp
+  ekat_assert.hpp
   ekat_macros.hpp
+  ekat_pack.hpp
+  ekat_pack_kokkos.hpp
+  ekat_pack_utils.hpp
+  ekat_parameter_list.hpp
+  ekat_parse_yaml_file.hpp
+  ekat_scalar_traits.hpp
+  ekat_session.hpp
   ekat_type_traits.hpp
+  ekat_workspace.hpp
+  ekat_workspace_impl.hpp
 )
 install(FILES ${EKAT_HEADERS} DESTINATION include/ekat)
 set(EKAT_KOKKOS_HEADERS
@@ -45,21 +46,21 @@ set(EKAT_STD_META_HEADERS
 )
 install(FILES ${EKAT_STD_META_HEADERS} DESTINATION include/ekat/std_meta)
 set(EKAT_UTIL_HEADERS
-  util/ekat_feutils.hpp
-  util/ekat_rational_constant.hpp
-  util/ekat_test_utils.hpp
   util/ekat_arch.hpp
-  util/ekat_file_utils.hpp
-  util/ekat_scaling_factor.hpp
-  util/ekat_tridiag.hpp
-  util/ekat_lin_interp.hpp
-  util/ekat_units.hpp
-  util/ekat_lin_interp_impl.hpp
-  util/ekat_string_utils.hpp
-  util/ekat_upper_bound.hpp
-  util/ekat_math_utils.hpp
   util/ekat_factory.hpp
+  util/ekat_feutils.hpp
+  util/ekat_file_utils.hpp
+  util/ekat_lin_interp.hpp
+  util/ekat_lin_interp_impl.hpp
+  util/ekat_math_utils.hpp
   util/ekat_md_array.hpp
+  util/ekat_rational_constant.hpp
+  util/ekat_scaling_factor.hpp
+  util/ekat_string_utils.hpp
+  util/ekat_test_utils.hpp
+  util/ekat_tridiag.hpp
+  util/ekat_units.hpp
+  util/ekat_upper_bound.hpp
 )
 install(FILES ${EKAT_UTIL_HEADERS} DESTINATION include/ekat/util)
 

--- a/src/ekat/ekat_pack_utils.hpp
+++ b/src/ekat/ekat_pack_utils.hpp
@@ -23,7 +23,8 @@ namespace ekat {
 
 template<int PackSize>
 struct PackInfo {
-  static constexpr int N = PackSize;
+  // Expose the pack size
+  enum : int { N = PackSize };
 
   static_assert(N>0, "Error! Pack size must be positive.\n");
   // This seems funky, but write down a pow of 2 and a non-pow of 2 in binary (both positive),
@@ -45,14 +46,26 @@ struct PackInfo {
   // The amount of padding added to the last pack
   KOKKOS_INLINE_FUNCTION
   constexpr static int padding (const int array_length) {
-    return array_length % N;
+    return num_packs(array_length)*N - array_length;
+  }
+
+  // The end of the last pack
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int last_vec_end (const int array_length) {
+    return N-padding(array_length);
   }
 
   // The end of a given pack. It is N for all packs, except possibly
   // for the last (if padding>0)
   KOKKOS_INLINE_FUNCTION
   constexpr static int vec_end (const int array_length, const int pack_idx) {
-    return (pack_idx+1)<num_packs(array_length) ? N : padding(array_length);
+    return (pack_idx+1)<num_packs(array_length) ? N : last_vec_end(array_length);
+  }
+
+  // Idx of the last pack
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int last_pack_idx (const int array_length) {
+    return num_packs(array_length)-1;
   }
 
   // The pack index corresponding to a given array entry

--- a/src/ekat/ekat_pack_utils.hpp
+++ b/src/ekat/ekat_pack_utils.hpp
@@ -1,0 +1,96 @@
+#ifndef EKAT_PACK_UTILS_HPP
+#define EKAT_PACK_UTILS_HPP
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/ekat_assert.hpp"
+
+#include "Kokkos_Pair.hpp"
+
+namespace ekat {
+
+/*
+ * A small struct to help with pack indexing arithmetics
+ *
+ * The struct offers a bunch of static methods, that can be
+ * used to go from unpacked indexing to packed indexing.
+ * For instance, we can check which pack and/or which entry
+ * within a pack does an array index i map to, or viceversa.
+ *
+ * Note: all methods are marker constexpr, so they can be
+ *       used inside template/constexpr constructs
+ * Note: NO CHECKS are performed on the inputs to the functions.
+ */
+
+template<int PackSize>
+struct PackInfo {
+  static constexpr int N = PackSize;
+
+  static_assert(N>0, "Error! Pack size must be positive.\n");
+  // This seems funky, but write down a pow of 2 and a non-pow of 2 in binary (both positive),
+  // and you'll see why it works
+  static_assert ((N & (N-1))==0, "Error! We only support packs with length = 2^n, n>=0.\n");
+
+  // Number of packs needed for a given array length
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int num_packs (const int array_length) {
+    return (array_length + N - 1) / N;
+  }
+
+  // Whether padding is needed in order to pack an array
+  KOKKOS_INLINE_FUNCTION
+  constexpr static bool has_padding (const int array_length) {
+    return array_length % N != 0;
+  }
+
+  // The amount of padding added to the last pack
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int padding (const int array_length) {
+    return array_length % N;
+  }
+
+  // The end of a given pack. It is N for all packs, except possibly
+  // for the last (if padding>0)
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int vec_end (const int array_length, const int pack_idx) {
+    return (pack_idx+1)<num_packs(array_length) ? N : padding(array_length);
+  }
+
+  // The pack index corresponding to a given array entry
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int pack_idx (const int idx) {
+    return idx / N;
+  }
+
+  // The index within a pack corresponding to a given array entry
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int vec_idx (const int idx) {
+    return idx % N;
+  }
+
+  // A combo version of the previous two
+  KOKKOS_INLINE_FUNCTION
+  constexpr static Kokkos::pair<int,int> pack_vec_idx (const int idx) {
+    return Kokkos::make_pair(idx / N, idx % N);
+  }
+
+  // Get the array index given pack and vec idx
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int array_idx (const int pack_idx, const int vec_idx) {
+    return pack_idx*N + vec_idx;
+  }
+
+  // Like the above one, but accepting a pair-like struct
+  // NOTE: when called on device, PairType *must* be a Kokkos::pair.
+  //       However, if used on host, std::pair will work too
+  //       Also, the pair value cannot be a template parameter,
+  //       due to limitations on non-type template parameters.
+  template<typename PairType>
+  KOKKOS_INLINE_FUNCTION
+  constexpr static int array_idx (const PairType& pack_vec_idx) {
+    return pack_vec_idx.first*N + pack_vec_idx.second;
+  }
+};
+
+} // namespace ekat
+
+#endif // EKAT_PACK_UTILS_HPP

--- a/tests/pack/CMakeLists.txt
+++ b/tests/pack/CMakeLists.txt
@@ -19,3 +19,6 @@ if (EKAT_TEST_SINGLE_PRECISION)
   )
   target_compile_definitions(packs${SP_POSTFIX} PRIVATE EKAT_TEST_SINGLE_PRECISION)
 endif ()
+
+# Test pack index arithmetics utils
+EkatCreateUnitTest(pack_utils pack_utils_tests.cpp LIBS ekat)

--- a/tests/pack/pack_utils_tests.cpp
+++ b/tests/pack/pack_utils_tests.cpp
@@ -1,0 +1,46 @@
+#include "catch2/catch.hpp"
+
+#include "ekat/ekat_pack_utils.hpp"
+
+namespace {
+
+TEST_CASE("PackInfo") {
+
+  SECTION ("pack1") {
+    using Info = ekat::PackInfo<1>;
+
+    REQUIRE (Info::num_packs(3)==3);
+
+    REQUIRE (!Info::has_padding(1));
+
+    REQUIRE (Info::pack_idx(4)==4);
+    REQUIRE (Info::vec_idx(4)==0);
+
+    REQUIRE (Info::pack_vec_idx(4)==Kokkos::make_pair(4,0));
+
+    REQUIRE (Info::array_idx(Kokkos::make_pair(4,0))==4);
+  }
+
+  SECTION ("pack8") {
+    using Info = ekat::PackInfo<8>;
+
+    REQUIRE (Info::num_packs(16)==2);
+    REQUIRE (Info::num_packs(17)==3);
+
+    REQUIRE (!Info::has_padding(16));
+    REQUIRE (Info::has_padding(13));
+
+
+    REQUIRE (Info::pack_idx(7)==0);
+    REQUIRE (Info::pack_idx(8)==1);
+    REQUIRE (Info::vec_idx(7)==7);
+    REQUIRE (Info::vec_idx(8)==0);
+
+    REQUIRE (Info::pack_vec_idx(7)==Kokkos::make_pair(0,7));
+    REQUIRE (Info::pack_vec_idx(8)==Kokkos::make_pair(1,0));
+
+    REQUIRE (Info::array_idx(Kokkos::make_pair(1,1))==9);
+  }
+}
+
+} // namespace

--- a/tests/pack/pack_utils_tests.cpp
+++ b/tests/pack/pack_utils_tests.cpp
@@ -9,26 +9,37 @@ TEST_CASE("PackInfo") {
   SECTION ("pack1") {
     using Info = ekat::PackInfo<1>;
 
+    REQUIRE (Info::N==1);
+
     REQUIRE (Info::num_packs(3)==3);
+    REQUIRE (Info::last_pack_idx(3)==2);
 
     REQUIRE (!Info::has_padding(1));
+    REQUIRE (Info::padding(3)==0);
 
     REQUIRE (Info::pack_idx(4)==4);
     REQUIRE (Info::vec_idx(4)==0);
 
     REQUIRE (Info::pack_vec_idx(4)==Kokkos::make_pair(4,0));
-
     REQUIRE (Info::array_idx(Kokkos::make_pair(4,0))==4);
+
+    REQUIRE (Info::vec_end(7,3)==1);
+    REQUIRE (Info::last_vec_end(7)==1);
   }
 
   SECTION ("pack8") {
     using Info = ekat::PackInfo<8>;
 
+    REQUIRE (Info::N==8);
+
     REQUIRE (Info::num_packs(16)==2);
     REQUIRE (Info::num_packs(17)==3);
+    REQUIRE (Info::last_pack_idx(17)==2);
 
     REQUIRE (!Info::has_padding(16));
     REQUIRE (Info::has_padding(13));
+    REQUIRE (Info::padding(16)==0);
+    REQUIRE (Info::padding(17)==7);
 
 
     REQUIRE (Info::pack_idx(7)==0);
@@ -38,8 +49,12 @@ TEST_CASE("PackInfo") {
 
     REQUIRE (Info::pack_vec_idx(7)==Kokkos::make_pair(0,7));
     REQUIRE (Info::pack_vec_idx(8)==Kokkos::make_pair(1,0));
-
     REQUIRE (Info::array_idx(Kokkos::make_pair(1,1))==9);
+
+    REQUIRE (Info::vec_end(17,1)==8);
+    REQUIRE (Info::vec_end(17,2)==1);
+    REQUIRE (Info::last_vec_end(16)==8);
+    REQUIRE (Info::last_vec_end(17)==1);
   }
 }
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Computing pack/vector indices by hand is error prone, and can make the code heavier and/or harder to read. Utility functions can make the code more self-documenting, and most importantly safe.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

-->
## Related Issues

* Closes #39


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Tests added for all the features.