### PR TITLE
Add better support for views of const packs in API

### DIFF
--- a/src/ekat/ekat_pack_kokkos.hpp
+++ b/src/ekat/ekat_pack_kokkos.hpp
@@ -178,6 +178,21 @@ repack (const Kokkos::View<Pack<T, old_pack_size>**, Parms...>& vp) {
     (old_pack_size / new_pack_size) * vp.extent_int(1));
 }
 
+template <int new_pack_size,
+          typename T, typename ...Parms, int old_pack_size,
+          typename std::enable_if<(old_pack_size > new_pack_size), int>::type = 0>
+KOKKOS_FORCEINLINE_FUNCTION
+Unmanaged<Kokkos::View<const Pack<T, new_pack_size>**, Parms...> >
+repack (const Kokkos::View<const Pack<T, old_pack_size>**, Parms...>& vp) {
+  static_assert(new_pack_size > 0 &&
+                old_pack_size % new_pack_size == 0,
+                "New pack size must divide old pack size.");
+  return Unmanaged<Kokkos::View<const Pack<T, new_pack_size>**, Parms...> >(
+    reinterpret_cast<const Pack<T, new_pack_size>*>(vp.data()),
+    vp.extent_int(0),
+    (old_pack_size / new_pack_size) * vp.extent_int(1));
+}
+
 // 2d growing
 template <int new_pack_size,
           typename T, typename ...Parms, int old_pack_size,
@@ -193,6 +208,20 @@ repack (const Kokkos::View<Pack<T, old_pack_size>**, Parms...>& vp) {
     (new_pack_size / old_pack_size) * vp.extent_int(1));
 }
 
+template <int new_pack_size,
+          typename T, typename ...Parms, int old_pack_size,
+          typename std::enable_if<(old_pack_size < new_pack_size), int>::type = 0>
+KOKKOS_FORCEINLINE_FUNCTION
+Unmanaged<Kokkos::View<const Pack<T, new_pack_size>**, Parms...> >
+repack (const Kokkos::View<const Pack<T, old_pack_size>**, Parms...>& vp) {
+  static_assert(new_pack_size % old_pack_size == 0,
+                "New pack size must divide old pack size.");
+  return Unmanaged<Kokkos::View<const Pack<T, new_pack_size>**, Parms...> >(
+    reinterpret_cast<const Pack<T, new_pack_size>*>(vp.data()),
+    vp.extent_int(0),
+    (new_pack_size / old_pack_size) * vp.extent_int(1));
+}
+
 // 2d staying the same
 template <int new_pack_size,
           typename T, typename ...Parms, int old_pack_size,
@@ -200,6 +229,15 @@ template <int new_pack_size,
 KOKKOS_FORCEINLINE_FUNCTION
 Unmanaged<Kokkos::View<Pack<T, new_pack_size>**, Parms...> >
 repack (const Kokkos::View<Pack<T, old_pack_size>**, Parms...>& vp) {
+  return vp;
+}
+
+template <int new_pack_size,
+          typename T, typename ...Parms, int old_pack_size,
+          typename std::enable_if<(new_pack_size == old_pack_size), int>::type = 0>
+KOKKOS_FORCEINLINE_FUNCTION
+Unmanaged<Kokkos::View<const Pack<T, new_pack_size>**, Parms...> >
+repack (const Kokkos::View<const Pack<T, old_pack_size>**, Parms...>& vp) {
   return vp;
 }
 
@@ -215,6 +253,20 @@ repack (const Kokkos::View<Pack<T, old_pack_size>*, Parms...>& vp) {
                 "New pack size must divide old pack size.");
   return Unmanaged<Kokkos::View<Pack<T, new_pack_size>*, Parms...> >(
     reinterpret_cast<Pack<T, new_pack_size>*>(vp.data()),
+    (old_pack_size / new_pack_size) * vp.extent_int(0));
+}
+
+template <int new_pack_size,
+          typename T, typename ...Parms, int old_pack_size,
+          typename std::enable_if<(old_pack_size > new_pack_size), int>::type = 0>
+KOKKOS_FORCEINLINE_FUNCTION
+Unmanaged<Kokkos::View<const Pack<T, new_pack_size>*, Parms...> >
+repack (const Kokkos::View<const Pack<T, old_pack_size>*, Parms...>& vp) {
+  static_assert(new_pack_size > 0 &&
+                old_pack_size % new_pack_size == 0,
+                "New pack size must divide old pack size.");
+  return Unmanaged<Kokkos::View<const Pack<T, new_pack_size>*, Parms...> >(
+    reinterpret_cast<const Pack<T, new_pack_size>*>(vp.data()),
     (old_pack_size / new_pack_size) * vp.extent_int(0));
 }
 
@@ -234,6 +286,21 @@ repack (const Kokkos::View<Pack<T, old_pack_size>*, Parms...>& vp) {
     vp.extent_int(0) / (new_pack_size / old_pack_size));
 }
 
+template <int new_pack_size,
+          typename T, typename ...Parms, int old_pack_size,
+          typename std::enable_if<(old_pack_size < new_pack_size), int>::type = 0>
+KOKKOS_FORCEINLINE_FUNCTION
+Unmanaged<Kokkos::View<const Pack<T, new_pack_size>*, Parms...> >
+repack (const Kokkos::View<const Pack<T, old_pack_size>*, Parms...>& vp) {
+  static_assert(new_pack_size > 0 &&
+                new_pack_size % old_pack_size == 0,
+                "Old pack size must divide new pack size.");
+  EKAT_KERNEL_ASSERT(vp.extent_int(0) % (new_pack_size / old_pack_size) == 0);
+  return Unmanaged<Kokkos::View<const Pack<T, new_pack_size>*, Parms...> >(
+    reinterpret_cast<const Pack<T, new_pack_size>*>(vp.data()),
+    vp.extent_int(0) / (new_pack_size / old_pack_size));
+}
+
 // 1d staying the same
 template <int new_pack_size,
           typename T, typename ...Parms, int old_pack_size,
@@ -241,6 +308,15 @@ template <int new_pack_size,
 KOKKOS_FORCEINLINE_FUNCTION
 Unmanaged<Kokkos::View<Pack<T, new_pack_size>*, Parms...> >
 repack (const Kokkos::View<Pack<T, old_pack_size>*, Parms...>& vp) {
+  return vp;
+}
+
+template <int new_pack_size,
+          typename T, typename ...Parms, int old_pack_size,
+          typename std::enable_if<(old_pack_size == new_pack_size), int>::type = 0>
+KOKKOS_FORCEINLINE_FUNCTION
+Unmanaged<Kokkos::View<const Pack<T, new_pack_size>*, Parms...> >
+repack (const Kokkos::View<const Pack<T, old_pack_size>*, Parms...>& vp) {
   return vp;
 }
 

--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -72,20 +72,20 @@ struct LinInterp
   int km1_pack() const { return m_km1_pack; }
   int km2_pack() const { return m_km2_pack; }
 
-  template<typename V>
+  template<typename V1, typename V2>
   KOKKOS_INLINE_FUNCTION
   void setup(const MemberType& team,
-             const V& x1,
-             const V& x2) const;
+             const V1& x1,
+             const V2& x2) const;
 
   // Linearly interpolate y(x1) onto coordinates x2
-  template <typename V>
+  template <typename V1, typename V2, typename V3, typename V4>
   KOKKOS_INLINE_FUNCTION
   void lin_interp(const MemberType& team,
-                  const V& x1,
-                  const V& x2,
-                  const V& y1,
-                  const V& y2) const;
+                  const V1& x1,
+                  const V2& x2,
+                  const V3& y1,
+                  const V4& y2) const;
 
   //
   // -------- Internal API, data ------

--- a/src/ekat/util/ekat_lin_interp_impl.hpp
+++ b/src/ekat/util/ekat_lin_interp_impl.hpp
@@ -19,24 +19,24 @@ LinInterp<ScalarT, PackSize, DeviceT>::LinInterp(int ncol, int km1, int km2, Sca
 {}
 
 template <typename ScalarT, int PackSize, typename DeviceT>
-template<typename V>
+template<typename V1, typename V2>
 KOKKOS_INLINE_FUNCTION
 void LinInterp<ScalarT, PackSize, DeviceT>::setup(const MemberType& team,
-                                        const V& x1,
-                                        const V& x2) const
+                                        const V1& x1,
+                                        const V2& x2) const
 {
   setup_impl(team, *this, ekat::repack<Pack::n>(x1), ekat::repack<Pack::n>(x2));
 }
 
 // Linearly interpolate y(x1) onto coordinates x2
 template <typename ScalarT, int PackSize, typename DeviceT>
-template <typename V>
+template <typename V1, typename V2, typename V3, typename V4>
 KOKKOS_INLINE_FUNCTION
 void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp(const MemberType& team,
-                                             const V& x1,
-                                             const V& x2,
-                                             const V& y1,
-                                             const V& y2) const
+                                             const V1& x1,
+                                             const V2& x2,
+                                             const V3& y1,
+                                             const V4& y2) const
 {
   lin_interp_impl(team,
                   *this,


### PR DESCRIPTION
Add support for having input args be Views of const Packs
for lin_interp. This required adding support for Views of const
Packs for all the repack functions as well.

## Motivation

@AaronDonahue is trying to use lin_interp on constant Field views.

## Testing
Added a lin_interp test that tries combinations of View<const Pack> inputs.
