### PR TITLE
Prototype for PhysicalConstant class [WIP]

### DIFF
--- a/src/ekat/ekat_physical_constants.hpp
+++ b/src/ekat/ekat_physical_constants.hpp
@@ -1,28 +1,29 @@
 #ifndef EKAT_PHYSICAL_CONSTANTS
+
 #define EKAT_PHYSICAL_CONSTANTS
 
 #include "ekat/util/ekat_units.hpp"
 
 namespace ekat {
 
-template <typename RealType=double>
 class PhysicalConstant {
   public:
+    using RealType = double;
     //enum Op {Times, Divide};
 
     // no default
     PhysicalConstant() = delete;
 
-    PhysicalConstant(const PhysicalConstant<RealType>&) = default;
+    PhysicalConstant(const PhysicalConstant&) = default;
 
     // Constructor for single value (i.e., NIST std)
     PhysicalConstant(const RealType& nvalue, const ekat::units::Units& units, const std::string& name) :
-      m_nist_val(nvalue), m_e3sm_val(nvalue), m_units(units), m_name(name), m_info("") {}
+      m_e3sm_val(nvalue), m_nist_val(nvalue), m_units(units), m_name(name), m_info("") {}
 
     // Constructor for single value (i.e., NIST std)
     PhysicalConstant(const RealType& nvalue, const ekat::units::Units& units, const std::string& name,
       const std::string& info) :
-      m_nist_val(nvalue), m_e3sm_val(nvalue), m_units(units), m_name(name), m_info(info) {}
+      m_e3sm_val(nvalue), m_nist_val(nvalue), m_units(units), m_name(name), m_info(info) {}
 
 
     // Constructor for two different values (i.e., when E3SM value and NIST value are different)
@@ -35,12 +36,6 @@ class PhysicalConstant {
       const std::string& name, const std::string& info) : m_e3sm_val(evalue), m_nist_val(nvalue), m_units(units),
       m_name(name), m_info(info) {}
 
-    // Constructor from the product of two other PhysicalConstants
-    PhysicalConstant(const PhysicalConstant& a, const PhysicalConstant& b, const std::string& name,
-      const std::string& info="") : m_nist_val(a.m_nist_val*b.m_nist_val),
-        m_e3sm_val(a.m_e3sm_val*b.m_e3sm_val), m_units(a.m_units*b.m_units),
-        m_name(name), m_info(info) {}
-
     std::string name() const {return m_name;}
 
     std::string get_string() const {return m_name + " [" + to_string(m_units) +
@@ -48,45 +43,83 @@ class PhysicalConstant {
 
     std::string unit_string() const {return to_string(m_units);}
 
+    units::Units get_units() const {return m_units;}
+
     RealType value() const {return m_e3sm_val;}
 
     RealType operator() () const {return value();}
 
   // allow subclasses for submodules (e.g., shoc, p3, haero, etc.)
   protected:
-    RealType m_nist_val;
     RealType m_e3sm_val;
-    ekat::units::Units m_units;
+    RealType m_nist_val;
+    units::Units m_units;
 
     std::string m_name;
     std::string m_info;
 
     friend bool operator == (const PhysicalConstant&, const PhysicalConstant&);
+    friend PhysicalConstant operator*(const PhysicalConstant&, const PhysicalConstant&);
+    friend PhysicalConstant operator/(const PhysicalConstant&, const PhysicalConstant&);
+    friend std::string combine_info(const PhysicalConstant&, const PhysicalConstant&);
 };
 
-template <typename RealType>
-inline bool operator == (const PhysicalConstant<RealType>& lhs, const PhysicalConstant<RealType>& rhs) {
+inline std::string combine_info(const PhysicalConstant& a, const PhysicalConstant& b) {
+  std::string result("");
+  if (a.m_info.empty()) {
+    if (!b.m_info.empty()) {
+      result = b.m_info;
+    }
+  }
+  else {
+    if (b.m_info.empty()){
+      result = a.m_info;
+    }
+    else {
+      result = a.m_info + "; " + b.m_info;
+    }
+  }
+  return result;
+}
+
+inline bool operator == (const PhysicalConstant& lhs, const PhysicalConstant& rhs) {
   return lhs.m_e3sm_val == rhs.m_e3sm_val &&
          lhs.m_nist_val == rhs.m_nist_val &&
          lhs.m_units == rhs.m_units;
 }
 
-template <typename RealType>
-inline bool operator != (const PhysicalConstant<RealType>& lhs, const PhysicalConstant<RealType>& rhs) {
+inline bool operator != (const PhysicalConstant& lhs, const PhysicalConstant& rhs) {
   return !(lhs == rhs);
 }
 
+inline PhysicalConstant operator*(const PhysicalConstant& lhs, const PhysicalConstant& rhs) {
+  return PhysicalConstant(lhs.m_e3sm_val * rhs.m_e3sm_val,
+                                    lhs.m_nist_val * rhs.m_nist_val,
+                                    lhs.m_units * rhs.m_units,
+                                    lhs.m_name + " * " + rhs.m_name,
+                                    combine_info(lhs,rhs));
+}
+
+inline PhysicalConstant operator/(const PhysicalConstant& lhs, const PhysicalConstant& rhs) {
+  return PhysicalConstant(lhs.m_e3sm_val / rhs.m_e3sm_val,
+                                    lhs.m_nist_val / rhs.m_nist_val,
+                                    lhs.m_units / rhs.m_units,
+                                    lhs.m_name + " / " + rhs.m_name,
+                                    combine_info(lhs, rhs));
+}
+
+
 // ================== COMMON PHYSICAL CONSTANTS (for examples only, at this point) =============== //
-const auto Pi = PhysicalConstant<>(3.14159265358979323846264, ekat::units::Units::nondimensional(), "Pi");
-const auto Avogadro = PhysicalConstant<>(6.022214E23, ekat::units::pow(ekat::units::mol,-1), "Avogadro constant, N_A");
-const auto Boltzmann = PhysicalConstant<>(1.38065E-23, ekat::units::J/ekat::units::K, "Boltzmann constant, k_B");
-const auto R_gas_universal = PhysicalConstant<>(Avogadro, Boltzmann, "Universal gas constant, R");
-const auto g_accel = PhysicalConstant<>(9.80616, ekat::units::m /ekat::units::pow(ekat::units::s,2), "gravity accerlation, g", "spherical geoid, constant radius");
-const auto molec_weight_h20 = PhysicalConstant<>(18.016, ekat::units::g/ekat::units::mol, "molecular weight of water, M_w_h20");
-const auto molec_weight_dry_air = PhysicalConstant<>(28.966, ekat::units::g/ekat::units::mol, "molecular weight of dry air, M_w_dry_air");
-const auto rho_h20_liquid = PhysicalConstant<>(1.0E3,
-  ekat::units::kg/ekat::units::pow(ekat::units::m,3), "rho_h20", "fresh water");
-const auto Gamma_dry = PhysicalConstant<>(0.0098, ekat::units::K / ekat::units::m, "dry adiabatic lapse rate, Gamma_dry");
+const auto Pi = PhysicalConstant(3.14159265358979323846264, units::Units::nondimensional(), "Pi");
+const auto Avogadro = PhysicalConstant(6.022214E23, units::pow(units::mol,-1), "Avogadro constant, N_A");
+const auto Boltzmann = PhysicalConstant(1.38065E-23, units::J/units::K, "Boltzmann constant, k_B");
+const auto R_gas_universal = Avogadro * Boltzmann;
+const auto g_accel = PhysicalConstant(9.80616, units::m /units::pow(units::s,2), "gravity accerlation, g", "spherical geoid, constant radius");
+const auto molec_weight_h20 = PhysicalConstant(18.016, units::g/units::mol, "molecular weight of water, M_w_h20");
+const auto molec_weight_dry_air = PhysicalConstant(28.966, units::g/units::mol, "molecular weight of dry air, M_w_dry_air");
+const auto rho_h20_liquid = PhysicalConstant(1.0E3,
+  units::kg/units::pow(units::m,3), "rho_h20", "fresh water");
+const auto Gamma_dry = PhysicalConstant(0.0098, units::K / units::m, "dry adiabatic lapse rate, Gamma_dry");
 
 } // namespace ekat
 #endif // EKAT_PHYSICAL_CONSTANTS

--- a/src/ekat/ekat_physical_constants.hpp
+++ b/src/ekat/ekat_physical_constants.hpp
@@ -1,6 +1,5 @@
-#ifndef EKAT_PHYSICAL_CONSTANTS
-
-#define EKAT_PHYSICAL_CONSTANTS
+#ifndef EKAT_PHYSICAL_CONSTANTS_HPP
+#define EKAT_PHYSICAL_CONSTANTS_HPP
 
 #include "ekat/util/ekat_units.hpp"
 
@@ -109,17 +108,7 @@ inline PhysicalConstant operator/(const PhysicalConstant& lhs, const PhysicalCon
 }
 
 
-// ================== COMMON PHYSICAL CONSTANTS (for examples only, at this point) =============== //
-const auto Pi = PhysicalConstant(3.14159265358979323846264, units::Units::nondimensional(), "Pi");
-const auto Avogadro = PhysicalConstant(6.022214E23, units::pow(units::mol,-1), "Avogadro constant, N_A");
-const auto Boltzmann = PhysicalConstant(1.38065E-23, units::J/units::K, "Boltzmann constant, k_B");
-const auto R_gas_universal = Avogadro * Boltzmann;
-const auto g_accel = PhysicalConstant(9.80616, units::m /units::pow(units::s,2), "gravity accerlation, g", "spherical geoid, constant radius");
-const auto molec_weight_h20 = PhysicalConstant(18.016, units::g/units::mol, "molecular weight of water, M_w_h20");
-const auto molec_weight_dry_air = PhysicalConstant(28.966, units::g/units::mol, "molecular weight of dry air, M_w_dry_air");
-const auto rho_h20_liquid = PhysicalConstant(1.0E3,
-  units::kg/units::pow(units::m,3), "rho_h20", "fresh water");
-const auto Gamma_dry = PhysicalConstant(0.0098, units::K / units::m, "dry adiabatic lapse rate, Gamma_dry");
+
 
 } // namespace ekat
 #endif // EKAT_PHYSICAL_CONSTANTS

--- a/src/ekat/ekat_physical_constants.hpp
+++ b/src/ekat/ekat_physical_constants.hpp
@@ -1,0 +1,105 @@
+#ifndef EKAT_PHYSICAL_CONSTANTS
+#define EKAT_PHYSICAL_CONSTANTS
+
+#include "ekat/util/ekat_units.hpp"
+
+namespace ekat {
+
+template <typename RealType=double>
+class PhysicalConstant {
+  public:
+    enum Op {Times, Divide};
+
+    // no default
+    PhysicalConstant() = delete;
+
+    PhysicalConstant(const PhysicalConstant<RealType>&) = default;
+
+    // Constructor for single value (i.e., NIST std)
+    PhysicalConstant(const RealType& nvalue, const ekat::units::Units& units, const std::string& name) :
+      m_nist_val(nvalue), m_e3sm_val(nvalue), m_units(units), m_name(name), m_info("") {}
+
+    // Constructor for single value (i.e., NIST std)
+    PhysicalConstant(const RealType& nvalue, const ekat::units::Units& units, const std::string& name,
+      const std::string& info) :
+      m_nist_val(nvalue), m_e3sm_val(nvalue), m_units(units), m_name(name), m_info(info) {}
+
+
+    // Constructor for two different values (i.e., when E3SM value and NIST value are different)
+    PhysicalConstant(const RealType& evalue, const RealType& nvalue, const ekat::units::Units& units,
+      const std::string& name) : m_e3sm_val(evalue), m_nist_val(nvalue), m_units(units),
+      m_name(name), m_info("") {}
+
+    // Constructor for two different values (i.e., when E3SM value and NIST value are different)
+    PhysicalConstant(const RealType& evalue, const RealType& nvalue, const ekat::units::Units& units,
+      const std::string& name, const std::string& info) : m_e3sm_val(evalue), m_nist_val(nvalue), m_units(units),
+      m_name(name), m_info(info) {}
+
+
+    // Constructor for a constant that is defined by the product or quotient of 2 other constants.
+    PhysicalConstant(const PhysicalConstant<RealType>& lhs, const Op& op, const PhysicalConstant<RealType>& rhs,
+       const std::string& name) :  m_e3sm_val(lhs.m_e3sm_val), m_nist_val(lhs.m_nist_val),
+       m_units(lhs.m_units), m_name(name), m_info(lhs.m_info + "; " + rhs.m_info) {
+        switch (op) {
+          case (Times) : {
+            m_e3sm_val *= rhs.m_e3sm_val;
+            m_nist_val *= rhs.m_nist_val;
+            m_units = lhs.m_units * rhs.m_units;
+            break;
+          }
+          case (Divide) : {
+            m_e3sm_val /= rhs.m_e3sm_val;
+            m_nist_val /= rhs.m_nist_val;
+            m_units = lhs.m_units / rhs.m_units;
+            break;
+          }
+        }
+    }
+
+    std::string name() const {return m_name;}
+
+    std::string get_string() const {return m_name + " " + to_string(m_units) +
+      (m_info.empty() ? "" : " (" + m_info + ")");}
+
+    std::string unit_string() const {return to_string(m_units);}
+
+    RealType value() const {return m_e3sm_val;}
+
+  // allow subclasses for submodules (e.g., shoc, p3, haero, etc.)
+  protected:
+    RealType m_nist_val;
+    RealType m_e3sm_val;
+    ekat::units::Units m_units;
+
+    std::string m_name;
+    std::string m_info;
+
+    friend bool operator == (const PhysicalConstant&, const PhysicalConstant&);
+};
+
+template <typename RealType>
+inline bool operator == (const PhysicalConstant<RealType>& lhs, const PhysicalConstant<RealType>& rhs) {
+  return lhs.m_e3sm_val == rhs.m_e3sm_val &&
+         lhs.m_nist_val == rhs.m_nist_val &&
+         lhs.m_units == rhs.m_units;
+}
+
+template <typename RealType>
+inline bool operator != (const PhysicalConstant<RealType>& lhs, const PhysicalConstant<RealType>& rhs) {
+  return !(lhs == rhs);
+}
+
+// ================== COMMON PHYSICAL CONSTANTS =============== //
+const auto Pi = PhysicalConstant<>(3.14159265358979323846264, ekat::units::Units::nondimensional(), "Pi");
+const auto Avogadro = PhysicalConstant<>(6.022214E23, 1/(ekat::units::mol), "Avogadro constant, N_A");
+const auto Boltzmann = PhysicalConstant<>(1.38065E-23, ekat::units::J/ekat::units::K, "Boltzmann constant, k_B");
+const auto R_gas_universal = PhysicalConstant<>(Avogadro, PhysicalConstant<>::Times, Boltzmann, "Universal gas constant, R");
+const auto g_accel = PhysicalConstant<>(9.80616, ekat::units::m /ekat::units::pow(ekat::units::s,2), "gravity accerlation, g", "spherical geoid, constant radius");
+const auto molec_weight_h20 = PhysicalConstant<>(18.016, ekat::units::g/ekat::units::mol, "molecular weight of water, M_w_h20");
+const auto molec_weight_dry_air = PhysicalConstant<>(28.966, ekat::units::g/ekat::units::mol, "molecular weight of dry air, M_w_dry_air");
+const auto rho_h20_liquid = PhysicalConstant<>(1.0E3,
+  ekat::units::kg/ekat::units::pow(ekat::units::m,3), "rho_h20", "fresh water");
+const auto Gamma_dry = PhysicalConstant<>(0.0098, ekat::units::K / ekat::units::m, "dry adiabatic lapse rate, Gamma_dry");
+
+} // namespace ekat
+#endif // EKAT_PHYSICAL_CONSTANTS

--- a/src/ekat/ekat_physical_constants.hpp
+++ b/src/ekat/ekat_physical_constants.hpp
@@ -8,7 +8,7 @@ namespace ekat {
 template <typename RealType=double>
 class PhysicalConstant {
   public:
-    enum Op {Times, Divide};
+    //enum Op {Times, Divide};
 
     // no default
     PhysicalConstant() = delete;
@@ -35,35 +35,22 @@ class PhysicalConstant {
       const std::string& name, const std::string& info) : m_e3sm_val(evalue), m_nist_val(nvalue), m_units(units),
       m_name(name), m_info(info) {}
 
-
-    // Constructor for a constant that is defined by the product or quotient of 2 other constants.
-    PhysicalConstant(const PhysicalConstant<RealType>& lhs, const Op& op, const PhysicalConstant<RealType>& rhs,
-       const std::string& name) :  m_e3sm_val(lhs.m_e3sm_val), m_nist_val(lhs.m_nist_val),
-       m_units(lhs.m_units), m_name(name), m_info(lhs.m_info + "; " + rhs.m_info) {
-        switch (op) {
-          case (Times) : {
-            m_e3sm_val *= rhs.m_e3sm_val;
-            m_nist_val *= rhs.m_nist_val;
-            m_units = lhs.m_units * rhs.m_units;
-            break;
-          }
-          case (Divide) : {
-            m_e3sm_val /= rhs.m_e3sm_val;
-            m_nist_val /= rhs.m_nist_val;
-            m_units = lhs.m_units / rhs.m_units;
-            break;
-          }
-        }
-    }
+    // Constructor from the product of two other PhysicalConstants
+    PhysicalConstant(const PhysicalConstant& a, const PhysicalConstant& b, const std::string& name,
+      const std::string& info="") : m_nist_val(a.m_nist_val*b.m_nist_val),
+        m_e3sm_val(a.m_e3sm_val*b.m_e3sm_val), m_units(a.m_units*b.m_units),
+        m_name(name), m_info(info) {}
 
     std::string name() const {return m_name;}
 
-    std::string get_string() const {return m_name + " " + to_string(m_units) +
-      (m_info.empty() ? "" : " (" + m_info + ")");}
+    std::string get_string() const {return m_name + " [" + to_string(m_units) +
+      (m_info.empty() ? "]" : "] (" + m_info + ")");}
 
     std::string unit_string() const {return to_string(m_units);}
 
     RealType value() const {return m_e3sm_val;}
+
+    RealType operator() () const {return value();}
 
   // allow subclasses for submodules (e.g., shoc, p3, haero, etc.)
   protected:
@@ -89,11 +76,11 @@ inline bool operator != (const PhysicalConstant<RealType>& lhs, const PhysicalCo
   return !(lhs == rhs);
 }
 
-// ================== COMMON PHYSICAL CONSTANTS =============== //
+// ================== COMMON PHYSICAL CONSTANTS (for examples only, at this point) =============== //
 const auto Pi = PhysicalConstant<>(3.14159265358979323846264, ekat::units::Units::nondimensional(), "Pi");
-const auto Avogadro = PhysicalConstant<>(6.022214E23, 1/(ekat::units::mol), "Avogadro constant, N_A");
+const auto Avogadro = PhysicalConstant<>(6.022214E23, ekat::units::pow(ekat::units::mol,-1), "Avogadro constant, N_A");
 const auto Boltzmann = PhysicalConstant<>(1.38065E-23, ekat::units::J/ekat::units::K, "Boltzmann constant, k_B");
-const auto R_gas_universal = PhysicalConstant<>(Avogadro, PhysicalConstant<>::Times, Boltzmann, "Universal gas constant, R");
+const auto R_gas_universal = PhysicalConstant<>(Avogadro, Boltzmann, "Universal gas constant, R");
 const auto g_accel = PhysicalConstant<>(9.80616, ekat::units::m /ekat::units::pow(ekat::units::s,2), "gravity accerlation, g", "spherical geoid, constant radius");
 const auto molec_weight_h20 = PhysicalConstant<>(18.016, ekat::units::g/ekat::units::mol, "molecular weight of water, M_w_h20");
 const auto molec_weight_dry_air = PhysicalConstant<>(28.966, ekat::units::g/ekat::units::mol, "molecular weight of dry air, M_w_dry_air");

--- a/src/ekat/util/ekat_common_constants.hpp
+++ b/src/ekat/util/ekat_common_constants.hpp
@@ -1,0 +1,35 @@
+#ifndef EKAT_COMMON_CONSTANTS_HPP
+#define EKAT_COMMON_CONSTANTS_HPP
+
+#include "ekat/ekat_physical_constants.hpp"
+
+namespace ekat {
+namespace common_constants {
+
+const auto Pi = PhysicalConstant(3.14159265358979323846264, units::Units::nondimensional(), "Pi");
+
+const auto Avogadro = PhysicalConstant(6.022214E23, units::pow(units::mol,-1), "Avogadro constant, N_A");
+
+const auto Boltzmann = PhysicalConstant(1.38065E-23, units::J/units::K, "Boltzmann constant, k_B");
+
+const auto R_gas_universal = Avogadro * Boltzmann;
+
+const auto g_accel = PhysicalConstant(9.80616, units::m /units::pow(units::s,2),
+  "gravity accerlation, g", "spherical geoid, constant radius");
+
+const auto molec_weight_h20 = PhysicalConstant(18.016, units::g/units::mol,
+  "molecular weight of water, M_w_h20");
+
+const auto molec_weight_dry_air = PhysicalConstant(28.966, units::g/units::mol,
+  "molecular weight of dry air, M_w_dry_air");
+
+const auto rho_h20_liquid = PhysicalConstant(1.0E3,
+  units::kg/units::pow(units::m,3), "rho_h20", "fresh water");
+
+const auto Gamma_dry = PhysicalConstant(0.0098, units::K / units::m,
+  "dry adiabatic lapse rate, Gamma_dry");
+
+
+} // common_constants
+} // namespace ekat
+#endif // EKAT_COMMON_CONSTANTS_HPP

--- a/tests/units/CMakeLists.txt
+++ b/tests/units/CMakeLists.txt
@@ -2,3 +2,6 @@ include(EkatCreateUnitTest)
 
 # Test units framework
 EkatCreateUnitTest(units "units.cpp" LIBS ekat)
+
+# Test physical constants
+EkatCreateUnitTest(physical_constants  "physical_constants.cpp" LIBS ekat)

--- a/tests/units/physical_constants.cpp
+++ b/tests/units/physical_constants.cpp
@@ -1,12 +1,14 @@
 #include <catch2/catch.hpp>
 
 #include "ekat/ekat_physical_constants.hpp"
+#include "ekat/util/ekat_common_constants.hpp"
 
 #include <iostream>
 
 TEST_CASE("physical_constants", "") {
   using namespace ekat;
   using namespace ekat::units;
+  using namespace ekat::common_constants;
 
   SECTION("Universal constants") {
     std::cout << Pi() << " " << Pi.get_string() << '\n';

--- a/tests/units/physical_constants.cpp
+++ b/tests/units/physical_constants.cpp
@@ -1,0 +1,28 @@
+#include <catch2/catch.hpp>
+
+#include "ekat/ekat_physical_constants.hpp"
+
+#include <iostream>
+
+TEST_CASE("physical_constants", "") {
+  using namespace ekat;
+  using namespace ekat::units;
+
+  SECTION("Universal constants") {
+    std::cout << Pi.get_string() << '\n';
+    std::cout << Avogadro.get_string() << '\n';
+    std::cout << Boltzmann.get_string() << '\n';
+    std::cout << R_gas_universal.get_string() << '\n';
+  }
+
+  SECTION("Shallow atmosphere constants") {
+    std::cout << g_accel.get_string() << '\n';
+    std::cout << molec_weight_dry_air.get_string() << '\n';
+    std::cout << Gamma_dry.get_string() << '\n';
+  }
+
+  SECTION("Water constants") {
+   std::cout << molec_weight_h20.get_string() << '\n';
+   std::cout << rho_h20_liquid.get_string() << '\n';
+  }
+}

--- a/tests/units/physical_constants.cpp
+++ b/tests/units/physical_constants.cpp
@@ -9,20 +9,20 @@ TEST_CASE("physical_constants", "") {
   using namespace ekat::units;
 
   SECTION("Universal constants") {
-    std::cout << Pi.get_string() << '\n';
-    std::cout << Avogadro.get_string() << '\n';
-    std::cout << Boltzmann.get_string() << '\n';
-    std::cout << R_gas_universal.get_string() << '\n';
+    std::cout << Pi() << " " << Pi.get_string() << '\n';
+    std::cout << Avogadro() << " " <<Avogadro.get_string() << '\n';
+    std::cout << Boltzmann() << " " << Boltzmann.get_string() << '\n';
+    std::cout << R_gas_universal() <<  " " << R_gas_universal.get_string() << '\n';
   }
 
   SECTION("Shallow atmosphere constants") {
-    std::cout << g_accel.get_string() << '\n';
-    std::cout << molec_weight_dry_air.get_string() << '\n';
-    std::cout << Gamma_dry.get_string() << '\n';
+    std::cout << g_accel() << " " << g_accel.get_string() << '\n';
+    std::cout << molec_weight_dry_air() << " " << molec_weight_dry_air.get_string() << '\n';
+    std::cout << Gamma_dry() << " " << Gamma_dry.get_string() << '\n';
   }
 
   SECTION("Water constants") {
-   std::cout << molec_weight_h20.get_string() << '\n';
-   std::cout << rho_h20_liquid.get_string() << '\n';
+   std::cout << molec_weight_h20() << " " << molec_weight_h20.get_string() << '\n';
+   std::cout << rho_h20_liquid() << " " << rho_h20_liquid.get_string() << '\n';
   }
 }

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -61,15 +61,12 @@ TEST_CASE("units_framework", "") {
     Units mix_ratio = kg/kg;
     mix_ratio.set_string("kg/kg");
 
-    Units u1 = kg/m/pow(s,2);
-    Units u2 = 1/K;
-    Units u3 = Units::nondimensional();
-    u3 = u1*u2;
 
     // Verify operations
     REQUIRE (milliJ == kPa*pow(m,3)/mega);
     REQUIRE (m/s*day/km == Units(one*86400/1000));
     REQUIRE (pow(sqrt(m),2)==m);
+    REQUIRE (one/mol == pow(mol,-1));
 
     // Verify printing
     REQUIRE (to_string(nondim)=="1");

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -61,6 +61,11 @@ TEST_CASE("units_framework", "") {
     Units mix_ratio = kg/kg;
     mix_ratio.set_string("kg/kg");
 
+    Units u1 = kg/m/pow(s,2);
+    Units u2 = 1/K;
+    Units u3 = Units::nondimensional();
+    u3 = u1*u2;
+
     // Verify operations
     REQUIRE (milliJ == kPa*pow(m,3)/mega);
     REQUIRE (m/s*day/km == Units(one*86400/1000));


### PR DESCRIPTION
## Motivation
To further the discussion about Physical Constants, here is a possible impl, based in large part on the `ekat::units` design.  The purpose of this WIP PR is to collect comments/criticism on the class design.

The basic data structure has three member variables, a `RealType` value (template parameter default is `double`), an `ekat::units::Units` object,  and a `std::string` name.  An additional field for extra info, e.g., assumptions related to the constant such as "at constant temperature" can be recorded.

There is an additional member variable to record two possibly different values (one used by e3sm, one defined by NIST).  The default `operator()` returns the e3sm value.  

Constructors allow for new constants to be defined explicitly or as the product of 2 previously defined constants.

The class is written for all-scream constants and allows for inheritance so that, for example, a subcomponent e.g., Haero or Shoc, could define module-specific constants as `class ShocConstant : public PhysicalConstant`, for example.   A few examples of some specific constants are defined as namespace variables in `ekat_physical_constants.hpp`, based on the convention used for the common SI units in `ekat_units.hpp`.  

A unit test is included, which demonstrates some basis behaviors.

## Related Issues
First step toward  #48.
Includes a test for #52 (currently fails at runtime). 
