### PR TITLE
Bug fix in ekat_catch_main

### DIFF
--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -63,20 +63,19 @@ int main (int argc, char **argv) {
     args.push_back(const_cast<char*>(new_arg.c_str()));
   }
 
-  // Initialize ekat
-  ekat::initialize_ekat_session(args.size(),args.data());
-
-  // Possibly calling user-defined initialization routines
+  // Initialize test session (initializes kokkos and print config settings).
+  // Ekat provides a defalt impl, but the user can choose
+  // Ekat provides a defalt one, but the user can choose
+  // to not use it, and provide one instead.
   ekat_initialize_test_session(args.size(),args.data());
 
   // Run tests
   int num_failed = catch_session.run(argc, argv);
 
-  // Possibly calling user-defined finalization routines
+  // Finalizes test session (finalizes kokkos).
+  // Ekat provides a defalt impl, but the user can choose
+  // to not use it, and provide one instead.
   ekat_finalize_test_session ();
-
-  // Finalize ekat
-  ekat::finalize_ekat_session();
 
   // Finalize MPI
   MPI_Finalize();


### PR DESCRIPTION
Micro PR to fix a testing bug. The bug is somewhat benign, in that it didn't affect ekat (or scream).

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Basically, we were calling ekat initialization/finalization routines twice. Ekat had a check to prevent double kokkos initialization, but if the downstream app decided to provide their own test session initialization, it could have generated errors.