### PR TITLE
When checking for fenv.h, use the cxx compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,11 +77,11 @@ option (EKAT_DEFAULT_BFB "Whether EKAT should default to BFB behavior whenever p
 ###  COMPILER/OS-SPECIFIC CONFIG OPTIONS ###
 ############################################
 
-include(CheckSymbolExists)
+include(CheckCXXSymbolExists)
 # Most of the FPE stuff was defined in c++99, but gnu has some additional non-std
 # functions that are helpful (such as feeenableexcept) --- Apple stopped including these
 # in 2005, so we have to drop-in replacements for them.
-check_symbol_exists(feenableexcept "fenv.h" EKAT_HAVE_FEENABLEEXCEPT)
+check_cxx_symbol_exists(feenableexcept "fenv.h" EKAT_HAVE_FEENABLEEXCEPT)
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   #  GCC has already impl'd some c++14 features even in a c++11 build.  Apple's Clang
   # (perhaps clang generally) doesn't like this and requires -std=c++14 for these features.


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Strictly speaking, the C++ compiler is not needed. What is needed is __GNU_SOURCE to be defined. Now,
the g++ compiler *does* define that macro, and since we compile ekat as c++ sources, we might as well check if the *cxx* compiler picks up the feenableexcept symbol.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Additional Information

Note: I have no idea why this never got picked up. Using `check_symbol_exists` should _always_ use the C compiler, which should not have feenableexcept defined. However, looking at the output of our autotester past builds, I see that mpicxx compiler was used, I'm not sure why. Still, when building scream within cime just now, I had mpicc as compiler, which caused the check to fail (with consequent compilation of `ekat_feutils.hpp`, which contains MacOS specific stuff.