### PR TITLE
Removed warning from ParameterList method

### DIFF
--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -86,16 +86,16 @@ private:
 template<typename T>
 inline T& ParameterList::get (const std::string& name) {
   // Check entry exists
-  error::runtime_check ( isParameter(name),
-                        "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
+  EKAT_REQUIRE_MSG ( isParameter(name),
+      "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
 
   return any_cast<T>(m_params[name]);
 }
 
 template<typename T>
 inline const T& ParameterList::get (const std::string& name) const {
-  error::runtime_check ( isParameter(name),
-                        "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
+  EKAT_REQUIRE_MSG ( isParameter(name),
+      "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
 
   return any_cast<T>(m_params.at(name));
 }
@@ -121,16 +121,9 @@ template<typename T>
 inline bool ParameterList::isType (const std::string& name) const {
   // Check entry exists
   EKAT_REQUIRE_MSG ( isParameter(name),
-                        "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
-  // Try to get variable with type T, return true if successful, false if an error is thrown
-  try {
-    auto& dummy = any_cast<T>(m_params.at(name));
-    return true;
-  }
-  catch (const std::exception&) {
-    // Do nothing with catch
-  }
-  return false;
+      "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
+
+  return m_params.at(name).isType<T>();
 }
 
 } // namespace ekat


### PR DESCRIPTION
Also, reworked impl details in ekat::any.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
There was a warning in the impl of `bool ParameterList::isType<T>()` due to unused var. While removing it, I improved a bit the function, by improving `any`'s interface, so that `ParameterList` doesn't need a try-catch block for the impl of `isType`.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Covered by same testing as before.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
