### PR TITLE
Fix overload of operator/ for Units

### DIFF
--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -207,13 +207,13 @@ inline Units operator/(const Units& lhs, const ScalingFactor& rhs) {
                lhs.m_scaling/rhs);
 }
 inline Units operator/(const ScalingFactor& lhs, const Units& rhs) {
-  return Units(1-rhs.m_units[0],
-               1-rhs.m_units[1],
-               1-rhs.m_units[2],
-               1-rhs.m_units[3],
-               1-rhs.m_units[4],
-               1-rhs.m_units[5],
-               1-rhs.m_units[6],
+  return Units(-rhs.m_units[0],
+               -rhs.m_units[1],
+               -rhs.m_units[2],
+               -rhs.m_units[3],
+               -rhs.m_units[4],
+               -rhs.m_units[5],
+               -rhs.m_units[6],
                lhs/rhs.m_scaling);
 }
 inline Units operator/(const RationalConstant& lhs, const Units& rhs) {

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -75,4 +75,16 @@ TEST_CASE("units_framework", "") {
     REQUIRE (to_string(mix_ratio)=="1");
     REQUIRE (mix_ratio.get_string()=="kg/kg");
   }
+
+  SECTION ("issue-52") {
+    auto one_over_mol = ScalingFactor::one() / mol;
+    auto mol_inverse = pow(mol, -1);
+
+    REQUIRE (one_over_mol == mol_inverse);
+
+    auto mol_mol = mol * mol;
+    auto mol_2 = pow(mol,2);
+
+    REQUIRE (mol_mol == mol_2);
+  }
 }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
There was a bug in the overload of operator/ that takes a ScalilngFactor and a Units objects. In particular, the implementation was basically saying that `1 / (a^n) = a^(1-n)`. A remarkable bug.

## Related Issues
* Closes #52

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a test that ensures op/ and op* are consistent with pow.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
