### PR TITLE
Update kokkos submodule to fix libdl issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "extern/kokkos"]
 	path = extern/kokkos
-	url = git@github.com:kokkos/kokkos
+	url = git@github.com:E3SM-Project/kokkos
 [submodule "extern/yaml-cpp"]
 	path = extern/yaml-cpp
 	url = git@github.com:SNLComputation/yaml-cpp.git

--- a/cmake/machine-files/kokkos/amd-zen2.cmake
+++ b/cmake/machine-files/kokkos/amd-zen2.cmake
@@ -1,4 +1,4 @@
 include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
 
 # Enable EPYC arch in kokkos
-option(Kokkos_ARCH_EPYC "" ON)
+option(Kokkos_ARCH_ZEN2 "" ON)

--- a/cmake/machine-files/mappy.cmake
+++ b/cmake/machine-files/mappy.cmake
@@ -1,3 +1,3 @@
 # Load epyc arch and openmp backend for kokkos
-include (${CMAKE_CURRENT_LIST_DIR}/kokkos/amd-epyc.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/kokkos/amd-zen2.cmake)
 include (${CMAKE_CURRENT_LIST_DIR}/kokkos/openmp.cmake)


### PR DESCRIPTION
This update switches the remote repo for kokkos from the kokkos/kokkos.git one to E3SM-Project/kokkos. The latter is E3SM fork, where we are able to put in hot fixes relatively quickly. This update, in particular, fixes an issue that
kokkos has when using '-static' linking on CRAY systems.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This update was necessary in E3SM master, to allow running on CORI, where static linking is used. The fix is relatively minor, and only affects CRAY system builds.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

