### PR TITLE
Fix deprecated option for kokkos argv list

### DIFF
--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -59,7 +59,7 @@ int main (int argc, char **argv) {
   // Create it outside the if, so its c_str pointer survives
   std::string new_arg;
   if (dev_id>=0) {
-    new_arg = "--kokkos-device=" + std::to_string(dev_id);
+    new_arg = "--kokkos-device-id=" + std::to_string(dev_id);
     args.push_back(const_cast<char*>(new_arg.c_str()));
   }
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When setting device id in `ekat_catch_main.cpp`, the option `--kokkos-device=ID` is deprecated, in favor of `--kokkos-device-id=ID`. This PR fixes it, removing the runtime warning.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
