### PR TITLE
Jgfouca/lin interp imprv

### DIFF
--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -69,8 +69,10 @@ struct LinInterp
 
   LinInterp(int ncol, int km1, int km2, Scalar minthresh);
 
+  // Simple getters
   int km1_pack() const { return m_km1_pack; }
   int km2_pack() const { return m_km2_pack; }
+  const TeamPolicy& policy() const { return m_policy; }
 
   // Setup the index map. This must be called before lin_interp. By default, will launch a
   // TeamThreadRange kernel. By default, the column idx will be team.league_rank(); this can be
@@ -82,7 +84,7 @@ struct LinInterp
     const V1& x1,
     const V2& x2,
     const Int col=-1) const;
-  
+
   // Same as above except uses a user-provided range boundary struct. This will likely
   // be a TeamVectorRange.
   template<typename V1, typename V2, typename RangeBoundary>
@@ -124,6 +126,7 @@ struct LinInterp
   //
   // -------- Internal API, data ------
   //
+ private:
 
   template <typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
@@ -144,7 +147,6 @@ struct LinInterp
     const view_1d<const Pack>& x1, const view_1d<const Pack>& x2, const view_1d<const Pack>& y1,
     const view_1d<Pack>& y2,
     const Int col);
-
 
   int m_km1;
   int m_km2;

--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -86,7 +86,7 @@ struct LinInterp
     const Int col=-1) const;
 
   // Same as above except uses a user-provided range boundary struct. This will likely
-  // be a TeamVectorRange.
+  // be a ThreadVectorRange.
   template<typename V1, typename V2, typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
   void setup(
@@ -111,7 +111,7 @@ struct LinInterp
     const Int col=-1) const;
 
   // Same as above except uses a user-provided range boundary struct. This will likely
-  // be a TeamVectorRange.
+  // be a ThreadVectorRange.
   template <typename V1, typename V2, typename V3, typename V4, typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
   void lin_interp(

--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -110,7 +110,7 @@ struct LinInterp
   int m_km2_pack;
   Scalar m_minthresh;
   TeamPolicy m_policy;
-  view_2d<IntPack> m_indx_map; // [x2-idx] -> x1-idx
+  view_2d<IntPack> m_indx_map; // [x2_idx] -> x1_idx
 };
 
 } //namespace ekat

--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -72,49 +72,80 @@ struct LinInterp
   int km1_pack() const { return m_km1_pack; }
   int km2_pack() const { return m_km2_pack; }
 
+  // Setup the index map. This must be called before lin_interp. By default, will launch a
+  // TeamThreadRange kernel. By default, the column idx will be team.league_rank(); this can be
+  // overridden by the col argument.
   template<typename V1, typename V2>
   KOKKOS_INLINE_FUNCTION
-  void setup(const MemberType& team,
-             const V1& x1,
-             const V2& x2) const;
+  void setup(
+    const MemberType& team,
+    const V1& x1,
+    const V2& x2,
+    const Int col=-1) const;
+  
+  // Same as above except uses a user-provided range boundary struct. This will likely
+  // be a TeamVectorRange.
+  template<typename V1, typename V2, typename RangeBoundary>
+  KOKKOS_INLINE_FUNCTION
+  void setup(
+    const MemberType& team,
+    const RangeBoundary& range_boundary,
+    const V1& x1,
+    const V2& x2,
+    const Int col=-1) const;
 
-  // Linearly interpolate y(x1) onto coordinates x2
+  // Linearly interpolate y(x1) onto coordinates x2. By default, will launch a
+  // TeamThreadRange kernel. The x1 and x2 should match what was given to setup.
+  // By default, the column idx will be team.league_rank(); this can be
+  // overridden by the col argument.
   template <typename V1, typename V2, typename V3, typename V4>
   KOKKOS_INLINE_FUNCTION
-  void lin_interp(const MemberType& team,
-                  const V1& x1,
-                  const V2& x2,
-                  const V3& y1,
-                  const V4& y2) const;
+  void lin_interp(
+    const MemberType& team,
+    const V1& x1,
+    const V2& x2,
+    const V3& y1,
+    const V4& y2,
+    const Int col=-1) const;
 
-  template <typename V1, typename V2, typename V3, typename V4, typename RangePolicy>
+  // Same as above except uses a user-provided range boundary struct. This will likely
+  // be a TeamVectorRange.
+  template <typename V1, typename V2, typename V3, typename V4, typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
-  void lin_interp(const MemberType& team,
-                  const RangePolicy& range_policy,
-                  const V1& x1,
-                  const V2& x2,
-                  const V3& y1,
-                  const V4& y2) const;
+  void lin_interp(
+    const MemberType& team,
+    const RangeBoundary& range_boundary,
+    const V1& x1,
+    const V2& x2,
+    const V3& y1,
+    const V4& y2,
+    const Int col=-1) const;
 
   //
   // -------- Internal API, data ------
   //
 
+  template <typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
   static void setup_impl(
-    const MemberType& team, const LinInterp& liv, const view_1d<const Pack>& x1, const view_1d<const Pack>& x2);
+    const MemberType& team,
+    const RangeBoundary& range_boundary,
+    const LinInterp& liv,
+    const view_1d<const Pack>& x1,
+    const view_1d<const Pack>& x2,
+    const Int col);
 
-  template <typename RangePolicy>
+  template <typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
   static void lin_interp_impl(
     const MemberType& team,
-    const RangePolicy& range_policy,
+    const RangeBoundary& range_boundary,
     const LinInterp& liv,
     const view_1d<const Pack>& x1, const view_1d<const Pack>& x2, const view_1d<const Pack>& y1,
-    const view_1d<Pack>& y2);
+    const view_1d<Pack>& y2,
+    const Int col);
 
 
-  int m_ncol;
   int m_km1;
   int m_km2;
   int m_km1_pack;

--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -87,6 +87,15 @@ struct LinInterp
                   const V3& y1,
                   const V4& y2) const;
 
+  template <typename V1, typename V2, typename V3, typename V4, typename RangePolicy>
+  KOKKOS_INLINE_FUNCTION
+  void lin_interp(const MemberType& team,
+                  const RangePolicy& range_policy,
+                  const V1& x1,
+                  const V2& x2,
+                  const V3& y1,
+                  const V4& y2) const;
+
   //
   // -------- Internal API, data ------
   //
@@ -95,9 +104,11 @@ struct LinInterp
   static void setup_impl(
     const MemberType& team, const LinInterp& liv, const view_1d<const Pack>& x1, const view_1d<const Pack>& x2);
 
+  template <typename RangePolicy>
   KOKKOS_INLINE_FUNCTION
   static void lin_interp_impl(
     const MemberType& team,
+    const RangePolicy& range_policy,
     const LinInterp& liv,
     const view_1d<const Pack>& x1, const view_1d<const Pack>& x2, const view_1d<const Pack>& y1,
     const view_1d<Pack>& y2);

--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -130,23 +130,21 @@ struct LinInterp
 
   template <typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
-  static void setup_impl(
+  void setup_impl(
     const MemberType& team,
     const RangeBoundary& range_boundary,
-    const LinInterp& liv,
     const view_1d<const Pack>& x1,
     const view_1d<const Pack>& x2,
-    const Int col);
+    const Int col) const;
 
   template <typename RangeBoundary>
   KOKKOS_INLINE_FUNCTION
-  static void lin_interp_impl(
+  void lin_interp_impl(
     const MemberType& team,
     const RangeBoundary& range_boundary,
-    const LinInterp& liv,
     const view_1d<const Pack>& x1, const view_1d<const Pack>& x2, const view_1d<const Pack>& y1,
     const view_1d<Pack>& y2,
-    const Int col);
+    const Int col) const;
 
   int m_km1;
   int m_km2;

--- a/src/ekat/util/ekat_lin_interp_impl.hpp
+++ b/src/ekat/util/ekat_lin_interp_impl.hpp
@@ -8,7 +8,6 @@ namespace ekat {
 
 template <typename ScalarT, int PackSize, typename DeviceT>
 LinInterp<ScalarT, PackSize, DeviceT>::LinInterp(int ncol, int km1, int km2, Scalar minthresh) :
-  m_ncol(ncol),
   m_km1(km1),
   m_km2(km2),
   m_km1_pack(ekat::npack<Pack>(km1)),
@@ -21,21 +20,40 @@ LinInterp<ScalarT, PackSize, DeviceT>::LinInterp(int ncol, int km1, int km2, Sca
 template <typename ScalarT, int PackSize, typename DeviceT>
 template<typename V1, typename V2>
 KOKKOS_INLINE_FUNCTION
-void LinInterp<ScalarT, PackSize, DeviceT>::setup(const MemberType& team,
-                                        const V1& x1,
-                                        const V2& x2) const
+void LinInterp<ScalarT, PackSize, DeviceT>::setup(
+  const MemberType& team,
+  const V1& x1,
+  const V2& x2,
+  const Int col) const
 {
-  setup_impl(team, *this, ekat::repack<Pack::n>(x1), ekat::repack<Pack::n>(x2));
+  setup_impl(team, Kokkos::TeamThreadRange(team, m_km2_pack),
+             *this, ekat::repack<Pack::n>(x1), ekat::repack<Pack::n>(x2), col);
+}
+
+template <typename ScalarT, int PackSize, typename DeviceT>
+template<typename V1, typename V2, typename RangeBoundary>
+KOKKOS_INLINE_FUNCTION
+void LinInterp<ScalarT, PackSize, DeviceT>::setup(
+  const MemberType& team,
+  const RangeBoundary& range_boundary,
+  const V1& x1,
+  const V2& x2,
+  const Int col) const
+{
+  setup_impl(team, range_boundary,
+             *this, ekat::repack<Pack::n>(x1), ekat::repack<Pack::n>(x2), col);
 }
 
 template <typename ScalarT, int PackSize, typename DeviceT>
 template <typename V1, typename V2, typename V3, typename V4>
 KOKKOS_INLINE_FUNCTION
-void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp(const MemberType& team,
-                                                       const V1& x1,
-                                                       const V2& x2,
-                                                       const V3& y1,
-                                                       const V4& y2) const
+void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp(
+  const MemberType& team,
+  const V1& x1,
+  const V2& x2,
+  const V3& y1,
+  const V4& y2,
+  const Int col) const
 {
   lin_interp_impl(team,
                   Kokkos::TeamThreadRange(team, m_km2_pack),
@@ -43,43 +61,48 @@ void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp(const MemberType& team,
                   ekat::repack<Pack::n>(x1),
                   ekat::repack<Pack::n>(x2),
                   ekat::repack<Pack::n>(y1),
-                  ekat::repack<Pack::n>(y2));
+                  ekat::repack<Pack::n>(y2),
+                  col);
 }
 
 template <typename ScalarT, int PackSize, typename DeviceT>
-template <typename V1, typename V2, typename V3, typename V4, typename RangePolicy>
+template <typename V1, typename V2, typename V3, typename V4, typename RangeBoundary>
 KOKKOS_INLINE_FUNCTION
-void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp(const MemberType& team,
-                                                       const RangePolicy& range_policy,
-                                                       const V1& x1,
-                                                       const V2& x2,
-                                                       const V3& y1,
-                                                       const V4& y2) const
+void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp(
+  const MemberType& team,
+  const RangeBoundary& range_boundary,
+  const V1& x1,
+  const V2& x2,
+  const V3& y1,
+  const V4& y2,
+  const Int col) const
 {
   lin_interp_impl(team,
-                  range_policy,
+                  range_boundary,
                   *this,
                   ekat::repack<Pack::n>(x1),
                   ekat::repack<Pack::n>(x2),
                   ekat::repack<Pack::n>(y1),
-                  ekat::repack<Pack::n>(y2));
+                  ekat::repack<Pack::n>(y2),
+                  col);
 }
 
 template <typename ScalarT, int PackSize, typename DeviceT>
-template <typename RangePolicy>
+template <typename RangeBoundary>
 KOKKOS_INLINE_FUNCTION
 void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp_impl(
   const MemberType& team,
-  const RangePolicy& range_policy,
+  const RangeBoundary& range_boundary,
   const LinInterp& liv,
   const view_1d<const Pack>& x1, const view_1d<const Pack>& x2, const view_1d<const Pack>& y1,
-  const view_1d<Pack>& y2)
+  const view_1d<Pack>& y2,
+  const Int col)
 {
   auto x1s = ekat::scalarize(x1);
   auto y1s = ekat::scalarize(y1);
 
-  const int i = team.league_rank();
-  Kokkos::parallel_for(range_policy, [&] (Int k2) {
+  const int i = col == -1 ? team.league_rank() : col;
+  Kokkos::parallel_for(range_boundary, [&] (Int k2) {
     const auto indx_pk = liv.m_indx_map(i, k2);
     const auto end_mask = indx_pk == liv.m_km1 - 1;
     if (end_mask.any()) {
@@ -107,16 +130,22 @@ void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp_impl(
 }
 
 template <typename ScalarT, int PackSize, typename DeviceT>
+template <typename RangeBoundary>
 KOKKOS_INLINE_FUNCTION
 void LinInterp<ScalarT, PackSize, DeviceT>::setup_impl(
-  const MemberType& team, const LinInterp& liv, const view_1d<const Pack>& x1, const view_1d<const Pack>& x2)
+  const MemberType& team,
+  const RangeBoundary& range_boundary,
+  const LinInterp& liv,
+  const view_1d<const Pack>& x1,
+  const view_1d<const Pack>& x2,
+  const Int col)
 {
   auto x1s = ekat::scalarize(x1);
   auto begin_x1 = x1s.data();
   auto end_x1 = begin_x1 + liv.m_km1;
 
-  const int i = team.league_rank();
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, liv.m_km2_pack), [&] (Int k2) {
+  const int i = col == -1 ? team.league_rank() : col;
+  Kokkos::parallel_for(range_boundary, [&] (Int k2) {
     for (int s = 0; s < Pack::n; ++s) {
       const Scalar x2_indv = x2(k2)[s];
       auto ub = upper_bound(begin_x1, end_x1, x2_indv);

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -195,7 +195,7 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
 
     // Run LiVect ThreadVectorRange
     {
-      LIV1::TeamPolicy policy(outer_dim, inner_dim, km2);
+      LIV1::TeamPolicy policy(outer_dim, ekat::OnGpu<LIV1::ExeSpace>::value ? inner_dim : 1, km2);
       Kokkos::parallel_for("lin-interp-ut-vect-tvr", policy,
                            KOKKOS_LAMBDA(typename LIV::MemberType const& team) {
         const int i = team.league_rank();

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -178,7 +178,7 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
     // Run LiVect TeamThreadRange
     {
       Kokkos::parallel_for("lin-interp-ut-vect-ttr",
-                           vect.m_policy,
+                           vect.policy(),
                            KOKKOS_LAMBDA(typename LIV::MemberType const& team_member) {
         const int i = team_member.league_rank();
         vect.setup(team_member,
@@ -260,7 +260,7 @@ TEST_CASE("lin_interp_api", "lin_interp")
   view_1dc x1c(x1), x2c(x2), y1c(y1);
 
   Kokkos::parallel_for("lin-interp-ut-vect",
-                       vect.m_policy,
+                       vect.policy(),
                        KOKKOS_LAMBDA(typename LIV::MemberType const& team_member)
   {
     vect.setup(team_member, x1, x2);
@@ -297,7 +297,7 @@ TEST_CASE("lin_interp_tvr", "lin_interp")
     y2kv("y2kv", 0, 0, 0);
 
   Kokkos::parallel_for("lin-interp-ut-vect",
-                       vect.m_policy,
+                       vect.policy(),
                        KOKKOS_LAMBDA(typename LIV::MemberType const& team) {
     const int i = team.league_rank();
     vect.setup(team,

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -199,14 +199,17 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
       Kokkos::parallel_for("lin-interp-ut-vect-tvr", policy,
                            KOKKOS_LAMBDA(typename LIV::MemberType const& team) {
         const int i = team.league_rank();
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, inner_dim), [&] (int j) {
-          const auto& tvr = Kokkos::ThreadVectorRange(team, km2);
+        for (int j = 0; j < inner_dim; ++j) {
           const int col = i*inner_dim + j;
-          vect1.setup(team, tvr,
+          vect1.setup(team,
                       ekat::subview(x1kv3, i, j),
                       ekat::subview(x2kv3, i, j),
                       col);
-          team.team_barrier();
+        }
+        team.team_barrier();
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, inner_dim), [&] (int j) {
+          const auto& tvr = Kokkos::ThreadVectorRange(team, km2);
+          const int col = i*inner_dim + j;
           vect1.lin_interp(team, tvr,
                            ekat::subview(x1kv3, i, j),
                            ekat::subview(x2kv3, i, j),

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -51,14 +51,6 @@ void populate_li_input(int km1, int km2, Scalar* x1_i, Scalar* y1_i, Scalar* x2_
     x2_i[j] = x_dist(*generator);
   }
 
-  // make endpoints same
-  if (generator != &local_generator) {
-    x1_i[0] = 0.0;
-    x2_i[0] = 0.0;
-    x1_i[km1-1] = 1.0;
-    x2_i[km2-1] = 1.0;
-  }
-
   std::sort(x1_i, x1_i + km1);
   std::sort(x2_i, x2_i + km2);
 }
@@ -233,6 +225,10 @@ TEST_CASE("lin_interp_api", "lin_interp")
     vect.lin_interp(team_member, x1c, x2, y1c, y2);
     vect.lin_interp(team_member, x1c, x2c, y1c, y2);
   });
+}
+
+TEST_CASE("lin_interp_tvr", "lin_interp")
+{
 
 }
 


### PR DESCRIPTION
Make the LinInterp API more flexible by allowing user to provide a range policy to lin_interp and setup. This will allow it to be used inside of TeamThreadRange kernels. The user can also specify the column being interpolated if they cannot rely on the league_rank = col assumption.

Merges tests of these new capabilities into the main Lin-interp soak test.

Also, minor clean ups of whitespace, variable names, and code structure. Adds better documentation for the main LinInterp API.
