### PR TITLE
Remove const from ekat::find signature.

### DIFF
--- a/src/ekat/std_meta/ekat_std_utils.hpp
+++ b/src/ekat/std_meta/ekat_std_utils.hpp
@@ -11,7 +11,7 @@ namespace ekat {
 
 // This function returns an iterator which is of the same type of c.begin()
 template<typename ContainerType, typename T>
-auto find (const ContainerType& c, T&& value) -> decltype(c.begin()) {
+auto find (ContainerType& c, T&& value) -> decltype(c.begin()) {
   return std::find(c.begin(),c.end(),value);
 }
 


### PR DESCRIPTION
If the input container `c` is const, the type of `c.begin()`, is an iterator to const, which can later mess up fcn overload resolution when using the result to call some other function. If the container is indeed const, the 'const' will be part of `ContainerType` anyways, yielding the same behavior as before.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Consider this example:

```
std::list<std::string> names = {"Luca", "Jim"};
auto it = ekat::find(names,"Jim");
std::iter_swap(names.begin(),it); // error!
```
The compiler will bark an error, saying that `*it` is a const reference, so it cannot be modified. That's because `ekat::find` returns the type of `begin()` called on a const list, which is an iterator to const.