### PR TITLE
Adds a fix so that CMAKE works for CMAKE versions older than 3.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required(VERSION 3.3)
 set (EKAT_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake CACHE INTERNAL "")
 
 # Do not ignore <PackageName_ROOT> env vars in find_package() calls
-cmake_policy (SET CMP0074 NEW)
+IF(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+    cmake_policy (SET CMP0074 NEW)
+ENDIF(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
 
 # Add our own cmake goodies to cmake module search path
 list(APPEND CMAKE_MODULE_PATH


### PR DESCRIPTION
cmake_policy CMP0074 is only available in versions 3.12.0 or newer. Some machines (such as Compy) still has older version of CMAKE where the code fails to compile. This fix wraps application of this policy in an "if" condition so that it is applied only for CMAKE versions newer than 3.12.0.  

I have tested it on Compy and the code compiles on Compy with this change.
Fixes: #58