### PR TITLE
EkatCreateUnitTest now runs unit tests serially if MPI_EXEC_NAME is omitted.

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -221,13 +221,11 @@ function(EkatCreateUnitTest target_name target_srcs)
     message (FATAL_ERROR "Error! THREAD_START < THREAD_END, but the increment is negative.")
   endif()
 
-  # Since we can't build without MPI, we must be prepared to supply the right
-  # MPI_EXEC.
-  if ("${ecut_MPI_EXEC_NAME}" STREQUAL "")
-    set (ecut_MPI_EXEC_NAME "mpiexec")
-  endif()
-  if ("${ecut_MPI_NP_FLAG}" STREQUAL "")
-    set (ecut_MPI_NP_FLAG "-n")
+  # If MPI_EXEC_NAME wasn't given, make sure we don't need more than one proc.
+  if (NOT ecut_MPI_EXEC_NAME)
+    if (MPI_START_RANK NOT EQUAL MPI_END_RANK)
+      message (FATAL_ERROR "Error! MPI_START_RANK != MPI_END_RANK, but MPI_EXEC_NAME was not given.")
+    endif()
   endif()
 
   #------------------------------------------------#
@@ -258,8 +256,12 @@ function(EkatCreateUnitTest target_name target_srcs)
       # outside of a shell process.
       set(mpi_extra_args_sep ${ecut_MPI_EXTRA_ARGS})
       separate_arguments(mpi_extra_args_sep)
-      add_test(NAME ${FULL_TEST_NAME}
-               COMMAND ${ecut_MPI_EXEC_NAME} ${ecut_MPI_NP_FLAG} ${NRANKS} ${mpi_extra_args_sep} ${invokeExecCurr})
+      if (ecut_MPI_EXEC_NAME)
+        add_test(NAME ${FULL_TEST_NAME}
+                 COMMAND ${ecut_MPI_EXEC_NAME} ${ecut_MPI_NP_FLAG} ${NRANKS} ${mpi_extra_args_sep} ${invokeExecCurr})
+      else()
+        add_test(NAME ${FULL_TEST_NAME} COMMAND ${invokeExecCurr})
+      endif()
 
       # Set test properties
       math(EXPR CURR_CORES "${NRANKS}*${NTHREADS}")

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -223,7 +223,7 @@ function(EkatCreateUnitTest target_name target_srcs)
 
   # If MPI_EXEC_NAME wasn't given, make sure we don't need more than one proc.
   if (NOT ecut_MPI_EXEC_NAME)
-    if (MPI_START_RANK NOT EQUAL MPI_END_RANK)
+    if (NOT MPI_START_RANK EQUAL MPI_END_RANK)
       message (FATAL_ERROR "Error! MPI_START_RANK != MPI_END_RANK, but MPI_EXEC_NAME was not given.")
     endif()
   endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,12 +13,16 @@ else ()
   set (DEFAULT_MAX_THREADS 16)
 endif ()
 
-set (EKAT_TEST_MAX_RANKS 4 CACHE STRING "Max number of ranks for tests")
-set (EKAT_TEST_MAX_THREADS ${DEFAULT_MAX_THREADS} CACHE STRING "Max number of threads for tests")
 set (EKAT_TEST_THREAD_INC 1  CACHE STRING "Increment for threads for tests")
 set (EKAT_TEST_MPI_EXEC_NAME "mpiexec" CACHE STRING "Name of mpirun executable")
 set (EKAT_TEST_MPI_NP_FLAG "-n" CACHE STRING "Flag to specify number of MPI processes")
 set (EKAT_TEST_MPI_EXTRA_ARGS "--bind-to core" CACHE STRING "Flag to specify extra args for MPI")
+if (EKAT_TEST_MPI_EXEC_NAME)
+  set (EKAT_TEST_MAX_RANKS 4 CACHE STRING "Max number of ranks for tests")
+else()
+  set (EKAT_TEST_MAX_RANKS 1 CACHE STRING "Max number of ranks for tests")
+endif()
+set (EKAT_TEST_MAX_THREADS ${DEFAULT_MAX_THREADS} CACHE STRING "Max number of threads for tests")
 
 #######################
 ###    PRECISION    ###

--- a/tests/logging/CMakeLists.txt
+++ b/tests/logging/CMakeLists.txt
@@ -5,20 +5,26 @@ EkatCreateUnitTest(logger logger_tests.cpp LIBS ekat)
 
 EkatCreateUnitTest(mpi_log_all mpi_log_all_ranks.cpp
   LIBS ekat
+  MPI_EXEC_NAME ${EKAT_TEST_MPI_EXEC_NAME}
   MPI_RANKS 1 ${EKAT_TEST_MAX_RANKS}
+  MPI_NP_FLAG ${EKAT_TEST_MPI_NP_FLAG}
   MPI_EXTRA_ARGS "--oversubscribe"
 )
 
 EkatCreateUnitTest(mpi_log_rank0 mpi_log_rank0_only.cpp
   LIBS ekat
+  MPI_EXEC_NAME ${EKAT_TEST_MPI_EXEC_NAME}
   MPI_RANKS 1 ${EKAT_TEST_MAX_RANKS}
+  MPI_NP_FLAG ${EKAT_TEST_MPI_NP_FLAG}
   MPI_EXTRA_ARGS "--oversubscribe"
   PROPERTIES FAIL_REGULAR_EXPRESSION "rank1"
 )
 
 EkatCreateUnitTest(multilog multiple_log_example.cpp
   LIBS ekat
+  MPI_EXEC_NAME ${EKAT_TEST_MPI_EXEC_NAME}
   MPI_RANKS 1 ${EKAT_TEST_MAX_RANKS}
+  MPI_NP_FLAG ${EKAT_TEST_MPI_NP_FLAG}
   MPI_EXTRA_ARGS "--oversubscribe"
   PROPERTIES FAIL_REGULAR_EXPRESSION "rank1"
 )


### PR DESCRIPTION
This change allows us to run tests in environments like Docker containers where we aren't allowed to use `mpiexec` (because, for example, of the ignorant-but-ubiquitous tendency of Docker to require running as `root`).
