### PR TITLE
Add utility for team policy creation

### DIFF
--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -221,6 +221,10 @@ struct ExeSpaceUtils {
     return TeamPolicy(ni, team_size);
   }
 
+  static TeamPolicy get_thread_range_parallel_scan_team_policy (Int league_size, Int team_size_request) {
+    return get_default_team_policy(league_size, team_size_request);
+  }
+
   // NOTE: f<bool,T> and f<T,bool> are *guaranteed* to be different overloads.
   //       The latter is better when bool needs a default, the former is
   //       better when bool must be specified, but we want T to be deduced.
@@ -284,12 +288,30 @@ template <>
 struct ExeSpaceUtils<Kokkos::Cuda> {
   using TeamPolicy = Kokkos::TeamPolicy<Kokkos::Cuda>;
 
+  static int num_warps (const int i) {
+    return (i+31)/32;
+  }
+
   static TeamPolicy get_default_team_policy (Int ni, Int nk) {
     return TeamPolicy(ni, std::min(128, 32*((nk + 31)/32)));
   }
 
   static TeamPolicy get_team_policy_force_team_size (Int ni, Int team_size) {
     return TeamPolicy(ni, team_size);
+  }
+
+  // On GPU, the team-level ||scan in column_ops only works for team sizes that are a power of 2.
+  static TeamPolicy get_thread_range_parallel_scan_team_policy (Int league_size, Int team_size_request) {
+    auto prev_pow_2 = [](const int i) -> int {
+      // Multiply by 2 until pp2>i, then divide by 2 once.
+      int pp2 = 1;
+      while (pp2<=i) pp2 *= 2;
+      return pp2/2;
+    };
+
+    const int pp2 = prev_pow_2(team_size_request);
+    const int team_size = 32*num_warps(pp2);
+    return TeamPolicy(league_size, std::min(128, team_size));
   }
 
   // NOTE: f<bool,T> and f<T,bool> are *guaranteed* to be different overloads.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When doing a thread-range level parallel scan, on CPU, any team policy works, but on GPU the team size must be a power of 2. Instead of having the user do the math (on top of checking what the execution space is), we provide a utility function that does the work, leaving the host app code more readable.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed by scream.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
These changes fix scream testing.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
