### PR TITLE
Bug fix to gather_tokens in ekat_string_utils.cpp

### DIFF
--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -91,29 +91,33 @@ TEST_CASE("Unmanaged", "ekat::ko") {
 TEST_CASE("string","string") {
   using namespace ekat;
 
-  CaseInsensitiveString cis1 = "field_1";
-  CaseInsensitiveString cis2 = "fIeLd_1";
-  CaseInsensitiveString cis3 = "field_2";
-  CaseInsensitiveString cis4 = "feld_1";
+  SECTION ("case_insensitive_string") {
+    CaseInsensitiveString cis1 = "field_1";
+    CaseInsensitiveString cis2 = "fIeLd_1";
+    CaseInsensitiveString cis3 = "field_2";
+    CaseInsensitiveString cis4 = "feld_1";
 
-  REQUIRE (cis1==cis2);
-  REQUIRE (cis1!=cis3);
-  REQUIRE (cis4<=cis1);
-  REQUIRE (cis4<cis1);
+    REQUIRE (cis1==cis2);
+    REQUIRE (cis1!=cis3);
+    REQUIRE (cis4<=cis1);
+    REQUIRE (cis4<cis1);
+  }
 
-  std::string my_str  = "item 1  ; item2;  item3 ";
-  std::string my_list = "item1;item2;item3";
+  SECTION ("utility_functions") {
+    std::string my_str  = "item 1  ; item2;  item3 ";
+    std::string my_list = "item1;item2;item3";
 
-  strip(my_str,' ');
-  REQUIRE(my_str==my_list);
+    strip(my_str,' ');
+    REQUIRE(my_str==my_list);
 
-  auto items = split(my_list,';');
-  REQUIRE(items.size()==3);
-  REQUIRE(items[0]=="item1");
-  REQUIRE(items[1]=="item2");
-  REQUIRE(items[2]=="item3");
+    auto items = split(my_list,';');
+    REQUIRE(items.size()==3);
+    REQUIRE(items[0]=="item1");
+    REQUIRE(items[1]=="item2");
+    REQUIRE(items[2]=="item3");
+  }
 
-  {
+  SECTION ("jaro_similarity") {
     // Jaro and Jaro-Winkler similarity tests
 
     // Benchmark list (including expected similarity values) from Winkler paper
@@ -157,8 +161,21 @@ TEST_CASE("string","string") {
     }
   }
 
+  SECTION ("gather_tokens") {
+    std::string s = "my_birthday_is coming soon";
+    std::vector<char> delims = {'_',' '};
+
+    auto no_atomic = gather_tokens(s,delims);
+    auto atomic_1  = gather_tokens(s,delims,"my_birth");
+    auto atomic_2  = gather_tokens(s,delims,"my_birthday");
+
+    REQUIRE (no_atomic.size()==5);
+    REQUIRE (atomic_1.size()==5);
+    REQUIRE (atomic_2.size()==4);
+  }
+
   // Jaccard (token-based) similarity test.
-  {
+  SECTION ("jaccard_similarity") {
     using entry_type = std::tuple<std::string,std::string,double>;
 
     std::vector<entry_type> benchmark =
@@ -181,20 +198,17 @@ TEST_CASE("string","string") {
       // Check simmetry
       REQUIRE (std::abs(s12-s21)<tol);
     }
-  }
 
-  {
     // Check similarity when not tokenizing one of the arguments
-    using entry_type = std::tuple<std::string,std::string,double,double>;
+    using entry2_type = std::tuple<std::string,std::string,double,double>;
 
-    std::vector<entry_type> benchmark =
+    std::vector<entry2_type> benchmark2 =
     {
-      entry_type{ "air pressure at sea level altitude", "air pressure", 0.333, 0.2},
-      entry_type{ "pressure of water in air", "air pressure", 0.4, 0.0},
+      entry2_type{ "air pressure at sea level altitude", "air pressure", 0.333, 0.2},
+      entry2_type{ "pressure of water in air", "air pressure", 0.4, 0.0},
     };
 
-    const double tol = 0.001;
-    for (const auto& entry : benchmark) {
+    for (const auto& entry : benchmark2) {
       // We tokenize strings using spaces and underscores.
       const auto& s1 = std::get<0>(entry);
       const auto& s2 = std::get<1>(entry);


### PR DESCRIPTION
Fixes implementation of gather_tokens for the case where an atomic substring is passed
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In the case where atomic!="" and the atomic string is found, we need to verify that it is preceded/followed by a delimiter
or the begin/end of s. Otherwise, we must proceed as if it wasn't found. E.g., when tokenizing `my_birthday_is_coming_soon` using `_` as delimiter, the atomic string `my_birth` should not yield a token. On the other hand, the atomic string `my_birthday` is a legit token.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a test for the `gather_tokens` function.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
