### PR TITLE
Print comm info before starting a catch test session.

### DIFF
--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -2,9 +2,10 @@
 
 #include "catch2/catch.hpp"
 
+#include "ekat/mpi/ekat_comm.hpp"
+#include "ekat/util/ekat_test_utils.hpp"
 #include "ekat/ekat_session.hpp"
 #include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
 
 #include <mpi.h>
 
@@ -53,9 +54,8 @@ int main (int argc, char **argv) {
     args.push_back(argv[i]);
   }
 
-  int rank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  int dev_id = ekat::get_test_device(rank);
+  ekat::Comm comm(MPI_COMM_WORLD);
+  int dev_id = ekat::get_test_device(comm.rank());
   // Create it outside the if, so its c_str pointer survives
   std::string new_arg;
   if (dev_id>=0) {
@@ -68,6 +68,8 @@ int main (int argc, char **argv) {
   // Ekat provides a defalt one, but the user can choose
   // to not use it, and provide one instead.
   ekat_initialize_test_session(args.size(),args.data());
+
+  std::cout << "Starting catch session on rank " << comm.rank() << " out of " << comm.size() << "\n";
 
   // Run tests
   int num_failed = catch_session.run(argc, argv);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
While figuring out how to run ekat's ctest through slurm scheduler, I was playing with mpirun/srun options. At some point, I saw tests passing, but after further inspection, I realized instead of running 1 copy of the test with 4 ranks, I was running 4 copies of the test with 1 rank. Having the comm stats printed out when the test is run can help spot scripting mistakes.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
No testing needed. It's a simple printout of comm stats.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
