### PR TITLE
add WSM constructor

### DIFF
--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -101,8 +101,8 @@ class WorkspaceManager
   // set of constructor inputs. Note, this does not actually create an instance of the WSM,
   // but is useful for when memory needs to be reserved in a different scope than the
   // WSM is created.
-  static size_t get_total_slots_to_be_used(int size, int max_used, TeamPolicy policy,
-                                           const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
+  static int get_total_bytes_needed(int size, int max_used, TeamPolicy policy,
+                                    const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
 
   // call from host.
   //

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -266,9 +266,6 @@ class WorkspaceManager
  private:
 #endif
 
-  // Initialize int and view-type class variables.
-  void initialize_variables(const int size, const int max_used);
-
   friend struct unit_test::UnitWrap;
 
   template <typename S=T>
@@ -292,7 +289,9 @@ class WorkspaceManager
   KOKKOS_INLINE_FUNCTION
   void init_metadata(const int ws_idx, const int slot) const;
 
-  static void init(const WorkspaceManager& wm, const int max_ws_idx, const int max_used);
+  void init(const int max_ws_idx, const int max_used);
+
+  void compute_internals(const int size, const int max_used);
 
   //
   // data

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -287,9 +287,9 @@ class WorkspaceManager
   Unmanaged<view_1d<S> > get_space_in_slot(const int team_idx, const int slot) const;
 
   KOKKOS_INLINE_FUNCTION
-  void init_metadata(const int ws_idx, const int slot) const;
+  void init_slot_metadata(const int ws_idx, const int slot) const;
 
-  void init(const int max_ws_idx, const int max_used);
+  void init_all_metadata(const int max_ws_idx, const int max_used);
 
   void compute_internals(const int size, const int max_used);
 

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -87,6 +87,23 @@ class WorkspaceManager
   WorkspaceManager(int size, int max_used, TeamPolicy policy,
                    const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
 
+  // Constructor, call from host
+  //   Same as above, but here the user initializes the data.
+  //   This is useful when the user wants to pre-reserve the data
+  //   for the WorkspaceManager. The user is responsible for
+  //   ensuring that m_max_ws_idx*m_total*m_max_used contiguous
+  //   data is available, for which the get_total_slots_to_be_used()
+  //   function can be helpful.
+  WorkspaceManager(T* data, int size, int max_used, TeamPolicy policy,
+                   const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
+
+  // Helper functions which return the number of slots that will be reserved for a given
+  // set of constructor inputs. Note, this does not actually create an instance of the WSM,
+  // but is useful for when memory needs to be reserved in a different scope than the
+  // WSM is created.
+  static size_t get_total_slots_to_be_used(int size, int max_used, TeamPolicy policy,
+                                           const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
+
   // call from host.
   //
   // Will report usage statistics for your workspaces. These statistics will

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -97,7 +97,7 @@ class WorkspaceManager
   WorkspaceManager(T* data, int size, int max_used, TeamPolicy policy,
                    const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
 
-  // Helper functions which return the number of slots that will be reserved for a given
+  // Helper functions which return the number of bytes that will be reserved for a given
   // set of constructor inputs. Note, this does not actually create an instance of the WSM,
   // but is useful for when memory needs to be reserved in a different scope than the
   // WSM is created.
@@ -265,6 +265,9 @@ class WorkspaceManager
 #ifndef KOKKOS_ENABLE_CUDA
  private:
 #endif
+
+  // Initialize int and view-type class variables.
+  void initialize_variables(const int size, const int max_used);
 
   friend struct unit_test::UnitWrap;
 

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -38,6 +38,41 @@ WorkspaceManager<T, D>::WorkspaceManager(int size, int max_used, TeamPolicy poli
 }
 
 template <typename T, typename D>
+WorkspaceManager<T, D>::WorkspaceManager(T* data, int size, int max_used,
+                                         TeamPolicy policy, const double& overprov_factor) :
+  m_tu(policy, overprov_factor),
+  m_max_ws_idx(m_tu.get_num_ws_slots()),
+  m_reserve( (sizeof(T) > 2*sizeof(int)) ? 1 :
+             (2*sizeof(int) + sizeof(T) - 1)/sizeof(T) ),
+  m_size(size),
+  m_total(m_size + m_reserve),
+  m_max_used(max_used),
+#ifndef NDEBUG
+  m_num_used("Workspace.m_num_used", m_max_ws_idx),
+  m_high_water("Workspace.m_high_water", m_max_ws_idx),
+  m_active("Workspace.m_active", m_max_ws_idx, m_max_used),
+  m_curr_names("Workspace.m_curr_names", m_max_ws_idx, m_max_used, m_max_name_len),
+  m_all_names("Workspace.m_all_names", m_max_ws_idx, m_max_names, m_max_name_len),
+  // A name's index in m_all_names is used to index into m_counts
+  m_counts("Workspace.m_counts", m_max_ws_idx, m_max_names, 2),
+#endif
+  m_next_slot("Workspace.m_next_slot", m_pad_factor*m_max_ws_idx),
+  m_data(data, m_max_ws_idx, m_total * m_max_used)
+{
+  init(*this, m_max_ws_idx, m_max_used);
+}
+
+template <typename T, typename D>
+size_t WorkspaceManager<T, D>::get_total_slots_to_be_used(int size, int max_used, TeamPolicy policy,
+                                                          const double& overprov_factor)
+{
+  TeamUtils<T,ExeSpace> tu(policy, overprov_factor);
+  const int reserve = (sizeof(T) > 2*sizeof(int)) ? 1 : (2*sizeof(int) + sizeof(T) - 1)/sizeof(T);
+  const int total = size + reserve;
+  return tu.get_num_ws_slots()*total*max_used;
+}
+
+template <typename T, typename D>
 void WorkspaceManager<T, D>::report() const
 {
 #ifndef NDEBUG

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -63,13 +63,13 @@ WorkspaceManager<T, D>::WorkspaceManager(T* data, int size, int max_used,
 }
 
 template <typename T, typename D>
-size_t WorkspaceManager<T, D>::get_total_slots_to_be_used(int size, int max_used, TeamPolicy policy,
-                                                          const double& overprov_factor)
+int WorkspaceManager<T, D>::get_total_bytes_needed(int size, int max_used, TeamPolicy policy,
+                                                   const double& overprov_factor)
 {
   TeamUtils<T,ExeSpace> tu(policy, overprov_factor);
-  const int reserve = (sizeof(T) > 2*sizeof(int)) ? 1 : (2*sizeof(int) + sizeof(T) - 1)/sizeof(T);
-  const int total = size + reserve;
-  return tu.get_num_ws_slots()*total*max_used;
+  const int reserve_slots = (sizeof(T) > 2*sizeof(int)) ? 1 : (2*sizeof(int) + sizeof(T) - 1)/sizeof(T);
+  const int total_slots = size + reserve_slots;
+  return tu.get_num_ws_slots()*total_slots*max_used*sizeof(T);
 }
 
 template <typename T, typename D>


### PR DESCRIPTION
Adds a new WSM constructor which takes in data pointer. This allows the user to per-reserve the memory used by the WSM. I also created a new function called `get_total_slots_to_be_used()` to calculate the total number of slots the WSM will require for a given set of constructor inputs, which will allow the creation of the WSM in a different scope than where the memory is reserved.

## Motivation
Memory for WSM needs to be reserved in SCREAM-AD in a different scope than the WSM is constructed. To see an example of this being used: https://github.com/E3SM-Project/scream/pull/1048

## Testing
Added a test for the new constructor and `get_total_slots_to_be_used()` function. Test asserts that data accessed in the WSM does not exceed the bounds of the view data it is constructed with.
