### PR TITLE
Only print_config on rank 0

### DIFF
--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -9,7 +9,7 @@
 
 #include <mpi.h>
 
-void ekat_initialize_test_session (int argc, char** argv);
+void ekat_initialize_test_session (int argc, char** argv, const bool print_config);
 void ekat_finalize_test_session ();
 
 int main (int argc, char **argv) {
@@ -64,10 +64,9 @@ int main (int argc, char **argv) {
   }
 
   // Initialize test session (initializes kokkos and print config settings).
-  // Ekat provides a defalt impl, but the user can choose
-  // Ekat provides a defalt one, but the user can choose
+  // Ekat provides a default impl, but the user can choose
   // to not use it, and provide one instead.
-  ekat_initialize_test_session(args.size(),args.data());
+  ekat_initialize_test_session(args.size(),args.data(),(comm.rank()==0));
 
   std::cout << "Starting catch session on rank " << comm.rank() << " out of " << comm.size() << "\n";
 

--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -68,7 +68,11 @@ int main (int argc, char **argv) {
   // to not use it, and provide one instead.
   ekat_initialize_test_session(args.size(),args.data(),(comm.rank()==0));
 
+#ifndef NDEBUG
+  MPI_Barrier(comm.mpi_comm());
   std::cout << "Starting catch session on rank " << comm.rank() << " out of " << comm.size() << "\n";
+  MPI_Barrier(comm.mpi_comm());
+#endif
 
   // Run tests
   int num_failed = catch_session.run(argc, argv);

--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -66,7 +66,7 @@ int main (int argc, char **argv) {
   // Initialize test session (initializes kokkos and print config settings).
   // Ekat provides a default impl, but the user can choose
   // to not use it, and provide one instead.
-  ekat_initialize_test_session(args.size(),args.data(),(comm.rank()==0));
+  ekat_initialize_test_session(args.size(),args.data(),comm.am_i_root());
 
 #ifndef NDEBUG
   MPI_Barrier(comm.mpi_comm());

--- a/src/ekat/util/ekat_test_session.cpp
+++ b/src/ekat/util/ekat_test_session.cpp
@@ -14,8 +14,8 @@
  * of these routines).
  */
 
-void ekat_initialize_test_session (int argc, char** argv) {
-  ekat::initialize_ekat_session (argc,argv);
+void ekat_initialize_test_session (int argc, char** argv, const bool print_config) {
+  ekat::initialize_ekat_session (argc,argv,print_config);
 }
 
 void ekat_finalize_test_session () {


### PR DESCRIPTION
`ekat_initialize_test_session()` was printing configs on every rank when called through `ekat_catch_main()`, but print info contains no rank-specific info. I added a `print_config` input arg which is set `mpi_rank == 0`. So now `initialize_ekat_session()` only prints info if `rank=0`.

Another thing added (and vetos are welcome) is that the
```std::cout << "Starting catch session on rank " << comm.rank() << " out of " << comm.size() << "\n";```
call output becomes very messy and intertwined with other output. I added barriers around it and put it in a DEBUG ifdef. 
