### PR TITLE
fix view_reduction

### DIFF
--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -123,7 +123,7 @@ void view_reduction (const TeamMember& team,
   if (has_garbage_begin) {
     const PackType temp_input = input(pack_loop_begin-1);
     const int first_indx = begin%vector_size;
-    Kokkos::single(Kokkos::PerTeam(team),[&] {
+    Kokkos::single(Kokkos::PerThread(team),[&] {
       for (int j=first_indx; j<vector_size; ++j) {
         result += temp_input[j];
       }
@@ -156,7 +156,7 @@ void view_reduction (const TeamMember& team,
   if (has_garbage_end) {
     const PackType temp_input = input(pack_loop_end);
     const int last_indx = end%vector_size;
-    Kokkos::single(Kokkos::PerTeam(team),[&] {
+    Kokkos::single(Kokkos::PerThread(team),[&] {
       for (int j=0; j<last_indx; ++j) {
         result += temp_input[j];
       }

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -290,7 +290,7 @@ void test_view_reduction(const Scalar a=Scalar(0.0), const int begin=0, const in
 
   // parallel_for over 1 team, i.e. call view_reduction once
   const auto policy =
-    ekat::ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(1, (UseThreads ? VectorSize : 1));
+    ekat::ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(1, (UseThreads ? omp_get_max_threads() : 1));
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     Scalar team_result = Scalar(a);
 

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -290,7 +290,8 @@ void test_view_reduction(const Scalar a=Scalar(0.0), const int begin=0, const in
 
   int team_size = ExeSpace::concurrency();
 #ifdef KOKKOS_ENABLE_CUDA
-  auto num_sm = Kokkos::Cuda::impl_internal_space_instance()->m_multiProcCount;
+  ExeSpace temp_space;
+  auto num_sm = temp_space.impl_internal_space_instance()->m_multiProcCount;
   team_size /= (ekat::is_single_precision<Real>::value ? num_sm*64 : num_sm*32);
 #endif
 

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -288,9 +288,14 @@ void test_view_reduction(const Scalar a=Scalar(0.0), const int begin=0, const in
   Kokkos::View<Scalar*> results ("results", 1);
   const auto results_h = Kokkos::create_mirror_view(results);
 
+#ifdef KOKKOS_ENABLE_OPENMP
+  const int n_threads = omp_get_max_threads();
+#else
+  const int n_threads = 1;
+#endif
   // parallel_for over 1 team, i.e. call view_reduction once
   const auto policy =
-    ekat::ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(1, (UseThreads ? omp_get_max_threads() : 1));
+    ekat::ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(1, (UseThreads ? n_threads : 1));
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     Scalar team_result = Scalar(a);
 

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -288,11 +288,11 @@ void test_view_reduction(const Scalar a=Scalar(0.0), const int begin=0, const in
   Kokkos::View<Scalar*> results ("results", 1);
   const auto results_h = Kokkos::create_mirror_view(results);
 
-  // Set team size
   int team_size = ExeSpace::concurrency();
-  if (ekat::OnGpu<ExeSpace>::value) {
-    team_size /= (ekat::is_single_precision<Real>::value ? 64 : 32);
-  }
+#ifdef KOKKOS_ENABLE_CUDA
+  auto num_sm = Kokkos::Cuda::impl_internal_space_instance()->m_multiProcCount;
+  team_size /= (ekat::is_single_precision<Real>::value ? num_sm*64 : num_sm*32);
+#endif
 
   // parallel_for over 1 team, i.e. call view_reduction once
   const auto policy =


### PR DESCRIPTION
## Motivation
Solves issue from https://github.com/E3SM-Project/scream/pull/615, namely, when running with OPENMP threads, the `has_garbage_begin/end` if-blocks of `impl::view_reduction()` were not summing over all view values. 

Easy fix: needs to run over `Kokkos:single(PerThread)` instead of `Kokkos::single(PerTeam)`.

## Testing
The original view_reduction test in EKAT never used threads, and so no error. I updated the test to run using a team policy with threads when OPENMP is used. I verified that the new test fails with the old PerTeam implementation, and passes with the PerThread impl. 