### PR TITLE
changed Pack copy ctor to allow different scalar types for mixed-precision

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -218,7 +218,7 @@ struct Pack {
     }
   }
 
-  // Init this Pack form two scalars, according to a given mask:
+  // Init this Pack from two scalars, according to a given mask:
   // if mask is true, set first value, otherwise the other.
   template <typename T, typename S>
   KOKKOS_FORCEINLINE_FUNCTION

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -133,7 +133,7 @@ Mask<n> operator ! (const Mask<n>& m) {
 // input is a Pack; _s means the input is a scalar.
 // NOTE: for volatile overload, you should return void. If not, if/when Kokkos
 //       atomic ops are compiled for Pack, you will see a compiler warning like
-//   warning: implicit dereference will not access object of type ‘volatile ekat::Pack<...>' in statement 
+//   warning: implicit dereference will not access object of type ‘volatile ekat::Pack<...>' in statement
 //       *dest = return_val + val;
 //       ^
 #define ekat_pack_gen_assign_op_p(op)                       \
@@ -190,13 +190,6 @@ struct Pack {
   }
 
   // Init this Pack from another one.
-  template <typename T>
-  KOKKOS_FORCEINLINE_FUNCTION explicit
-  Pack (const Pack<T,n>& v) {
-    vector_simd for (int i = 0; i < n; ++i) d[i] = v[i];
-  }
-
-  // Init this Pack from another one.
   KOKKOS_FORCEINLINE_FUNCTION
   Pack (const Pack& src) {
     vector_simd for (int i = 0; i < n; ++i) d[i] = src[i];
@@ -206,6 +199,13 @@ struct Pack {
   KOKKOS_FORCEINLINE_FUNCTION
   Pack (const volatile Pack& src) {
     vector_simd for (int i = 0; i < n; ++i) d[i] = src.d[i];
+  }
+
+  // Init this Pack from another one with possibly different scalar_type (for mixed precision)
+  template <typename S2>
+  KOKKOS_FORCEINLINE_FUNCTION explicit
+  Pack (const Pack<S2,n>& v) {
+    vector_simd for (int i=0; i<n; ++i) d[i] = ScalarType(v[i]);
   }
 
   // Init this Pack from a scalar, but only where Mask is true; otherwise
@@ -218,7 +218,7 @@ struct Pack {
     }
   }
 
-  // Init this Pack from two scalars, according to a given mask:
+  // Init this Pack form two scalars, according to a given mask:
   // if mask is true, set first value, otherwise the other.
   template <typename T, typename S>
   KOKKOS_FORCEINLINE_FUNCTION

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -203,8 +203,8 @@ struct TestPack {
     const ekat::Pack<float, PACKN> ftwos(twos);
 
     vector_novec for (int i=0; i<PACKN; ++i) {
-      REQUIRE( std::abs(dones[i] - 1.0) < 1e-7 );
-      REQUIRE( std::abs(ftwos[i] - 2.0) < 1e-13 );
+      REQUIRE( std::abs(dones[i] - 1.0) < 1e-13 );
+      REQUIRE( std::abs(ftwos[i] - 2.0) < 1e-7 );
     }
   }
 

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -157,7 +157,7 @@ struct TestPack {
     Pack p_ref;
 
     // Make p_ref = [1 3 1 3 ... ]
-    vector_novec 
+    vector_novec
     for (int i = 0; i < PACKN; ++i) {
       p_ref[i] = 3-2*(i%2);
     }
@@ -195,11 +195,24 @@ struct TestPack {
     }
   }
 
+  static void test_mixed_prec () {
+    const ekat::Pack<float, PACKN> ones(1.0);
+    const ekat::Pack<double, PACKN> twos(2.0);
+
+    const ekat::Pack<double, PACKN> dones(ones);
+    const ekat::Pack<float, PACKN> ftwos(twos);
+
+    vector_novec for (int i=0; i<PACKN; ++i) {
+      REQUIRE( std::abs(dones[i] - 1.0) < 1e-7 );
+      REQUIRE( std::abs(ftwos[i] - 2.0) < 1e-7 );
+    }
+  }
+
   static void test_masked_set () {
     Pack p_ref;
 
     // Make p_ref = [1 3 1 3 ... ]
-    vector_novec 
+    vector_novec
     for (int i = 0; i < PACKN; ++i) {
       p_ref[i] = 3-2*(i%2);
     }
@@ -393,6 +406,7 @@ struct TestPack {
     test_ostream();
     test_masked_ctor();
     test_masked_set();
+    test_mixed_prec();
 
     test_reduce_sum<true>();
     test_reduce_sum<false>();
@@ -503,5 +517,7 @@ TEST_CASE("isnan", "ekat::pack") {
     REQUIRE (mn[i]);  // the view 'nan'  should contain nans
   }
 }
+
+
 
 } // namespace

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -204,7 +204,7 @@ struct TestPack {
 
     vector_novec for (int i=0; i<PACKN; ++i) {
       REQUIRE( std::abs(dones[i] - 1.0) < 1e-7 );
-      REQUIRE( std::abs(ftwos[i] - 2.0) < 1e-7 );
+      REQUIRE( std::abs(ftwos[i] - 2.0) < 1e-13 );
     }
   }
 


### PR DESCRIPTION
This PR changes the `ekat::Pack` copy constructor to allow copying between packs of the same size, but different scalar types.  It adds a test that copies between packs of `double` and packs of `float` type.

## Motivation

Some ill-conditioned algorithms require double precision arithemetic.  This PR allows client codes that are configured for single precision to convert to double precision upon entry to such an algorithm, perform the computations in double precision, then convert pack to single precision to return.

## Related Issues

Closes #111

## Testing

Added an associated test function to the pack unit tests.

