### PR TITLE
Add possibility of whole-string-matching to Jaccard similarity algorithm

### DIFF
--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <set>
 #include <sstream>
+#include <list>
 
 namespace ekat {
 
@@ -128,15 +129,31 @@ namespace {
 
 // This is a helper function for token-based similarity indexes. It gathers
 // tokens from the given string for the given list of delimiters.
-std::vector<std::string> gather_tokens(const std::string& s,
-                                       const std::vector<char>& delimiters) {
+std::list<std::string> gather_tokens(const std::string& s,
+                                     const std::vector<char>& delimiters,
+                                     const std::string& atomic = "") {
+  std::list<std::string> all_tokens;
+
+  if (atomic!="") {
+    auto pos = s.find(atomic);
+    if (pos==std::string::npos) {
+      // The atomic string wasn't found.
+      return gather_tokens(s,delimiters,"");
+    }
+
+    std::string s_mod(s);
+    s_mod.erase(pos,atomic.size());
+    all_tokens.push_back(atomic);
+    all_tokens.splice(all_tokens.end(),gather_tokens(s_mod,delimiters));
+    return all_tokens;
+  }
+
   std::string delim_str;
   for (char delim: delimiters) {
     delim_str.append(1, delim);
   }
   std::size_t prev = 0, pos;
   std::stringstream sstr(s);
-  std::vector<std::string> all_tokens;
   while ((pos = s.find_first_of(delim_str, prev)) != std::string::npos)
   {
     if (pos > prev) {
@@ -153,13 +170,38 @@ std::vector<std::string> gather_tokens(const std::string& s,
 } // anonymous namespace
 
 double jaccard_similarity (const std::string& s1, const std::string& s2,
-                           const std::vector<char>& delimiters) {
+                           const std::vector<char>& delimiters,
+                           const bool tokenize_s1,
+                           const bool tokenize_s2)
+{
+  // Nobody should call this case, but just in case: not tokenizing either one,
+  // is equivalent to returning s1==s2
+  if (!tokenize_s1 && !tokenize_s2) {
+    return static_cast<double>(s1==s2);
+  }
   // Break the first and second strings up into tokens using all given
   // delimiters.
-  auto s1_tokens = gather_tokens(s1, delimiters);
-  auto s1_set = std::set<std::string>(s1_tokens.begin(), s1_tokens.end());
-  auto s2_tokens = gather_tokens(s2, delimiters);
-  auto s2_set = std::set<std::string>(s2_tokens.begin(), s2_tokens.end());
+  std::list<std::string> s1_tokens, s2_tokens;
+  std::set<std::string> s1_set, s2_set;
+
+  if (tokenize_s1) {
+    if (tokenize_s2) {
+      s2_tokens = gather_tokens(s2, delimiters);
+      s1_tokens = gather_tokens(s1, delimiters);
+    } else {
+      // S2 is a single token
+      s2_tokens.push_back(s2);
+      s1_tokens = gather_tokens(s1, delimiters, s2);
+    }
+  } else {
+    // We already took care of the case were we don't tokenize either one,
+    // so we can be sure tokenize_s2 is true.
+    // S2 is a single token
+    s1_tokens.push_back(s1);
+    s2_tokens = gather_tokens(s2, delimiters, s1);
+  }
+  s1_set = std::set<std::string>(s1_tokens.begin(), s1_tokens.end());
+  s2_set = std::set<std::string>(s2_tokens.begin(), s2_tokens.end());
 
   // Compute the intersection of the two sets of tokens.
   std::vector<std::string> s_intersection(std::max(s1_set.size(), s2_set.size()));

--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -125,13 +125,11 @@ double jaro_winkler_similarity (const std::string& s1, const std::string& s2,
   return sim_j;
 }
 
-namespace {
-
 // This is a helper function for token-based similarity indexes. It gathers
 // tokens from the given string for the given list of delimiters.
 std::list<std::string> gather_tokens(const std::string& s,
                                      const std::vector<char>& delimiters,
-                                     const std::string& atomic = "") {
+                                     const std::string& atomic) {
   std::list<std::string> all_tokens;
 
   if (atomic!="") {
@@ -140,11 +138,15 @@ std::list<std::string> gather_tokens(const std::string& s,
       // The atomic string wasn't found.
       return gather_tokens(s,delimiters,"");
     }
+    // The atomic string was found. Add it as a token, then remove if from
+    // the input string, and run again on what's left.
+    all_tokens.push_back(atomic);
 
     std::string s_mod(s);
     s_mod.erase(pos,atomic.size());
-    all_tokens.push_back(atomic);
-    all_tokens.splice(all_tokens.end(),gather_tokens(s_mod,delimiters));
+
+    // Note: splice is better than manual push back, since it only moves a couple of ptrs.
+    all_tokens.splice(all_tokens.end(),gather_tokens(s_mod,delimiters,atomic));
     return all_tokens;
   }
 
@@ -164,10 +166,9 @@ std::list<std::string> gather_tokens(const std::string& s,
   if (prev < s.length()) {
     all_tokens.push_back(s.substr(prev, std::string::npos));
   }
+
   return all_tokens;
 }
-
-} // anonymous namespace
 
 double jaccard_similarity (const std::string& s1, const std::string& s2,
                            const std::vector<char>& delimiters,

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -61,9 +61,14 @@ double jaro_winkler_similarity (const std::string& s1, const std::string& s2,
 // Jaro-Winkler indices, the Jaccard index is token-based, and useful for
 // identifying similarity between phrases in which the same words appear in
 // different orders. The string s1 and s2 are broken up into tokens using
-// the given deliminator characters.
+// the given deliminator characters. The optional arguments split_s1 and
+// split_s2 are to allow searching for an exact string. E.g., if one
+// wants to find only strings containing s1="air_pressure", but allow
+// s2 to be split with '_' characters, he/she can pass split_s1=false.
 double jaccard_similarity (const std::string& s1, const std::string& s2,
-                           const std::vector<char>& delimiters);
+                           const std::vector<char>& delimiters,
+                           const bool tokenize_s1 = true,
+                           const bool tokenize_s2 = true);
 
 // ==================== Case Insensitive string =================== //
 

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <list>
 
 /*
  * A set of utilities for string manipulation
@@ -35,6 +36,13 @@ std::string strint (const std::string& s, const int i);
 
 // Conver the string to all upper case
 std::string upper_case (const std::string& s);
+
+// Split a string into tokens, according to any of the provided delimiters.
+// If atomic!="", substrings matching atomic will not be split with
+// any of the delimiters.
+std::list<std::string> gather_tokens(const std::string& s,
+                                     const std::vector<char>& delimiters,
+                                     const std::string& atomic = "");
 
 // Computing similarity index between s1 and s2 using Jaro algorithm
 // For a quick description of the Jaro similarity index, see, e.g.,

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -175,6 +175,32 @@ TEST_CASE("string","string") {
       double sj = jaccard_similarity(s1,s2,{' ', '_'});
       const double sj_ex = std::get<2>(entry);
       REQUIRE (std::abs(sj-sj_ex)<tol);
+  }
+
+  {
+    // Check similarity when not tokenizing one of the arguments
+    using entry_type = std::tuple<std::string,std::string,double,double>;
+
+    std::vector<entry_type> benchmark =
+    {
+      entry_type{ "air pressure at sea level altitude", "air pressure", 0.333, 0.2},
+      entry_type{ "pressure of water in air", "air pressure", 0.4, 0.0},
+    };
+
+    const double tol = 0.001;
+    for (const auto& entry : benchmark) {
+      // We tokenize strings using spaces and underscores.
+      const auto& s1 = std::get<0>(entry);
+      const auto& s2 = std::get<1>(entry);
+
+      double s12_tokenize = jaccard_similarity(s1,s2,{' ', '_'});
+      const double s12_tokenize_ex = std::get<2>(entry);
+
+      double s12_no_tokenize = jaccard_similarity(s1,s2,{' ', '_'},true,false);
+      const double s12_no_tokenize_ex = std::get<3>(entry);
+
+      REQUIRE (std::abs(s12_tokenize-s12_tokenize_ex)<tol);
+      REQUIRE (std::abs(s12_no_tokenize-s12_no_tokenize_ex)<tol);
     }
   }
 }

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -172,9 +172,15 @@ TEST_CASE("string","string") {
       // We tokenize strings using spaces and underscores.
       const auto& s1 = std::get<0>(entry);
       const auto& s2 = std::get<1>(entry);
-      double sj = jaccard_similarity(s1,s2,{' ', '_'});
-      const double sj_ex = std::get<2>(entry);
-      REQUIRE (std::abs(sj-sj_ex)<tol);
+      double s12 = jaccard_similarity(s1,s2,{' ', '_'});
+      double s21 = jaccard_similarity(s1,s2,{' ', '_'});
+      const double s_ex = std::get<2>(entry);
+
+      // Check against expected value
+      REQUIRE (std::abs(s12-s_ex)<tol);
+      // Check simmetry
+      REQUIRE (std::abs(s12-s21)<tol);
+    }
   }
 
   {


### PR DESCRIPTION
Allows to run the Jaccard similiarity index algorithm without tokenizing one of the two strings.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
An example where this can help: search for `air_pressure` in the list `{ "pressure_of_water_in_air", "air_pressure_at_sea_level_altitude"}`.

 With whole string matching, the latter gets a higher score (1/5=0.2) than  the first (0/5=0.0). Without whole string matching, the first gets a higher score (0.4=2/5) than the second (2/6=0.33).

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a test for the example above.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
