### PR TITLE
Aarondonahue/any cast throw exception

### DIFF
--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -62,6 +62,10 @@ public:
   bool isParameter (const std::string& name) const { return m_params.find(name)!=m_params.end(); }
   bool isSublist   (const std::string& name) const { return m_sublists.find(name)!=m_sublists.end(); }
 
+  // Check methods, to determine the type of a node
+  template<typename T>
+  bool isType (const std::string& name);
+
   // Display the sublist.
   // NOTE: this *requires* op<< to be overloaded for all the stored parameters.
   //       The code won't crash otherwise, but instead of the parameter, you
@@ -111,6 +115,19 @@ inline void ParameterList::set (const std::string& name, const T& value) {
   } else {
     get<T>(name) = value;
   }
+}
+
+template<typename T>
+inline bool ParameterList::isType (const std::string& name) {
+  // Try to get variable with type T, return true if successful, false if an error is thrown
+  try {
+    auto& dummy = any_cast<T>(m_params.at(name));
+    return true;
+  }
+  catch (std::exception& e) {
+    // Do nothing with catch
+  }
+  return false;
 }
 
 } // namespace ekat

--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -64,7 +64,7 @@ public:
 
   // Check methods, to determine the type of a node
   template<typename T>
-  bool isType (const std::string& name);
+  const bool isType (const std::string& name);
 
   // Display the sublist.
   // NOTE: this *requires* op<< to be overloaded for all the stored parameters.
@@ -118,13 +118,16 @@ inline void ParameterList::set (const std::string& name, const T& value) {
 }
 
 template<typename T>
-inline bool ParameterList::isType (const std::string& name) {
+inline const bool ParameterList::isType (const std::string& name) {
+  // Check entry exists
+  EKAT_REQUIRE_MSG ( isParameter(name),
+                        "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
   // Try to get variable with type T, return true if successful, false if an error is thrown
   try {
     auto& dummy = any_cast<T>(m_params.at(name));
     return true;
   }
-  catch (std::exception& e) {
+  catch (const std::exception&) {
     // Do nothing with catch
   }
   return false;

--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -64,7 +64,7 @@ public:
 
   // Check methods, to determine the type of a node
   template<typename T>
-  const bool isType (const std::string& name);
+  bool isType (const std::string& name) const;
 
   // Display the sublist.
   // NOTE: this *requires* op<< to be overloaded for all the stored parameters.
@@ -118,7 +118,7 @@ inline void ParameterList::set (const std::string& name, const T& value) {
 }
 
 template<typename T>
-inline const bool ParameterList::isType (const std::string& name) {
+inline bool ParameterList::isType (const std::string& name) const {
   // Check entry exists
   EKAT_REQUIRE_MSG ( isParameter(name),
                         "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");

--- a/src/ekat/std_meta/ekat_std_any.hpp
+++ b/src/ekat/std_meta/ekat_std_any.hpp
@@ -132,11 +132,11 @@ ConcreteType& any_cast (any& src) {
   const auto& src_type = src.content().type();
   const auto& req_type = typeid(ConcreteType);
 
-  error::runtime_check(src_type==req_type, std::string("Error! Invalid cast requested, from '") + src_type.name() + "' to '" + req_type.name() + "'.\n", -1);
+  EKAT_REQUIRE_MSG(src_type==req_type, std::string("Error! Invalid cast requested, from '") + src_type.name() + "' to '" + req_type.name() + "'.\n");
 
   any::holder<ConcreteType>* ptr = dynamic_cast<any::holder<ConcreteType>*>(src.content_ptr());
 
-  error::runtime_check(ptr!=nullptr, "Error! Failed dynamic_cast during any_cast. This is an internal problem, please, contact developers.\n", -1);
+  EKAT_REQUIRE_MSG(ptr!=nullptr, "Error! Failed dynamic_cast during any_cast. This is an internal problem, please, contact developers.\n");
 
   return ptr->value();
 }
@@ -146,11 +146,11 @@ const ConcreteType& any_cast (const any& src) {
   const auto& src_type = src.content().type();
   const auto& req_type = typeid(ConcreteType);
 
-  error::runtime_check(src_type==req_type, std::string("Error! Invalid cast requested, from '") + src_type.name() + "' to '" + req_type.name() + "'.\n", -1);
+  EKAT_REQUIRE_MSG(src_type==req_type, std::string("Error! Invalid cast requested, from '") + src_type.name() + "' to '" + req_type.name() + "'.\n");
 
   any::holder<ConcreteType>* ptr = dynamic_cast<any::holder<ConcreteType>*>(src.content_ptr());
 
-  error::runtime_check(ptr!=nullptr, "Error! Failed dynamic_cast during any_cast. This is an internal problem, please, contact developers.\n", -1);
+  EKAT_REQUIRE_MSG(ptr!=nullptr, "Error! Failed dynamic_cast during any_cast. This is an internal problem, please, contact developers.\n");
 
   return ptr->value();
 }

--- a/tests/io/yaml_parser.cpp
+++ b/tests/io/yaml_parser.cpp
@@ -49,6 +49,7 @@ TEST_CASE ("yaml_parser","") {
   REQUIRE (!options.isType<bool>("My Real"));
   REQUIRE (!options.isType<int>("My Real"));
   REQUIRE (!options.isType<std::string>("My Real"));
+  REQUIRE_THROWS(options.isType<double>("I am not in the list"));
 
 }
 

--- a/tests/io/yaml_parser.cpp
+++ b/tests/io/yaml_parser.cpp
@@ -41,6 +41,15 @@ TEST_CASE ("yaml_parser","") {
   REQUIRE (constants.isSublist("Nested Sublist"));
   auto& sl = constants.sublist("Nested Sublist");
   REQUIRE (sl.get<int>("The Answer") == 42);
+
+  REQUIRE (options.isType<bool>("My Bool"));
+  REQUIRE (options.isType<int>("My Int"));
+  REQUIRE (options.isType<std::string>("My String"));
+  REQUIRE (options.isType<double>("My Real"));
+  REQUIRE (!options.isType<bool>("My Real"));
+  REQUIRE (!options.isType<int>("My Real"));
+  REQUIRE (!options.isType<std::string>("My Real"));
+
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This PR introduces the function `isType` to the YAML parameter list parser.

`isType` is a templated function that allows the user to check if a parameter in a parameter list is
of a specific type.  This is particularly useful in cases where a YAML node may have the option to be
of multiple types. 

## Motivation
Allows a node in a YAML file to be given different types of entries, providing flexibility for applications.

## E3SM Stakeholder Feedback
Addresses SCREAM issue: https://github.com/E3SM-Project/scream/issues/975

## Testing
This new function is tested in the `yaml_parser` test.

