### PR TITLE
SCREAM: in debug mode, init workspace buffer with NaN

### DIFF
--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -253,8 +253,7 @@ class WorkspaceManager
   KOKKOS_INLINE_FUNCTION
   void init_metadata(const int ws_idx, const int slot) const;
 
-  static void init(const WorkspaceManager& wm, const view_2d<T>& data,
-                   const int max_ws_idx, const int max_used, const int total);
+  static void init(const WorkspaceManager& wm, const int max_ws_idx, const int max_used);
 
   //
   // data

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -146,7 +146,7 @@ WorkspaceManager<T, D>::get_space_in_slot(const int team_idx, const int slot) co
     (m_size*sizeof(T))/sizeof(S));
 #ifndef NDEBUG
   for (size_t k=0; k<space.size(); ++k) {
-    space(k) = ekat::ScalarTraits<S>::quiet_NaN();
+    space(k) = ekat::ScalarTraits<S>::invalid();
   }
 #endif
   return space;

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -139,11 +139,17 @@ KOKKOS_FORCEINLINE_FUNCTION
 Unmanaged<typename WorkspaceManager<T, D>::template view_1d<S> >
 WorkspaceManager<T, D>::get_space_in_slot(const int team_idx, const int slot) const
 {
-  return Unmanaged<view_1d<S> >(
+  Unmanaged<view_1d<S> > space(
     reinterpret_cast<S*>(&m_data(team_idx, slot*m_total) + m_reserve),
     sizeof(T) == sizeof(S) ?
     m_size :
     (m_size*sizeof(T))/sizeof(S));
+#ifndef NDEBUG
+  for (size_t k=0; k<space.size(); ++k) {
+    space(k) = ekat::ScalarTraits<S>::quiet_NaN();
+  }
+#endif
+  return space;
 }
 
 template <typename T, typename D>

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -34,7 +34,7 @@ WorkspaceManager<T, D>::WorkspaceManager(int size, int max_used, TeamPolicy poli
   m_data(Kokkos::ViewAllocateWithoutInitializing("Workspace.m_data"),
          m_max_ws_idx, m_total * m_max_used)
 {
-  init(*this, m_data, m_max_ws_idx, m_max_used, m_total);
+  init(*this, m_max_ws_idx, m_max_used);
 }
 
 template <typename T, typename D>
@@ -109,8 +109,8 @@ void WorkspaceManager<T, D>::release_workspace(const MemberType& team, const Wor
 { m_tu.release_workspace_idx(team, ws.m_ws_idx); }
 
 template <typename T, typename D>
-void WorkspaceManager<T, D>::init(const WorkspaceManager<T, D>& wm, const view_2d<T>& data,
-                                  const int max_ws_idx, const int max_used, const int total)
+void WorkspaceManager<T, D>::init(const WorkspaceManager<T, D>& wm,
+                                  const int max_ws_idx, const int max_used)
 {
   Kokkos::parallel_for(
     "WorkspaceManager ctor",


### PR DESCRIPTION
In debug mode, fill a slot with NaN during the 'take' calls.

## Motivation
Not initializing can cause hard-to-find bugs. This is b/c during a malloc request, if the OS provides a fresh new page (as opposed to a previous one being recycled) it is _always_ going to zero it out (for security reasons). This could hide some bugs. However, if during another execution a previous page is reused, no zeroing out happens, which can cause erratic behavior

NaN's should already cause some check to fail, should these arrays be used without being properly initialized. This is why it is enough to do this only in debug mode: once all bugs (due to uninited vals being used) are fixed, it is safe to let the WSM provide uninitialized memory, since we know that the provided arrays will be written before they are read.

## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This will help fixing some valgrind errors in scream.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
The WSM is already tested.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
