### PR TITLE
Disable fpe tests if fpe functions aren't available.

### DIFF
--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,8 +1,12 @@
 include(EkatCreateUnitTest)
 
 # Test debug tools
+if (${EKAT_HAVE_FEENABLEEXCEPT})
 EkatCreateUnitTest(debug_tools debug_tools_tests.cpp
   LIBS ekat)
+else ()
+ message(STATUS "feeenableexcept not found in fenv.h -- disabling debug_tools_tests")
+endif()
 
 # Test utilities (c++)
 EkatCreateUnitTest(util_cxx util_tests.cpp


### PR DESCRIPTION
Disable fpe tests if fpe functions aren't available.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation

Mac's compilers don't include the gnu FPE functions, so Mac builds have had a failing unit test (debug_tools_tests) as a consequence.  This PR disables that test if the FPE functions it requires are not found.

Closes #23 

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing

Builds & tests pass on Mac.

<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
