### PR TITLE
Set default value of EKAT_DEFAULT_BFB to ON/OFF depending on CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ endif()
 # EKAT has mostly C++, but some Fortran too
 project (EKAT CXX Fortran)
 
+include(EkatUtils)
+IsDebugBuild(EKAT_IS_DEBUG_BUILD)
+
 set (EKAT_VERSION_MAJOR 1)
 set (EKAT_VERSION_MINOR 0)
 set (EKAT_VERSION_PATCH 0)
@@ -68,7 +71,7 @@ set (EKAT_TPL_LIBRARIES ${EKAT_TPL_LIBRARIES_INTERNAL} CACHE INTERNAL "List of E
 ############################
 
 option (EKAT_MPI_ERRORS_ARE_FATAL " Whether EKAT should crash when MPI errors happen." ON)
-option (EKAT_DEFAULT_BFB "Whether EKAT should default to BFB behavior whenever possible/appropriate." OFF)
+option (EKAT_DEFAULT_BFB "Whether EKAT should default to BFB behavior whenever possible/appropriate." ${EKAT_IS_DEBUG_BUILD})
 
 ############################################
 ###  COMPILER/OS-SPECIFIC CONFIG OPTIONS ###

--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -1,3 +1,12 @@
+macro (IsDebugBuild OUT_VAR_NAME)
+  string(TOLOWER "${CMAKE_BUILD_TYPE}" INTERNAL_BUILD_TYPE_CI)
+  if ("${INTERNAL_BUILD_TYPE_CI}" STREQUAL "debug")
+    set (${OUT_VAR_NAME} TRUE CACHE INTERNAL "")
+  else ()
+    set (${OUT_VAR_NAME} FALSE CACHE INTERNAL "")
+  endif()
+endmacro()
+
 macro (CheckMacroArgs macroName parsePrefix validOptions validOneValueArgs validMultiValueArgs)
   if (${parsePrefix}_UNPARSED_ARGUMENTS)
     message (AUTHOR_WARNING


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
Users may forget to enable the EKAT_DEFAULT_BFB option. To make life easy, we set the default of this option to ON in debug builds, and OFF in non debug builds.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
