### PR TITLE
add Workspace::reserve_n_contiguous_sub_blocks

### DIFF
--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -142,7 +142,7 @@ class WorkspaceManager
     //                                                     n, m_sizes);
     template <typename S=T>
     KOKKOS_INLINE_FUNCTION
-    Unmanaged<view_1d<S> > take_n_size_block(const char* name, const int n) const;
+    Unmanaged<view_1d<S> > take_n_size_block(const char* name, const int n_sub_blocks) const;
 
     // Combines reset and take_many_contiguous_unsafe. This is the most-performant
     // option for a kernel to use N sub-blocks that are needed for the duration of the

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -166,7 +166,7 @@ class WorkspaceManager
     // Release block of size n*m_size.
     template <typename S=T>
     KOKKOS_INLINE_FUNCTION
-    void release_n_size_block(const Unmanaged<view_1d<S> >& space, const int n) const;
+    void release_n_size_block(const Unmanaged<view_1d<S> >& space, const int n_sub_blocks) const;
 
 #ifndef NDEBUG
     // Get the name of a sub-block

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -131,9 +131,10 @@ class WorkspaceManager
     void take_many_contiguous_unsafe(const Kokkos::Array<const char*, N>& names,
                                      const view_1d_ptr_array<S, N>& ptrs) const;
 
-    // Take a block of size n*m_size, where m_size is the size used to construct
-    // the WorkspaceManager. This is useful for creating local 2d views through
-    // the WorkspaceManager.
+    // Take an individual sub-block while telling the WorkSpaceManager to skip over the
+    // next n_sub_blocks-1 sub-blocks. This allows the user to safely access the memory
+    // of these sub-block, which is useful for creating local 2d views through the
+    // WorkspaceManager.
     //
     // Example: Local 2d view of size (n, m_size).
     // Code:
@@ -166,7 +167,7 @@ class WorkspaceManager
     // Release block of size n*m_size.
     template <typename S=T>
     KOKKOS_INLINE_FUNCTION
-    void release_n_size_block(const Unmanaged<view_1d<S> >& space, const int n_sub_blocks) const;
+    void release_macro_block(const Unmanaged<view_1d<S> >& space, const int n_sub_blocks) const;
 
 #ifndef NDEBUG
     // Get the name of a sub-block
@@ -267,10 +268,6 @@ class WorkspaceManager
   template <typename S=T>
   KOKKOS_FORCEINLINE_FUNCTION
   Unmanaged<view_1d<S> > get_space_in_slot(const int team_idx, const int slot) const;
-
-  template <typename S=T>
-  KOKKOS_FORCEINLINE_FUNCTION
-  Unmanaged<view_1d<S> > get_n_spaces_in_slot(const int team_idx, const int slot, const int n) const;
 
   KOKKOS_INLINE_FUNCTION
   void init_metadata(const int ws_idx, const int slot) const;

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -142,7 +142,7 @@ class WorkspaceManager
     //                                                     n, m_sizes);
     template <typename S=T>
     KOKKOS_INLINE_FUNCTION
-    Unmanaged<view_1d<S> > take_n_size_block(const char* name, const int n_sub_blocks) const;
+    Unmanaged<view_1d<S> > take_macro_block(const char* name, const int n_sub_blocks) const;
 
     // Combines reset and take_many_contiguous_unsafe. This is the most-performant
     // option for a kernel to use N sub-blocks that are needed for the duration of the

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -273,6 +273,7 @@ WorkspaceManager<T, D>::Workspace::take_n_size_block(
   for (int n = 0; n < n_sub_blocks; ++n) {
     const auto space = m_parent.get_space_in_slot<S>(m_ws_idx, m_next_slot + n);
     EKAT_KERNEL_ASSERT(m_parent.get_next<S>(space) == m_next_slot + n + 1);
+    m_team.team_barrier();
   }
 #endif
 
@@ -559,6 +560,7 @@ void WorkspaceManager<T, D>::Workspace::release_n_size_block(
   });
 
   // Reset metadata
+  m_team.team_barrier();
   Kokkos::parallel_for(
     Kokkos::TeamThreadRange(m_team, n_sub_blocks), [&] (int i) {
       m_parent.init_metadata(m_ws_idx, i+m_next_slot);

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -152,6 +152,7 @@ WorkspaceManager<T, D>::get_space_in_slot(const int team_idx, const int slot) co
   return space;
 }
 
+// Like get_space_in_slot, but returns n contiguous spaces
 template <typename T, typename D>
 template <typename S>
 KOKKOS_FORCEINLINE_FUNCTION
@@ -264,7 +265,7 @@ template <typename T, typename D>
 template <typename S>
 KOKKOS_INLINE_FUNCTION
 Unmanaged<typename WorkspaceManager<T, D>::template view_1d<S> >
-WorkspaceManager<T, D>::Workspace::take_n_size_block(
+WorkspaceManager<T, D>::Workspace::take_macro_block(
   const char* name, const int n_sub_blocks) const
 {
 #ifndef NDEBUG

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -214,7 +214,7 @@ void WorkspaceManager<T, D>::Workspace::take_many_contiguous_unsafe(
 #ifndef NDEBUG
   change_num_used(N);
   // Verify contiguous
-  for (int n = 0; n < static_cast<int>(N); ++n) {
+  for (int n = 0; n < static_cast<int>(N) - 1; ++n) {
     const auto space = m_parent.get_space_in_slot<S>(m_ws_idx, m_next_slot + n);
     EKAT_KERNEL_ASSERT(m_parent.get_next<S>(space) == m_next_slot + n + 1);
   }
@@ -251,7 +251,7 @@ WorkspaceManager<T, D>::Workspace::take_macro_block(
 #ifndef NDEBUG
   change_num_used(n_sub_blocks);
   // Verify contiguous
-  for (int n = 0; n < n_sub_blocks; ++n) {
+  for (int n = 0; n < n_sub_blocks - 1; ++n) {
     const auto space = m_parent.get_space_in_slot<S>(m_ws_idx, m_next_slot + n);
     EKAT_KERNEL_ASSERT(m_parent.get_next<S>(space) == m_next_slot + n + 1);
   }

--- a/tests/kokkos/workspace_tests.cpp
+++ b/tests/kokkos/workspace_tests.cpp
@@ -152,8 +152,9 @@ static void unittest_workspace()
     team.team_barrier();
 
     Kokkos::Array<Unmanaged<view_1d<int> >, num_ws> wssub;
-    Unmanaged<view_2d<int> wsmacro;
-    const auto space = ws.take_macro_block("space", num_ws);
+
+    Unmanaged<view_1d<int>> wsmacro1d;
+    Unmanaged<view_2d<int>> wsmacro2d;
 
     // Main test. Test different means of taking and release spaces.
     for (int r = 0; r < 10; ++r) {
@@ -165,8 +166,9 @@ static void unittest_workspace()
         }
       }
       else if (r % 5 == 1) {
-        wsmacro = Unmanaged<view_2d<int> (reinterpret_cast<int*>(space.data()),
-                                          num_ws,ints_per_ws);
+        wsmacro1d = ws.take_macro_block("wsmacro1d", num_ws);
+        wsmacro2d = Unmanaged<view_2d<int>> (reinterpret_cast<int*>(wsmacro1d.data()),
+                                             num_ws,ints_per_ws);
       }
       else {
         Unmanaged<view_1d<int> > ws1, ws2, ws3, ws4;
@@ -190,7 +192,7 @@ static void unittest_workspace()
       for (int w = 0; w < num_ws; ++w) {
         Kokkos::parallel_for(Kokkos::TeamThreadRange(team, ints_per_ws), [&] (Int i) {
           if (r % 5 == 1) {
-            wsmacro(w,i) = i * w;
+            wsmacro2d(w,i) = i * w;
           } else {
             wssub[w](i) = i * w;
           }
@@ -227,7 +229,7 @@ static void unittest_workspace()
         ws.reset();
       }
       else if (r % 5 == 1) {
-        ws.release_macro_block(space,num_ws);
+        ws.release_macro_block(wsmacro1d,num_ws);
       }
       else if (r % 5 == 2) {
         Kokkos::Array<Unmanaged<view_1d<int> >*, num_ws> ptrs = { {&wssub[0], &wssub[1], &wssub[2], &wssub[3]} };


### PR DESCRIPTION
Adds a function `Workspace::reserve_n_contiguous_sub_blocks()` which can reserve a certain number of sub-blocks defined at runtime.

## Motivation
The other contiguous function does not allow for variable size.

## Testing
Still need to add a test..
