### PR TITLE
Add support for bool data, add tests for this

### DIFF
--- a/src/ekat/ekat_pack_kokkos.hpp
+++ b/src/ekat/ekat_pack_kokkos.hpp
@@ -255,7 +255,14 @@ struct HTDVectorT
 template<>
 struct HTDVectorT<bool>
 {
-  static_assert(sizeof(bool) == sizeof(char));
+  static_assert(
+    sizeof(bool) == sizeof(char),
+    "host_to_device/device_to_host use vectors as flexible memory buffers "
+    "and they make use of vector API calls that are not available in the "
+    "vector<bool> specialization, so if a user is sending bool data, we must "
+    "use vector<char> instead and reinterpret the data as bool*. This is only "
+    "valid if chars and bools are the same size");
+
   using type = char;
 };
 

--- a/src/ekat/ekat_pack_kokkos.hpp
+++ b/src/ekat/ekat_pack_kokkos.hpp
@@ -247,6 +247,14 @@ repack (const Kokkos::View<Pack<T, old_pack_size>*, Parms...>& vp) {
 // Take an array of Host scalar pointers and turn them into device pack views
 //
 
+template <typename T>
+struct HTDVectorT
+{ using type = T; };
+
+template<>
+struct HTDVectorT<bool>
+{ using type = char; };
+
 // 1d
 template <typename SizeT, size_t N, typename ViewT>
 void host_to_device(const Kokkos::Array<typename ViewT::value_type::scalar const*, N>& data,
@@ -280,8 +288,9 @@ void host_to_device(const Kokkos::Array<typename ViewT::value_type::scalar const
 {
   using PackT = typename ViewT::value_type;
   using ScalarT = typename PackT::scalar;
+  using VectorT = typename HTDVectorT<ScalarT>::type;
 
-  std::vector<ScalarT> tdata;
+  std::vector<VectorT> tdata;
   for (size_t n = 0; n < N; ++n) {
     const size_t dim1_size = static_cast<size_t>(dim1_sizes[n]);
     const size_t dim2_size = static_cast<size_t>(dim2_sizes[n]);
@@ -292,7 +301,7 @@ void host_to_device(const Kokkos::Array<typename ViewT::value_type::scalar const
     ScalarT* the_data = nullptr;
     if (do_transpose) {
       tdata.reserve(dim1_size * dim2_size);
-      the_data = tdata.data();
+      the_data = reinterpret_cast<ScalarT*>(tdata.data());
       transpose<TransposeDirection::f2c>(data[n], the_data, dim1_size, dim2_size);
     }
     else {
@@ -323,8 +332,9 @@ void host_to_device(const Kokkos::Array<typename ViewT::value_type::scalar const
 {
   using PackT = typename ViewT::value_type;
   using ScalarT = typename PackT::scalar;
+  using VectorT = typename HTDVectorT<ScalarT>::type;
 
-  std::vector<ScalarT> tdata;
+  std::vector<VectorT> tdata;
   for (size_t n = 0; n < N; ++n) {
     const size_t dim1_size = static_cast<size_t>(dim1_sizes[n]);
     const size_t dim2_size = static_cast<size_t>(dim2_sizes[n]);
@@ -336,7 +346,7 @@ void host_to_device(const Kokkos::Array<typename ViewT::value_type::scalar const
     ScalarT* the_data = nullptr;
     if (do_transpose) {
       tdata.reserve(dim1_size * dim2_size * dim3_size);
-      the_data = tdata.data();
+      the_data = reinterpret_cast<ScalarT*>(tdata.data());
       transpose<TransposeDirection::f2c>(data[n], the_data, dim1_size, dim2_size, dim3_size);
     }
     else {
@@ -437,8 +447,9 @@ void device_to_host(const Kokkos::Array<typename ViewT::value_type::scalar*, N>&
 {
   using PackT = typename ViewT::value_type;
   using ScalarT = typename PackT::scalar;
+  using VectorT = typename HTDVectorT<ScalarT>::type;
 
-  std::vector<ScalarT> tdata;
+  std::vector<VectorT> tdata;
   for (size_t n = 0; n < N; ++n) {
     const size_t dim1_size = static_cast<size_t>(dim1_sizes[n]);
     const size_t dim2_size = static_cast<size_t>(dim2_sizes[n]);
@@ -449,7 +460,7 @@ void device_to_host(const Kokkos::Array<typename ViewT::value_type::scalar*, N>&
     ScalarT* the_data = nullptr;
     if (do_transpose) {
       tdata.reserve(dim1_size * dim2_size);
-      the_data = tdata.data();
+      the_data = reinterpret_cast<ScalarT*>(tdata.data());
     }
     else {
       the_data = data[n];
@@ -482,8 +493,9 @@ void device_to_host(const Kokkos::Array<typename ViewT::value_type::scalar*, N>&
 {
   using PackT = typename ViewT::value_type;
   using ScalarT = typename PackT::scalar;
+  using VectorT = typename HTDVectorT<ScalarT>::type;
 
-  std::vector<ScalarT> tdata;
+  std::vector<VectorT> tdata;
   for (size_t n = 0; n < N; ++n) {
     const size_t dim1_size = static_cast<size_t>(dim1_sizes[n]);
     const size_t dim2_size = static_cast<size_t>(dim2_sizes[n]);
@@ -495,7 +507,7 @@ void device_to_host(const Kokkos::Array<typename ViewT::value_type::scalar*, N>&
     ScalarT* the_data = nullptr;
     if (do_transpose) {
       tdata.reserve(dim1_size * dim2_size * dim3_size);
-      the_data = tdata.data();
+      the_data = reinterpret_cast<ScalarT*>(tdata.data());
     }
     else {
       the_data = data[n];

--- a/src/ekat/ekat_pack_kokkos.hpp
+++ b/src/ekat/ekat_pack_kokkos.hpp
@@ -8,6 +8,7 @@
 #include <Kokkos_Core.hpp>
 
 #include <vector>
+#include <type_traits>
 
 namespace ekat {
 
@@ -253,7 +254,10 @@ struct HTDVectorT
 
 template<>
 struct HTDVectorT<bool>
-{ using type = char; };
+{
+  static_assert(sizeof(bool) == sizeof(char));
+  using type = char;
+};
 
 // 1d
 template <typename SizeT, size_t N, typename ViewT>

--- a/tests/pack/pack_kokkos_tests.cpp
+++ b/tests/pack/pack_kokkos_tests.cpp
@@ -278,18 +278,45 @@ TEST_CASE("kokkos_packs", "ekat::pack") {
   REQUIRE(nerr == 0);
 }
 
-TEST_CASE("host_device_packs_1d", "ekat::pack")
+template <typename T>
+struct VectorT
 {
+  using type = T;
+
+  static T get_value(int arg) { return arg; }
+
+  static void modify_value(T& value, int arg) { value += arg; }
+};
+
+template<>
+struct VectorT<bool>
+{
+  using type = char;
+
+  static bool get_value(int arg) { return arg%2 == 0; }
+
+  static void modify_value(bool& value, int arg) {
+    bool arg_value = get_value(arg);
+    value = (value && arg_value) || (!value && !arg_value);
+  }
+};
+
+template <typename T>
+void host_device_packs_1d()
+{
+  using VTS = VectorT<T>;
+  using VT = typename VTS::type;
+
   static constexpr int num_pksizes_to_test = 4;
   static constexpr int num_views_per_pksize = 3;
   static constexpr int fixed_view_size = 67;
 
   using KT = ekat::KokkosTypes<ekat::DefaultDevice>;
 
-  using Pack1T = ekat::Pack<int, 1>;
-  using Pack2T = ekat::Pack<int, 2>;
-  using Pack4T = ekat::Pack<int, 4>;
-  using Pack8T = ekat::Pack<int, 8>; // we will use this to test fixed-sized view sugar
+  using Pack1T = ekat::Pack<T, 1>;
+  using Pack2T = ekat::Pack<T, 2>;
+  using Pack4T = ekat::Pack<T, 4>;
+  using Pack8T = ekat::Pack<T, 8>; // we will use this to test fixed-sized view sugar
 
   using view_p1_t = typename KT::template view_1d<Pack1T>;
   using view_p2_t = typename KT::template view_1d<Pack2T>;
@@ -297,7 +324,7 @@ TEST_CASE("host_device_packs_1d", "ekat::pack")
   using view_p8_t = typename KT::template view_1d<Pack8T>;
 
   Kokkos::Array<size_t, num_views_per_pksize> sizes = {13, 37, 59}; // num scalars per view
-  std::vector<std::vector<int> > raw_data(num_pksizes_to_test, std::vector<int>());
+  std::vector<std::vector<VT> > raw_data(num_pksizes_to_test, std::vector<VT>());
 
   // each pksize test (except for the one used to test fixed-size views (Pack8)) has total_flex_scalars
   // of data spread across 3 (num_views_per_pksize) views
@@ -318,12 +345,12 @@ TEST_CASE("host_device_packs_1d", "ekat::pack")
   Kokkos::Array<view_p4_t, num_views_per_pksize> p4_d;
   Kokkos::Array<view_p8_t, num_views_per_pksize> p8_d; // fixed-size
 
-  Kokkos::Array<Kokkos::Array<int*,       num_views_per_pksize>, num_pksizes_to_test> ptr_data;
-  Kokkos::Array<Kokkos::Array<const int*, num_views_per_pksize>, num_pksizes_to_test> cptr_data;
+  Kokkos::Array<Kokkos::Array<T*,       num_views_per_pksize>, num_pksizes_to_test> ptr_data;
+  Kokkos::Array<Kokkos::Array<const T*, num_views_per_pksize>, num_pksizes_to_test> cptr_data;
   for (int i = 0; i < num_pksizes_to_test; ++i) {
     for (int j = 0; j < num_views_per_pksize; ++j) {
       if (j == 0) {
-        ptr_data[i][j] = raw_data[i].data();
+        ptr_data[i][j] = reinterpret_cast<T*>(raw_data[i].data());
       }
       else {
         const int last_size = i == num_pksizes_to_test-1 ? fixed_view_size : sizes[j-1];
@@ -338,7 +365,7 @@ TEST_CASE("host_device_packs_1d", "ekat::pack")
     for (int j = 0; j < num_views_per_pksize; ++j) {
       const int klim = (i == num_pksizes_to_test - 1 ? fixed_view_size : sizes[j]);
       for (int k = 0; k < klim; ++k) {
-        ptr_data[i][j][k] = k*(i+j+1);
+        ptr_data[i][j][k] = VTS::get_value(k*(i+j+1));
       }
     }
   }
@@ -358,20 +385,20 @@ TEST_CASE("host_device_packs_1d", "ekat::pack")
           const int pk_idx = k % pk_sizes[i];
 
           if (i == 0) {
-            EKAT_KERNEL_REQUIRE(p1_d[j](view_idx)[pk_idx] == k*(i+j+1));
-            p1_d[j](view_idx)[pk_idx] += i+j;
+            EKAT_KERNEL_REQUIRE(p1_d[j](view_idx)[pk_idx] == VTS::get_value(k*(i+j+1)));
+            p1_d[j](view_idx)[pk_idx] = VTS::get_value(k*(i+j+1) + i + j);
           }
           else if (i == 1) {
-            EKAT_KERNEL_REQUIRE(p2_d[j](view_idx)[pk_idx] == k*(i+j+1));
-            p2_d[j](view_idx)[pk_idx] += i+j;
+            EKAT_KERNEL_REQUIRE(p2_d[j](view_idx)[pk_idx] == VTS::get_value(k*(i+j+1)));
+            p2_d[j](view_idx)[pk_idx] = VTS::get_value(k*(i+j+1) + i + j);
           }
           else if (i == 2) {
-            EKAT_KERNEL_REQUIRE(p4_d[j](view_idx)[pk_idx] == k*(i+j+1));
-            p4_d[j](view_idx)[pk_idx] += i+j;
+            EKAT_KERNEL_REQUIRE(p4_d[j](view_idx)[pk_idx] == VTS::get_value(k*(i+j+1)));
+            p4_d[j](view_idx)[pk_idx] = VTS::get_value(k*(i+j+1) + i + j);
           }
           else if (i == 3) {
-            EKAT_KERNEL_REQUIRE(p8_d[j](view_idx)[pk_idx] == k*(i+j+1));
-            p8_d[j](view_idx)[pk_idx] += i+j;
+            EKAT_KERNEL_REQUIRE(p8_d[j](view_idx)[pk_idx] == VTS::get_value(k*(i+j+1)));
+            p8_d[j](view_idx)[pk_idx] = VTS::get_value(k*(i+j+1) + i + j);
           }
           else {
             EKAT_KERNEL_REQUIRE_MSG(false, "Unhandled i");
@@ -390,14 +417,24 @@ TEST_CASE("host_device_packs_1d", "ekat::pack")
     for (int j = 0; j < num_views_per_pksize; ++j) {
       const int klim = (i == num_pksizes_to_test - 1 ? fixed_view_size : sizes[j]);
       for (int k = 0; k < klim; ++k) {
-        REQUIRE(ptr_data[i][j][k] == k*(i+j+1) + i + j);
+        REQUIRE(ptr_data[i][j][k] == VTS::get_value(k*(i+j+1) + i + j));
       }
     }
   }
 }
 
+TEST_CASE("host_device_packs_1d", "ekat::pack")
+{
+  host_device_packs_1d<int>();
+  host_device_packs_1d<bool>();
+}
+
+template <typename T>
 void host_device_packs_2d(bool transpose)
 {
+  using VTS = VectorT<T>;
+  using VT = typename VTS::type;
+
   static constexpr int num_pksizes_to_test = 4;
   static constexpr int num_views_per_pksize = 3;
   static constexpr int fixed_view_dim1 = 5;
@@ -405,10 +442,10 @@ void host_device_packs_2d(bool transpose)
 
   using KT = ekat::KokkosTypes<ekat::DefaultDevice>;
 
-  using Pack1T = ekat::Pack<int, 1>;
-  using Pack2T = ekat::Pack<int, 2>;
-  using Pack4T = ekat::Pack<int, 4>;
-  using Pack8T = ekat::Pack<int, 8>; // we will use this to test fixed-sized view sugar
+  using Pack1T = ekat::Pack<T, 1>;
+  using Pack2T = ekat::Pack<T, 2>;
+  using Pack4T = ekat::Pack<T, 4>;
+  using Pack8T = ekat::Pack<T, 8>; // we will use this to test fixed-sized view sugar
 
   using view_p1_t = typename KT::template view_2d<Pack1T>;
   using view_p2_t = typename KT::template view_2d<Pack2T>;
@@ -424,7 +461,7 @@ void host_device_packs_2d(bool transpose)
   }
 
   // place to store raw data
-  std::vector<std::vector<int> > raw_data(num_pksizes_to_test, std::vector<int>());
+  std::vector<std::vector<VT> > raw_data(num_pksizes_to_test, std::vector<VT>());
 
   // each pksize test (except for the one used to test fixed-size views (Pack8)) has total_flex_scalars
   // of data spread across 3 (num_views_per_pksize) views
@@ -446,12 +483,12 @@ void host_device_packs_2d(bool transpose)
   Kokkos::Array<view_p4_t, num_views_per_pksize> p4_d;
   Kokkos::Array<view_p8_t, num_views_per_pksize> p8_d; // fixed-size
 
-  Kokkos::Array<Kokkos::Array<int*,       num_views_per_pksize>, num_pksizes_to_test> ptr_data;
-  Kokkos::Array<Kokkos::Array<const int*, num_views_per_pksize>, num_pksizes_to_test> cptr_data;
+  Kokkos::Array<Kokkos::Array<T*,       num_views_per_pksize>, num_pksizes_to_test> ptr_data;
+  Kokkos::Array<Kokkos::Array<const T*, num_views_per_pksize>, num_pksizes_to_test> cptr_data;
   for (int i = 0; i < num_pksizes_to_test; ++i) {
     for (int j = 0; j < num_views_per_pksize; ++j) {
       if (j == 0) {
-        ptr_data[i][j] = raw_data[i].data();
+        ptr_data[i][j] = reinterpret_cast<T*>(raw_data[i].data());
       }
       else {
         const int last_size = i == num_pksizes_to_test-1 ? fixed_scalars_per_view : total_sizes[j-1];
@@ -468,7 +505,7 @@ void host_device_packs_2d(bool transpose)
       const int kdim2 = (i == num_pksizes_to_test - 1 ? fixed_view_dim2 : dim2_sizes[j]);
       for (int k1 = 0; k1 < kdim1; ++k1) {
         for (int k2 = 0; k2 < kdim2; ++k2) {
-          ptr_data[i][j][k1*kdim2 + k2] = k1*(i+j+1) + k2*(i-j-1);
+          ptr_data[i][j][k1*kdim2 + k2] = VTS::get_value(k1*(i+j+1) + k2*(i-j-1));
         }
       }
     }
@@ -490,7 +527,7 @@ void host_device_packs_2d(bool transpose)
             const int view_idx = k2 / pk_sizes[i];
             const int pk_idx = k2 % pk_sizes[i];
 
-            int* curr_scalar = nullptr;
+            T* curr_scalar = nullptr;
             if (i == 0) {
               curr_scalar = &(p1_d[j](k1, view_idx)[pk_idx]);
             }
@@ -506,13 +543,10 @@ void host_device_packs_2d(bool transpose)
             else {
               EKAT_KERNEL_REQUIRE_MSG(false, "Unhandled i");
             }
-            if (transpose) {
-              //EKAT_KERNEL_REQUIRE(*curr_scalar == k2*(i+j+1) + k1*(i-j-1));
+            if (!transpose) {
+              EKAT_KERNEL_REQUIRE(*curr_scalar == VTS::get_value(k1*(i+j+1) + k2*(i-j-1)));
             }
-            else {
-              EKAT_KERNEL_REQUIRE(*curr_scalar == k1*(i+j+1) + k2*(i-j-1));
-            }
-            *curr_scalar += i+j;
+            VTS::modify_value(*curr_scalar, i + j);
           }
         }
       }
@@ -530,7 +564,7 @@ void host_device_packs_2d(bool transpose)
       const int kdim2 = (i == num_pksizes_to_test - 1 ? fixed_view_dim2 : dim2_sizes[j]);
       for (int k1 = 0; k1 < kdim1; ++k1) {
         for (int k2 = 0; k2 < kdim2; ++k2) {
-          REQUIRE(ptr_data[i][j][k1*kdim2 + k2] == k1*(i+j+1) + k2*(i-j-1) + i + j);
+          REQUIRE(ptr_data[i][j][k1*kdim2 + k2] == VTS::get_value(k1*(i+j+1) + k2*(i-j-1) + i + j));
         }
       }
     }
@@ -539,12 +573,18 @@ void host_device_packs_2d(bool transpose)
 
 TEST_CASE("host_device_packs_2d", "ekat::pack")
 {
-  host_device_packs_2d(false);
-  host_device_packs_2d(true);
+  host_device_packs_2d<bool>(false);
+  host_device_packs_2d<bool>(true);
+  host_device_packs_2d<int>(false);
+  host_device_packs_2d<int>(true);
 }
 
+template <typename T>
 void host_device_packs_3d(bool transpose)
 {
+  using VTS = VectorT<T>;
+  using VT = typename VTS::type;
+
   static constexpr int num_pksizes_to_test = 4;
   static constexpr int num_views_per_pksize = 3;
   static constexpr int fixed_view_dim1 = 3;
@@ -553,10 +593,10 @@ void host_device_packs_3d(bool transpose)
 
   using KT = ekat::KokkosTypes<ekat::DefaultDevice>;
 
-  using Pack1T = ekat::Pack<int, 1>;
-  using Pack2T = ekat::Pack<int, 2>;
-  using Pack4T = ekat::Pack<int, 4>;
-  using Pack8T = ekat::Pack<int, 8>; // we will use this to test fixed-sized view sugar
+  using Pack1T = ekat::Pack<T, 1>;
+  using Pack2T = ekat::Pack<T, 2>;
+  using Pack4T = ekat::Pack<T, 4>;
+  using Pack8T = ekat::Pack<T, 8>; // we will use this to test fixed-sized view sugar
 
   using view_p1_t = typename KT::template view_3d<Pack1T>;
   using view_p2_t = typename KT::template view_3d<Pack2T>;
@@ -573,7 +613,7 @@ void host_device_packs_3d(bool transpose)
   }
 
   // place to store raw data
-  std::vector<std::vector<int> > raw_data(num_pksizes_to_test, std::vector<int>());
+  std::vector<std::vector<VT> > raw_data(num_pksizes_to_test, std::vector<VT>());
 
   // each pksize test (except for the one used to test fixed-size views (Pack8)) has total_flex_scalars
   // of data spread across 3 (num_views_per_pksize) views
@@ -595,12 +635,12 @@ void host_device_packs_3d(bool transpose)
   Kokkos::Array<view_p4_t, num_views_per_pksize> p4_d;
   Kokkos::Array<view_p8_t, num_views_per_pksize> p8_d; // fixed-size
 
-  Kokkos::Array<Kokkos::Array<int*,       num_views_per_pksize>, num_pksizes_to_test> ptr_data;
-  Kokkos::Array<Kokkos::Array<const int*, num_views_per_pksize>, num_pksizes_to_test> cptr_data;
+  Kokkos::Array<Kokkos::Array<T*,       num_views_per_pksize>, num_pksizes_to_test> ptr_data;
+  Kokkos::Array<Kokkos::Array<const T*, num_views_per_pksize>, num_pksizes_to_test> cptr_data;
   for (int i = 0; i < num_pksizes_to_test; ++i) {
     for (int j = 0; j < num_views_per_pksize; ++j) {
       if (j == 0) {
-        ptr_data[i][j] = raw_data[i].data();
+        ptr_data[i][j] = reinterpret_cast<T*>(raw_data[i].data());
       }
       else {
         const int last_size = i == num_pksizes_to_test-1 ? fixed_scalars_per_view : total_sizes[j-1];
@@ -619,7 +659,7 @@ void host_device_packs_3d(bool transpose)
       for (int k1 = 0; k1 < kdim1; ++k1) {
         for (int k2 = 0; k2 < kdim2; ++k2) {
           for (int k3 = 0; k3 < kdim3; ++k3) {
-            ptr_data[i][j][k1*(kdim2*kdim3) + k2*(kdim3) + k3] = k1*(i+j+1) + k2*(i-j-1) + k3*(i+j-1);
+            ptr_data[i][j][k1*(kdim2*kdim3) + k2*(kdim3) + k3] = VTS::get_value(k1*(i+j+1) + k2*(i-j-1) + k3*(i+j-1));
           }
         }
       }
@@ -644,7 +684,7 @@ void host_device_packs_3d(bool transpose)
               const int view_idx = k3 / pk_sizes[i];
               const int pk_idx = k3 % pk_sizes[i];
 
-              int* curr_scalar = nullptr;
+              T* curr_scalar = nullptr;
               if (i == 0) {
                 curr_scalar = &(p1_d[j](k1, k2, view_idx)[pk_idx]);
               }
@@ -661,9 +701,9 @@ void host_device_packs_3d(bool transpose)
                 EKAT_KERNEL_REQUIRE_MSG(false, "Unhandled i");
               }
               if (!transpose) {
-                EKAT_KERNEL_REQUIRE(*curr_scalar == k1*(i+j+1) + k2*(i-j-1) + k3*(i+j-1));
+                EKAT_KERNEL_REQUIRE(*curr_scalar == VTS::get_value(k1*(i+j+1) + k2*(i-j-1) + k3*(i+j-1)));
               }
-              *curr_scalar += i+j;
+              VTS::modify_value(*curr_scalar, i + j);
             }
           }
         }
@@ -684,7 +724,7 @@ void host_device_packs_3d(bool transpose)
       for (int k1 = 0; k1 < kdim1; ++k1) {
         for (int k2 = 0; k2 < kdim2; ++k2) {
           for (int k3 = 0; k3 < kdim3; ++k3) {
-            REQUIRE(ptr_data[i][j][k1*(kdim2*kdim3) + k2*(kdim3) + k3] == k1*(i+j+1) + k2*(i-j-1) + k3*(i+j-1) + i + j);
+            REQUIRE(ptr_data[i][j][k1*(kdim2*kdim3) + k2*(kdim3) + k3] == VTS::get_value(k1*(i+j+1) + k2*(i-j-1) + k3*(i+j-1) + i + j));
           }
         }
       }
@@ -694,8 +734,10 @@ void host_device_packs_3d(bool transpose)
 
 TEST_CASE("host_device_packs_3d", "ekat::pack")
 {
-  host_device_packs_3d(true);
-  host_device_packs_3d(false);
+  host_device_packs_3d<bool>(false);
+  host_device_packs_3d<bool>(true);
+  host_device_packs_3d<int>(false);
+  host_device_packs_3d<int>(true);
 }
 
 TEST_CASE("index_and_shift", "ekat::pack")

--- a/tests/pack/pack_kokkos_tests.cpp
+++ b/tests/pack/pack_kokkos_tests.cpp
@@ -283,9 +283,9 @@ struct VectorT
 {
   using type = T;
 
-  static T get_value(int arg) { return arg; }
+  static T get_value(int arg) { return static_cast<T>(arg); }
 
-  static void modify_value(T& value, int arg) { value += arg; }
+  static void modify_value(T& value, int arg) { value += static_cast<T>(arg); }
 };
 
 template<>
@@ -297,7 +297,7 @@ struct VectorT<bool>
 
   static void modify_value(bool& value, int arg) {
     bool arg_value = get_value(arg);
-    value = (value && arg_value) || (!value && !arg_value);
+    value = (value == arg_value);
   }
 };
 


### PR DESCRIPTION
Due to the very-annoying STL specialization of vector<bool>, some of the host_to_device/device_to_host stuff was broken for bool data. We are now porting SHOC routine that use arrays of bools, so we need this to work. This PR achieves that by using vector<char> and doing reinterpret casts for data() pointers.

## Testing
I've templated all the original host_to_device/device_to_host tests and they now test ints and bools.
