### PR TITLE
Minor fixes to enable_shared_from_this

### DIFF
--- a/src/ekat/std_meta/ekat_std_enable_shared_from_this.hpp
+++ b/src/ekat/std_meta/ekat_std_enable_shared_from_this.hpp
@@ -48,11 +48,11 @@ public:
   enable_shared_from_this () = default;
   virtual ~enable_shared_from_this () = default;
 
-  std::shared_ptr<T> shared_from_this () {
+  std::shared_ptr<T> shared_from_this () const noexcept {
     return m_self.lock();
   }
 
-  std::weak_ptr<T> weak_from_this () {
+  std::weak_ptr<T> weak_from_this () const noexcept {
     return m_self;
   }
 


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The C++17 backport class `enable_shared_from_this` needed a couple of fixes regarding const-correctness and noexcept specifiers.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in scream

