### PR TITLE
Implemented a Jaccard string similarity index function (and a test).

### DIFF
--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -56,6 +56,15 @@ double jaro_winkler_similarity (const std::string& s1, const std::string& s2,
                                 const double p = 0.1,
                                 const double threshold = 0.7);
 
+// Computes the similarity index between s1 and s2 using the Jaccard algorithm
+// (https://en.wikipedia.org/wiki/Jaccard_index). Unlike the Jaro and
+// Jaro-Winkler indices, the Jaccard index is token-based, and useful for
+// identifying similarity between phrases in which the same words appear in
+// different orders. The string s1 and s2 are broken up into tokens using
+// the given deliminator characters.
+double jaccard_similarity (const std::string& s1, const std::string& s2,
+                           const std::vector<char>& delimiters);
+
 // ==================== Case Insensitive string =================== //
 
 // A no-overhead class that inherits from std::string, which we only

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -113,17 +113,18 @@ TEST_CASE("string","string") {
   REQUIRE(items[1]=="item2");
   REQUIRE(items[2]=="item3");
 
-  // Jaro and Jaro-Winkler similarity tests
+  {
+    // Jaro and Jaro-Winkler similarity tests
 
-  // Benchmark list (including expected similarity values) from Winkler paper
-  //  https://www.census.gov/srd/papers/pdf/rrs2006-02.pdf
-  // Note: Winkler clamps all values below 0.7 to 0. I don't like that,
-  //       so I had to remove some entries.
+    // Benchmark list (including expected similarity values) from Winkler paper
+    //  https://www.census.gov/srd/papers/pdf/rrs2006-02.pdf
+    // Note: Winkler clamps all values below 0.7 to 0. I don't like that,
+    //       so I had to remove some entries.
 
-  //                          LHS         RHS       JARO   JARO-WINKLER
-  using entry_type = std::tuple<std::string,std::string,double, double>;
+    //                          LHS         RHS       JARO   JARO-WINKLER
+    using entry_type = std::tuple<std::string,std::string,double, double>;
 
-  std::vector<entry_type> benchmark =
+    std::vector<entry_type> benchmark =
     {
       entry_type{ "shackleford", "shackelford", 0.970, 0.982 },
       entry_type{ "dunningham" , "cunnigham"  , 0.896, 0.896 },
@@ -141,20 +142,41 @@ TEST_CASE("string","string") {
       entry_type{ "jon"        , "john"       , 0.917, 0.933 },
     };
 
-  const double tol = 0.005;
-  for (const auto& entry : benchmark) {
-    const auto& s1 = std::get<0>(entry);
-    const auto& s2 = std::get<1>(entry);
-    double sj  = jaro_similarity(s1,s2);
-    double sjw = jaro_winkler_similarity(s1,s2);
+    const double tol = 0.005;
+    for (const auto& entry : benchmark) {
+      const auto& s1 = std::get<0>(entry);
+      const auto& s2 = std::get<1>(entry);
+      double sj  = jaro_similarity(s1,s2);
+      double sjw = jaro_winkler_similarity(s1,s2);
 
-    const double sj_ex = std::get<2>(entry);
-    const double sjw_ex = std::get<3>(entry);
+      const double sj_ex = std::get<2>(entry);
+      const double sjw_ex = std::get<3>(entry);
 
-    REQUIRE (std::fabs(sj-sj_ex)<tol);
-    REQUIRE (std::fabs(sjw-sjw_ex)<tol);
+      REQUIRE (std::fabs(sj-sj_ex)<tol);
+      REQUIRE (std::fabs(sjw-sjw_ex)<tol);
+    }
   }
 
+  // Jaccard (token-based) similarity test.
+  {
+    using entry_type = std::tuple<std::string,std::string,double>;
+
+    std::vector<entry_type> benchmark =
+    {
+      entry_type{ "hello world", "world_hello", 1.000},
+      entry_type{ "hello_new_world", "hello world", 0.6666667},
+    };
+
+    const double tol = 0.001;
+    for (const auto& entry : benchmark) {
+      // We tokenize strings using spaces and underscores.
+      const auto& s1 = std::get<0>(entry);
+      const auto& s2 = std::get<1>(entry);
+      double sj = jaccard_similarity(s1,s2,{' ', '_'});
+      const double sj_ex = std::get<2>(entry);
+      REQUIRE (std::abs(sj-sj_ex)<tol);
+    }
+  }
 }
 
 } // empty namespace


### PR DESCRIPTION
This adds a Jaccard similarity index to our list of string utilities, along with a helper function that allows us to tokenize a string with a set of several delimiters.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
