### PR TITLE
Add wrappers to common MPI communication calls to Comm class

### DIFF
--- a/src/ekat/mpi/ekat_comm.cpp
+++ b/src/ekat/mpi/ekat_comm.cpp
@@ -37,6 +37,16 @@ void Comm::barrier () const
   MPI_Barrier(m_mpi_comm);
 }
 
+Comm Comm::split (const int color) const
+{
+  check_mpi_inited ();
+
+  MPI_Comm new_comm;
+  MPI_Comm_split(m_mpi_comm,color,m_rank,&new_comm);
+
+  return Comm(new_comm);
+}
+
 void Comm::check_mpi_inited () const
 {
   int flag;

--- a/src/ekat/mpi/ekat_comm.cpp
+++ b/src/ekat/mpi/ekat_comm.cpp
@@ -31,22 +31,10 @@ void Comm::reset_mpi_comm (MPI_Comm new_mpi_comm)
 #endif
 }
 
-template<>
-void Comm::scan_sum<int>(const int* my_vals, int* my_sums, const int count) const {
+void Comm::barrier () const
+{
   check_mpi_inited();
-  MPI_Scan(my_vals,my_sums,count,MPI_INT,MPI_SUM,m_mpi_comm);
-}
-
-template<>
-void Comm::scan_sum<float>(const float* my_vals, float* my_sums, const int count) const {
-  check_mpi_inited();
-  MPI_Scan(my_vals,my_sums,count,MPI_FLOAT,MPI_SUM,m_mpi_comm);
-}
-
-template<>
-void Comm::scan_sum<double>(const double* my_vals, double* my_sums, const int count) const {
-  check_mpi_inited();
-  MPI_Scan(my_vals,my_sums,count,MPI_DOUBLE,MPI_SUM,m_mpi_comm);
+  MPI_Barrier(m_mpi_comm);
 }
 
 void Comm::check_mpi_inited () const

--- a/src/ekat/mpi/ekat_comm.hpp
+++ b/src/ekat/mpi/ekat_comm.hpp
@@ -50,7 +50,12 @@ public:
   template<typename T>
   void broadcast (T* vals, const int count, const int root) const;
 
+  template<typename T>
+  void all_gather (const T* my_vals, T* all_vals, const int count) const;
+
   void barrier () const;
+
+  Comm split (const int color) const;
 private:
 
   template<typename T>
@@ -97,6 +102,17 @@ void Comm::broadcast (T* vals, const int count, const int root) const
   check_mpi_inited();
   MPI_Bcast(vals,count,get_mpi_type<T>(),root,m_mpi_comm);
 }
+
+template<typename T>
+void Comm::all_gather (const T* my_vals, T* all_vals, const int count) const
+{
+  check_mpi_inited();
+  auto mpi_type = get_mpi_type<T>();
+  MPI_Allgather(my_vals, count,mpi_type,
+                all_vals,count,mpi_type,
+                m_mpi_comm);
+}
+
 
 } // namespace ekat
 

--- a/src/ekat/mpi/ekat_comm.hpp
+++ b/src/ekat/mpi/ekat_comm.hpp
@@ -1,6 +1,8 @@
 #ifndef EKAT_COMM_HPP
 #define EKAT_COMM_HPP
 
+#include <type_traits>
+
 #include <mpi.h>
 
 namespace ekat
@@ -36,12 +38,34 @@ public:
   int  size () const { return m_size; }
   MPI_Comm mpi_comm () const { return m_mpi_comm; }
 
-  // Convenience function wrapping MPI_Scan.
-  // Note: the function is templated on T, but only int, float, double are implemented (eti-ed).
+  // Convenience functions wrapping MPI analogues.
+  // NOTE: the methods are templated on the values types, but so far the only
+  // supporterd types are: int, float, double
   template<typename T>
-  void scan_sum (const T* my_vals, T* my_sums, const int count) const;
+  void scan (const T* my_vals, T* result, const int count, const MPI_Op op) const;
 
+  template<typename T>
+  void all_reduce (const T* my_vals, T* result, const int count, const MPI_Op op) const;
+
+  template<typename T>
+  void broadcast (T* vals, const int count, const int root) const;
+
+  void barrier () const;
 private:
+
+  template<typename T>
+  static MPI_Datatype get_mpi_type () {
+    // Sanity check
+    static_assert (
+        std::is_same<T,int>::value ||
+        std::is_same<T,float>::value ||
+        std::is_same<T,double>::value,
+        "Error! Type not supported for MPI operations.\n");
+
+    return std::is_same<T,int>::value ? MPI_INT :
+          (std::is_same<T,float>::value ? MPI_FLOAT : MPI_DOUBLE);
+  }
+
   // Checks (with an assert) that MPI is already init-ed.
   void check_mpi_inited () const;
 
@@ -50,6 +74,29 @@ private:
   int       m_size;
   int       m_rank;
 };
+
+// ========================= IMPLEMENTATION =========================== //
+
+template<typename T>
+void Comm::scan (const T* my_vals, T* result, const int count, const MPI_Op op) const
+{
+  check_mpi_inited();
+  MPI_Scan(my_vals,result,count,get_mpi_type<T>(),op,m_mpi_comm);
+}
+
+template<typename T>
+void Comm::all_reduce (const T* my_vals, T* result, const int count, const MPI_Op op) const
+{
+  check_mpi_inited();
+  MPI_Allreduce(my_vals,result,count,get_mpi_type<T>(),op,m_mpi_comm);
+}
+
+template<typename T>
+void Comm::broadcast (T* vals, const int count, const int root) const
+{
+  check_mpi_inited();
+  MPI_Bcast(vals,count,get_mpi_type<T>(),root,m_mpi_comm);
+}
 
 } // namespace ekat
 

--- a/tests/mpi/comm.cpp
+++ b/tests/mpi/comm.cpp
@@ -24,8 +24,8 @@ TEST_CASE ("ekat_comm","") {
     comm.scan(&val_d,&sum_d,1,MPI_SUM);
 
     const int    sum_gauss_i = rank*(rank+1)/2;
-    const float  sum_gauss_f = rank*(rank+1)/2;
-    const double sum_gauss_d = rank*(rank+1)/2;
+    const float  sum_gauss_f = sum_gauss_i;
+    const double sum_gauss_d = sum_gauss_i;
 
     REQUIRE(sum_i==sum_gauss_i);
     REQUIRE(sum_f==sum_gauss_f);
@@ -72,12 +72,63 @@ TEST_CASE ("ekat_comm","") {
     const int n = size - 1;
 
     const int    sum_gauss_i = n*(n+1)/2;
-    const float  sum_gauss_f = n*(n+1)/2;
-    const double sum_gauss_d = n*(n+1)/2;
+    const float  sum_gauss_f = sum_gauss_i;
+    const double sum_gauss_d = sum_gauss_i;
 
     REQUIRE (sum_i==sum_gauss_i);
     REQUIRE (sum_f==sum_gauss_f);
     REQUIRE (sum_d==sum_gauss_d);
+  }
+
+  SECTION ("gather") {
+    int*    ranks_i = new int   [size];
+    float*  ranks_f = new float [size];
+    double* ranks_d = new double[size];
+
+    int    rank_i = rank;
+    float  rank_f = rank;
+    double rank_d = rank;
+
+    comm.all_gather(&rank_i, ranks_i, 1);
+    comm.all_gather(&rank_f, ranks_f, 1);
+    comm.all_gather(&rank_d, ranks_d, 1);
+
+    for (int i=0; i<size; ++i) {
+      REQUIRE (ranks_i [i]==i);
+      REQUIRE (ranks_f [i]==i);
+      REQUIRE (ranks_d [i]==i);
+    }
+
+    delete[] ranks_i;
+    delete[] ranks_f;
+    delete[] ranks_d;
+  }
+
+  SECTION ("split") {
+    auto new_comm = comm.split(rank % 2);
+    
+    const bool am_even = rank%2 == 0;
+    const int num_odd  = size/2;
+    const int num_even = size%2 + num_odd;
+
+    // Check the new comm has the right size
+    REQUIRE ( ((am_even && new_comm.size()==num_even) ||
+               (not am_even && new_comm.size()==num_odd)) );
+
+    // Check that the right world ranks ended up in the new comm
+    int* ranks = new int[new_comm.size()];
+
+    new_comm.all_gather(&rank,ranks,1);
+
+    for (int i=0; i<new_comm.size(); ++i) {
+      if (am_even) {
+        REQUIRE ( ranks[i] == 2*i );
+      } else {
+        REQUIRE ( ranks[i] == (2*i+1) );
+      }
+    }
+
+    delete[] ranks;
   }
 }
 

--- a/tests/mpi/comm.cpp
+++ b/tests/mpi/comm.cpp
@@ -7,15 +7,78 @@ TEST_CASE ("ekat_comm","") {
   using namespace ekat;
 
   Comm comm(MPI_COMM_WORLD);
+  const int rank = comm.rank();
+  const int size = comm.size();
 
-  int r_p1 = comm.rank()+1;
-  int sum;
-  comm.scan_sum(&r_p1,&sum,1);
+  SECTION ("scan") {
+    int    val_i = rank;
+    float  val_f = rank;
+    double val_d = rank;
 
-  int gauss_formula = r_p1*(r_p1+1)/2;
+    int    sum_i;
+    float  sum_f;
+    double sum_d;
 
-  REQUIRE(sum==gauss_formula);
+    comm.scan(&val_i,&sum_i,1,MPI_SUM);
+    comm.scan(&val_f,&sum_f,1,MPI_SUM);
+    comm.scan(&val_d,&sum_d,1,MPI_SUM);
 
+    const int    sum_gauss_i = rank*(rank+1)/2;
+    const float  sum_gauss_f = rank*(rank+1)/2;
+    const double sum_gauss_d = rank*(rank+1)/2;
+
+    REQUIRE(sum_i==sum_gauss_i);
+    REQUIRE(sum_f==sum_gauss_f);
+    REQUIRE(sum_d==sum_gauss_d);
+  }
+
+  SECTION ("broadcast") {
+    int*    ints    = new int   [size];
+    float*  floats  = new float [size];
+    double* doubles = new double[size];
+
+    ints   [rank] = -rank;
+    floats [rank] = -rank;
+    doubles[rank] = -rank;
+
+    for (int i=0; i<size; ++i) {
+      comm.broadcast(&ints   [i],1,i);
+      comm.broadcast(&floats [i],1,i);
+      comm.broadcast(&doubles[i],1,i);
+
+      REQUIRE (ints   [i]==-i);
+      REQUIRE (floats [i]==-i);
+      REQUIRE (doubles[i]==-i);
+    }
+
+    delete[] ints;
+    delete[] floats;
+    delete[] doubles;
+  }
+
+  SECTION ("reduce") {
+    int    val_i = rank;
+    float  val_f = rank;
+    double val_d = rank;
+
+    int    sum_i;
+    float  sum_f;
+    double sum_d;
+
+    comm.all_reduce(&val_i,&sum_i,1,MPI_SUM);
+    comm.all_reduce(&val_f,&sum_f,1,MPI_SUM);
+    comm.all_reduce(&val_d,&sum_d,1,MPI_SUM);
+
+    const int n = size - 1;
+
+    const int    sum_gauss_i = n*(n+1)/2;
+    const float  sum_gauss_f = n*(n+1)/2;
+    const double sum_gauss_d = n*(n+1)/2;
+
+    REQUIRE (sum_i==sum_gauss_i);
+    REQUIRE (sum_f==sum_gauss_f);
+    REQUIRE (sum_d==sum_gauss_d);
+  }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
MPI calls can be clunky, and these interfaces make the signature of a call a tad shorter. In particular, Comm now offers: scan, all_reduce, broadcast, and barrier. The first three are templated on the values type, but only int, float, and double are currently supported.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
All communication functions are tested in `tests/mpi/comm.cpp`.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
