### PR TITLE
Enable kokkos bounds checking by default if DEBUG is enabled

### DIFF
--- a/cmake/pkg_build/EkatBuildKokkos.cmake
+++ b/cmake/pkg_build/EkatBuildKokkos.cmake
@@ -49,9 +49,11 @@ macro(BuildKokkos)
 
     # Enable Kokkos debug if the host project is in debug mode.
     if (CMAKE_BUILD_TYPE_ci STREQUAL "debug")
-      set(Kokkos_ENABLE_DEBUG TRUE  CACHE BOOL "Enable Kokkos Debug")
+      set(Kokkos_ENABLE_DEBUG              TRUE CACHE BOOL "Enable Kokkos Debug")
+      set(Kokkos_ENABLE_DEBUG_BOUNDS_CHECK TRUE CACHE BOOL "Enable Kokkos Debug bounds checking")
     else()
-      set(Kokkos_ENABLE_DEBUG FALSE CACHE BOOL "Enable Kokkos Debug")
+      set(Kokkos_ENABLE_DEBUG              FALSE CACHE BOOL "Enable Kokkos Debug")
+      set(Kokkos_ENABLE_DEBUG_BOUNDS_CHECK FALSE CACHE BOOL "Enable Kokkos Debug bounds checking")
     endif()
 
     add_subdirectory(${Kokkos_SOURCE_DIR} ${Kokkos_BINARY_DIR})


### PR DESCRIPTION
I think enabling KOKKOS_DEBUG used to turn on bounds checking, but
that is no longer the case. I believe most, if not all, EKAT clients
will want bounds checking on Kokkos views in DEBUG mode, so I think it's
reasonable to turn this on by default if the CMake build type is DEBUG.

The SCREAM project relies on EKAT to configure Kokkos and out-of-bounds errors
have slipped into the code in the period since we stopped doing bounds checking.
Some of these errors were subtle and required significant debugging but would have
been much easier to detect and fix with bounds-checked views.
