### PR TITLE
added << operator for packs, plus unit tests.

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -10,6 +10,7 @@
 #include "ekat/ekat_type_traits.hpp"
 
 #include <Kokkos_Core.hpp>
+#include <iostream>
 
 namespace ekat {
 
@@ -609,6 +610,16 @@ struct ScalarTraits<Pack<T,N>> {
     return value_type(inner_traits::invalid());
   }
 };
+
+template <typename PackType>
+inline typename std::enable_if<PackType::packtag, std::ostream&>::type
+operator << (std::ostream& os, const PackType& p) {
+  for (int i=0; i<PackType::n; ++i) {
+    os << p[i] << ' ';
+  }
+  return os;
+}
+
 
 } // namespace ekat
 

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -3,6 +3,7 @@
 #include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_types.hpp"
 #include "ekat_test_config.h"
+#include <sstream>
 
 namespace {
 
@@ -155,6 +156,16 @@ struct TestPack {
     const auto p = ekat::range<Pack>(42);
     vector_novec for (int i = 0; i < Pack::n; ++i)
       REQUIRE(p[i] == static_cast<scalar>(42 + i));
+  }
+
+  static void test_ostream() {
+    const auto p = ekat::range<Pack>(42);
+    std::ostringstream ssp;
+    ssp << p;
+    std::ostringstream sst;
+    for (int i = 0; i < Pack::n; ++i)
+      sst << 42 + i << ' ';
+    REQUIRE(ssp.str() == sst.str());
   }
 
   template<bool Serialize>
@@ -311,6 +322,7 @@ struct TestPack {
     test_conversion();
     test_unary_min_max();
     test_range();
+    test_ostream();
 
     test_reduce_sum<true>();
     test_reduce_sum<false>();


### PR DESCRIPTION
## Motivation

Adds host-only `operator <<` for pack types.

## Related Issues

* Closes #40 

## Tests

tests build & pass on Mac (clang 11.0) and linux (gcc 7.3).