### PR TITLE
Add support for using valgrind on all created tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND CMAKE_MODULE_PATH
 # (for openpmi; -lmpicxx for mpich) flag.
 include(EkatMpiUtils)
 DisableMpiCxxBindings()
+
 # Scripts containing macros needed to handle TPLs
 include(EkatBuildKokkos)
 include(EkatBuildYamlCpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ list(APPEND CMAKE_MODULE_PATH
 # (for openpmi; -lmpicxx for mpich) flag.
 include(EkatMpiUtils)
 DisableMpiCxxBindings()
-
 # Scripts containing macros needed to handle TPLs
 include(EkatBuildKokkos)
 include(EkatBuildYamlCpp)
@@ -72,6 +71,7 @@ set (EKAT_TPL_LIBRARIES ${EKAT_TPL_LIBRARIES_INTERNAL} CACHE INTERNAL "List of E
 
 option (EKAT_MPI_ERRORS_ARE_FATAL " Whether EKAT should crash when MPI errors happen." ON)
 option (EKAT_DEFAULT_BFB "Whether EKAT should default to BFB behavior whenever possible/appropriate." ${EKAT_IS_DEBUG_BUILD})
+option (EKAT_ENABLE_VALGRIND "Whether to run tests with valgrind" OFF)
 
 ############################################
 ###  COMPILER/OS-SPECIFIC CONFIG OPTIONS ###
@@ -90,6 +90,14 @@ endif()
 
 include(EkatSetCompilerFlags)
 SetCompilerFlags()
+
+############################
+##     EKAT VALGRIND SUPPORT ###
+############################
+
+if (EKAT_ENABLE_VALGRIND)
+  add_subdirectory(valgrind_support)
+endif()
 
 ############################
 ###    EKAT LIBRARIES    ###

--- a/tests/utils/upper_bound_test.cpp
+++ b/tests/utils/upper_bound_test.cpp
@@ -19,6 +19,7 @@ TEST_CASE("upper_bound", "soak") {
     for (int i = 0; i < size; ++i) {
       v[i] = value_dist(generator);
     }
+    v[0] = 1.0; // ensures upper_bound search never goes off the end of the vector
     std::sort(v.begin(), v.end());
     double search_val = value_dist(generator);
     double v1 = *ekat::upper_bound_impl(v.data(), v.data() + size, search_val);

--- a/valgrind_support/CMakeLists.txt
+++ b/valgrind_support/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+add_executable(serial_hw serial_hw.cxx)
+add_executable(mpi_hw mpi_hw.cxx)
+
+add_custom_target(serial_sup ALL
+  COMMAND valgrind --gen-suppressions=all ./serial_hw 2>&1 | ${CMAKE_CURRENT_SOURCE_DIR}/gen_sup.sh > ${CMAKE_BINARY_DIR}/serial.supp
+  DEPENDS serial_hw
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+add_custom_target(mpi_sup ALL
+  COMMAND mpiexec -np 2 valgrind --gen-suppressions=all ./mpi_hw 2>&1 | ${CMAKE_CURRENT_SOURCE_DIR}/gen_sup.sh > ${CMAKE_BINARY_DIR}/mpi.supp
+  DEPENDS mpi_hw
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )

--- a/valgrind_support/gen_sup.sh
+++ b/valgrind_support/gen_sup.sh
@@ -1,0 +1,60 @@
+#! /usr/bin/awk -f
+
+# Copied from: https://wiki.wxwidgets.org/Parse_valgrind_suppressions.sh
+#
+# A script to extract the actual suppression info from the output of (for example) valgrind --leak-check=full --show-reachable=yes --error-limit=no --gen-suppressions=all ./minimal
+# The desired bits are between ^{ and ^} (including the braces themselves).
+# The combined output should either be appended to /usr/lib/valgrind/default.supp, or placed in a .supp of its own
+# If the latter, either tell valgrind about it each time with --suppressions=<filename>, or add that line to ~/.valgrindrc
+
+# NB This script uses the |& operator, which I believe is gawk-specific. In case of failure, check that you're using gawk rather than some other awk
+
+# The script looks for suppressions. When it finds one it stores it temporarily in an array,
+# and also feeds it line by line to the external app 'md5sum' which generates a unique checksum for it.
+# The checksum is used as an index in a different array. If an item with that index already exists the suppression must be a duplicate and is discarded.
+
+BEGIN { suppression=0; md5sum = "md5sum" }
+  # If the line begins with '{', it's the start of a supression; so set the var and initialise things
+  /^{/  {
+           suppression=1;  i=0; next
+        }
+  # If the line begins with '}' its the end of a suppression
+  /^}/  {
+          if (suppression)
+           { suppression=0;
+             close(md5sum, "to")  # We've finished sending data to md5sum, so close that part of the pipe
+             ProcessInput()       # Do the slightly-complicated stuff in functions
+             delete supparray     # We don't want subsequent suppressions to append to it!
+           }
+     }
+  # Otherwise, it's a normal line. If we're inside a supression, store it, and pipe it to md5sum. Otherwise it's cruft, so ignore it
+     { if (suppression)
+         {
+            supparray[++i] = $0
+            print |& md5sum
+         }
+     }
+
+
+ function ProcessInput()
+ {
+    # Pipe the result from md5sum, then close it
+    md5sum |& getline result
+    close(md5sum)
+    # gawk can't cope with enormous ints like $result would be, so stringify it first by prefixing a definite string
+    resultstring = "prefix"result
+
+    if (! (resultstring in chksum_array) )
+      { chksum_array[resultstring] = 0;  # This checksum hasn't been seen before, so add it to the array
+        OutputSuppression()              # and output the contents of the suppression
+      }
+ }
+
+ function OutputSuppression()
+ {
+  # A suppression is surrounded by '{' and '}'. Its data was stored line by line in the array
+  print "{"
+  for (n=1; n <= i; ++n)
+    { print supparray[n] }
+  print "}"
+ }

--- a/valgrind_support/mpi_hw.cxx
+++ b/valgrind_support/mpi_hw.cxx
@@ -1,0 +1,19 @@
+#include <iostream>
+#include "mpi.h"
+
+using namespace std;
+
+int main(int argc, char** argv)
+{
+  MPI_Init(&argc, &argv);
+
+  cout << "Hello ";
+  for (int i = 1; i < argc; ++i) {
+    cout << argv[i] << " ";
+  }
+  cout << endl;
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/valgrind_support/serial_hw.cxx
+++ b/valgrind_support/serial_hw.cxx
@@ -1,0 +1,9 @@
+#include <iostream>
+
+using namespace std;
+
+int main(int argc, char** argv)
+{
+  cout << "Hello" << endl;
+  return 0;
+}


### PR DESCRIPTION
CMAKE option is EKAT_ENABLE_VALGRIND. Supports automatic generation
of suppresion files which is necessary for clean runs of tests that use
MPI.

Discovered a minor memory problem in upper_bound test which I fixed.

Once this is merged and available to SCREAM, we can begin exploring options for having valgrind in our CI/nightly testing.

I tested this by hand. First, tested EKAT both with and without EKAT_ENABLE_VALGRIND. Without it, tests ran as before. With it, I checked ctest with verbose mode on and confirmed the injection of valgrind. I then ran all tests with valgrind on and noticed the valgrind problem in upper_bound.

Second, I repeated this process for SCREAM. SCREAM has a a number of valgrind issues, mostly in SHOC.
