### PR TITLE
Add MemoryTraits to template signature of view aliases

### DIFF
--- a/src/ekat/kokkos/ekat_kokkos_types.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_types.hpp
@@ -4,6 +4,7 @@
 #include "ekat/ekat_config.h"
 #include "ekat/kokkos/ekat_kokkos_meta.hpp"
 #include "ekat/std_meta/ekat_std_type_traits.hpp"
+#include <Kokkos_MemoryTraits.hpp>
 
 /*
  * Header contains globally useful kokkos-related types for ekat.
@@ -43,39 +44,39 @@ struct KokkosTypes
   template<typename TagType>
   using TeamTagPolicy = Kokkos::TeamPolicy<ExeSpace,TagType>;
 
-  template <typename DataType>
-  using view = Kokkos::View<DataType, Layout, Device>;
+  template <typename DataType, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view = Kokkos::View<DataType, Layout, Device, MemoryTraits>;
 
   // left-layout views, may be useful for interacting with fortran
-  template <typename DataType>
-  using lview = Kokkos::View<DataType, Kokkos::LayoutLeft, Device>;
+  template <typename DataType, typename MemoryTraits = Kokkos::MemoryManaged>
+  using lview = Kokkos::View<DataType, Kokkos::LayoutLeft, Device, MemoryTraits>;
 
   // A N-dim view given scalar type and N
-  template<typename Scalar, int N>
-  using view_ND = view<typename DataND<Scalar,N>::type>;
+  template<typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_ND = view<typename DataND<Scalar,N>::type,MemoryTraits>;
 
   // More verbose cases for N=1,2,3
-  template <typename Scalar>
-  using view_1d = view<Scalar*>;
+  template <typename Scalar, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_1d = view<Scalar*,MemoryTraits>;
 
-  template <typename Scalar>
-  using view_2d = view<Scalar**>;
+  template <typename Scalar, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_2d = view<Scalar**,MemoryTraits>;
 
-  template <typename Scalar>
-  using view_3d = view<Scalar***>;
+  template <typename Scalar, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_3d = view<Scalar***,MemoryTraits>;
 
-  template <typename Scalar, int X>
-  using view_1d_table = view<const Scalar[X]>;
+  template <typename Scalar, int X, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_1d_table = view<const Scalar[X],MemoryTraits>;
 
-  template <typename Scalar, int X, int Y>
-  using view_2d_table = view<const Scalar[X][Y]>;
+  template <typename Scalar, int X, int Y, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_2d_table = view<const Scalar[X][Y],MemoryTraits>;
 
   // Our workspace implementation makes this a useful type
-  template <typename Scalar, int N>
-  using view_1d_ptr_array = Kokkos::Array<Unmanaged<view_1d<Scalar> >*, N>;
+  template <typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_1d_ptr_array = Kokkos::Array<Unmanaged<view_1d<Scalar,MemoryTraits> >*, N>;
 
-  template <typename Scalar, int N>
-  using view_1d_ptr_carray = Kokkos::Array<const Unmanaged<view_1d<Scalar> >*, N>;
+  template <typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryManaged>
+  using view_1d_ptr_carray = Kokkos::Array<const Unmanaged<view_1d<Scalar,MemoryTraits> >*, N>;
 };
 
 } // namespace ekat


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
If you don't specify MemoryTraits in a view template signature, the resulting type is different (and therefore incompatible) with a type that has it declared. E.g., with
```
using V1 = Kokkos::View<int*,Kokkos::MemoryManaged>;
using V2 = Kokkos::View<int*>;
```
an object of type V2 cannot be bound to a reference V2&. This makes writing functions that take in, say, view_1d<Real>, more complicated. E.g., the two functions
```
void f1 (const view_1d<Real>& v);
void f2 (const ekat::Unmanaged<view_1d<Real>>& v);
```
will both fail to compile if passed either a V2 or V1 respectively. Adding MemoryTraits to the templated signature of view_1d makes things easier:

```
template<typename MT>
void f1 (const view_1d<Real,MT>& v);

view_2d<Real> a("",10,10
view_1d<Real> b("",10);
auto c = subivew(a,0); // this view has MemoryTraits=Kokkos::MemoryUnmanaged

f1(b); // works
f1(c); // works
```

NOTE: of course, in order to keep things simple, and not to break existing code, the MemoryTraits argument of views aliases in KokkosTypes is defaulted to Kokkos::MemoryManaged (which is what kokkos still picks under the hood if no memory traits are specified).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in SCREAM.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
All current tests pass. Views with non-defaulted MemoryTraits working (tested in scream).
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
