### PR TITLE
Fix lin_interp test on CUDA

### DIFF
--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -70,8 +70,11 @@ struct LinInterp
   LinInterp(int ncol, int km1, int km2, Scalar minthresh);
 
   // Simple getters
+  KOKKOS_INLINE_FUNCTION
   int km1_pack() const { return m_km1_pack; }
+  KOKKOS_INLINE_FUNCTION
   int km2_pack() const { return m_km2_pack; }
+
   const TeamPolicy& policy() const { return m_policy; }
 
   // Setup the index map. This must be called before lin_interp. By default, will launch a


### PR DESCRIPTION
km2_pack is not a kokkos function, need to call it outside of kernels.

