### PR TITLE
Fix EkatDisableAllWarnings for cmake versions older than 3.14.0

### DIFF
--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -102,9 +102,14 @@ macro (EkatDisableAllWarning targetName)
   target_compile_options (${targetName} PRIVATE
     $<$<COMPILE_LANGUAGE:C>:$<$<C_COMPILER_ID:GNU>:-w> $<$<C_COMPILER_ID:Intel>: -w>>)
   target_compile_options (${targetName} PRIVATE
-    $<$<COMPILE_LANGUAGE:Fortran>:$<$<Fortran_COMPILER_ID:GNU>:-w> $<$<Fortran_COMPILER_ID:Intel>: -w>>)
-  target_compile_options (${targetName} PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:GNU>:-w> $<$<CXX_COMPILER_ID:Intel>: -w>>)
+  if (${CMAKE_VERSION} VERSION_LESS "3.14.0")
+    target_compile_options (${targetName} PRIVATE
+      $<$<COMPILE_LANGUAGE:Fortran>:$<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","GNU">:-w> $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","Intel">: -w>>)
+  else ()
+    target_compile_options (${targetName} PRIVATE
+      $<$<COMPILE_LANGUAGE:Fortran>:$<$<Fortran_COMPILER_ID:GNU>:-w> $<$<Fortran_COMPILER_ID:Intel>: -w>>)
+  endif()
 
 endmacro (EkatDisableAllWarning)
 


### PR DESCRIPTION
Allows to use the `EkatDisableAllWarning` cmake utility function for targets that compile F90 files.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
See issue #82 for a detail explanation.

## Related Issues

* Closes #82 

## Testing
Manually verified with CMake 3.12.2 that this works (I temporarily added `EkatDisableAllWarning(ekat)` to `src/ekat/CMakeLists.txt`, and inspected the `flags.make` file.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
