### PR TITLE
add erf

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -301,6 +301,7 @@ ekat_pack_gen_unary_stdfn(tgamma)
 ekat_pack_gen_unary_stdfn(sqrt)
 ekat_pack_gen_unary_stdfn(cbrt)
 ekat_pack_gen_unary_stdfn(tanh)
+ekat_pack_gen_unary_stdfn(erf)
 
 template <typename PackType> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<PackType, typename PackType::scalar> min (const PackType& p) {

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -308,6 +308,7 @@ struct TestPack {
     test_pack_gen_unary_stdfn(log10);
     test_pack_gen_unary_stdfn(tgamma);
     test_pack_gen_unary_stdfn(sqrt);
+    test_pack_gen_unary_stdfn(erf);
 
     test_pack_gen_unary_fn(square, square);
     test_pack_gen_unary_fn(cube, cube);


### PR DESCRIPTION
Adds `ekat::erf(Pack p)` which just calls `std::erf(p[i])`. 
Added a test `test_pack_gen_unary_stdfn(erf)` to `pack_tests.cpp`.