### PR TITLE
Yet another overload of pack's op= with volatile cv

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -136,21 +136,26 @@ Mask<n> operator ! (const Mask<n>& m) {
 //   warning: implicit dereference will not access object of type ‘volatile ekat::Pack<...>' in statement 
 //       *dest = return_val + val;
 //       ^
-#define ekat_pack_gen_assign_op_p(op)                   \
-  KOKKOS_FORCEINLINE_FUNCTION                             \
-  Pack& operator op (const Pack& a) {                     \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i]; \
-    return *this;                                         \
-  }                                                       \
-  KOKKOS_FORCEINLINE_FUNCTION                             \
-  void operator op (const Pack& a) volatile {   \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i]; \
+#define ekat_pack_gen_assign_op_p(op)                       \
+  KOKKOS_FORCEINLINE_FUNCTION                               \
+  Pack& operator op (const volatile Pack& a) {              \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
+    return *this;                                           \
+  }                                                         \
+  KOKKOS_FORCEINLINE_FUNCTION                               \
+  Pack& operator op (const Pack& a) {                       \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i];   \
+    return *this;                                           \
+  }                                                         \
+  KOKKOS_FORCEINLINE_FUNCTION                               \
+  void operator op (const Pack& a) volatile {               \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i];   \
   }
-#define ekat_pack_gen_assign_op_s(op)                 \
-  KOKKOS_FORCEINLINE_FUNCTION                           \
-  Pack& operator op (const scalar& a) {                 \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a;  \
-    return *this;                                       \
+#define ekat_pack_gen_assign_op_s(op)                       \
+  KOKKOS_FORCEINLINE_FUNCTION                               \
+  Pack& operator op (const scalar& a) {                     \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a;      \
+    return *this;                                           \
   }
 #define ekat_pack_gen_assign_op_all(op)       \
   ekat_pack_gen_assign_op_p(op)               \


### PR DESCRIPTION
This one assumes the src object to be volatile.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In scream, we were getting some errors claiming no overload of `Pack::operator=(volatile Pack)` was found.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
No additional testing. But I verified that this PR fixes the compilation error in scream.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
