### PR TITLE
Using NEW behavior for cmp0074

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.3)
 
 set (EKAT_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake CACHE INTERNAL "")
 
+# Do not ignore <PackageName_ROOT> env vars in find_package() calls
+cmake_policy (SET CMP0074 NEW)
+
 # Add our own cmake goodies to cmake module search path
 list(APPEND CMAKE_MODULE_PATH
      ${EKAT_CMAKE_PATH}


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
CMake 3.12 and above defaults to OLD, but issues a warning. OLD behavior ignores cmake/env `<PackageName>_ROOT` vars already defined when calling `find_package(<PackageName>)`, while the NEW behavior uses those variables.

Since we are ok with the NEW behavior, and OLD behaviors are deprecated by default (and may disappear in the future), better switch explicitly to NEW.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
