### PR TITLE
Add yet another volatile overload for Pack's assigment op

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -149,7 +149,11 @@ Mask<n> operator ! (const Mask<n>& m) {
   }                                                         \
   KOKKOS_FORCEINLINE_FUNCTION                               \
   void operator op (const Pack& a) volatile {               \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i];   \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
+  }                                                         \
+  KOKKOS_FORCEINLINE_FUNCTION                               \
+  void operator op (const volatile Pack& a) volatile {      \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
   }
 #define ekat_pack_gen_assign_op_s(op)                       \
   KOKKOS_FORCEINLINE_FUNCTION                               \


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
E3SM-Project/SCREAM#1019 has exposed the need for another volatile overload for Pack's assigment ops (this time for both lhs and rhs volatile).

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
SCREAM needs it.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
No additional testing, but the aforementioned PR builds once this modification is introduced.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
