### PR TITLE
Make pack ctor from scalar *not* explicit

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -11,6 +11,7 @@
 
 #include <Kokkos_Core.hpp>
 #include <iostream>
+#include <type_traits>
 
 namespace ekat {
 
@@ -157,7 +158,7 @@ struct Pack {
 
   // Init all slots to scalar v.
   KOKKOS_FORCEINLINE_FUNCTION
-  explicit Pack (const scalar& v) {
+  Pack (const scalar& v) {
     vector_simd for (int i = 0; i < n; ++i) d[i] = v;
   }
 


### PR DESCRIPTION
Allows to use copy-initialization for packs.
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When I tried to use Kokkos' team parallel_scan with packs as value type. Inside the its impl, Kokkos has a line
```
  value_type accum = 0;
```
which requires value_type to be copy-initializable, which means that the ctor cannot be explicit.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
No additional tests added.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
