### PR TITLE
change macro

### DIFF
--- a/src/ekat/ekat.hpp
+++ b/src/ekat/ekat.hpp
@@ -12,7 +12,7 @@ namespace ekat {
 
 using Int = int;
 
-#if EKAT_DEFAULT_BFB
+#ifdef EKAT_DEFAULT_BFB
 static constexpr bool ekatBFB = true;
 #else
 static constexpr bool ekatBFB = false;

--- a/src/ekat/ekat_config.h.in
+++ b/src/ekat/ekat_config.h.in
@@ -17,6 +17,6 @@
 #cmakedefine EKAT_HAVE_FEENABLEEXCEPT
 
 // Decide whether ekat defaults to BFB behavior when possible/appropriate
-#cmakedefine01 EKAT_DEFAULT_BFB
+#cmakedefine EKAT_DEFAULT_BFB
 
 #endif // EKAT_CONFIG_H


### PR DESCRIPTION
Change the definition of `EKAT_DEFAULT_BFB` from `#cmakedefine01` to `#cmakedefine` to match others.