### PR TITLE
Avoid printing lines of tildes in catch2

### DIFF
--- a/extern/catch2/include/catch2/catch.hpp
+++ b/extern/catch2/include/catch2/catch.hpp
@@ -15774,7 +15774,7 @@ void ConsoleReporter::lazyPrintWithoutClosingBenchmarkTable() {
     }
 }
 void ConsoleReporter::lazyPrintRunInfo() {
-    stream << '\n' << getLineOfChars<'~'>() << '\n';
+    stream << '\n' << getLineOfChars<'='>() << '\n';
     Colour colour(Colour::SecondaryText);
     stream << currentTestRunInfo->name
         << " is a Catch v" << libraryVersion() << " host application.\n"


### PR DESCRIPTION
Github parses a line of tilde as a code block opening. If tests output is
written in a msg on a PR/issue, this causes parsing mess.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When the AutoTester writes a message on a PR, it adds outputs from the tests in case there are failures, but lines of `~` chars mess up the parsing.

## Related Issues

* Closes #85 