### PR TITLE
Minor change to remove unused warning

### DIFF
--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -125,6 +125,7 @@ inline bool ParameterList::isType (const std::string& name) const {
   // Try to get variable with type T, return true if successful, false if an error is thrown
   try {
     auto& dummy = any_cast<T>(m_params.at(name));
+    (void)dummy;
     return true;
   }
   catch (const std::exception&) {


### PR DESCRIPTION
Trick compiler into thinking variable is used.

## Motivation
Fewer warnings when building SCREAM.


## Testing
None
