### PR TITLE
Added an import method to ParameterList, and added documentation

### DIFF
--- a/src/ekat/ekat_parameter_list.cpp
+++ b/src/ekat/ekat_parameter_list.cpp
@@ -26,4 +26,13 @@ void ParameterList::print(std::ostream& out, const int indent) const {
   }
 }
 
+void ParameterList::import (const ParameterList& src) {
+  for (const auto& it : src.m_sublists) {
+    m_sublists[it.first] = it.second;
+  }
+  for (const auto& it : src.m_params) {
+    m_params[it.first] = it.second;
+  }
+}
+
 } // namespace ekat

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_meta.hpp"
+#include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_type_traits.hpp"
 
 #include "ekat_test_config.h"
@@ -85,6 +86,29 @@ TEST_CASE("Unmanaged", "ekat::ko") {
                   "VUm </- CVUm");
     CVUm cv_um(v);
   }
+}
+
+TEST_CASE("parameter_list", "") {
+  using namespace ekat;
+
+  ParameterList src("src");
+  src.set<int>("i",8);
+  src.set<int>("j",10);
+  src.sublist("sl").set<double>("d",1.0);
+
+  ParameterList dst("dst");
+  dst.set<int>("i",10);
+
+  dst.import(src);
+
+  REQUIRE (dst.get<int>("i")==8);
+
+  REQUIRE (dst.isParameter("j"));
+  REQUIRE (dst.get<int>("j")==10);
+
+  REQUIRE (dst.isSublist("sl"));
+  REQUIRE (dst.sublist("sl").isParameter("d"));
+  REQUIRE (dst.sublist("sl").get<double>("d")==1.0);
 }
 
 } // empty namespace


### PR DESCRIPTION
Allow to 'merge' two parameter lists.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation

The import method allows to import data from another parameter list. The user had no way of doing it manually, since the class did not expose a way to iterate over its content.

Also, the class was almost completely lacking documentation. I added a header describing roughly what the class achieves.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a test.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
