### PR TITLE
Some mods to compiler flags and vectorization pragmas

### DIFF
--- a/src/ekat/ekat_macros.hpp
+++ b/src/ekat/ekat_macros.hpp
@@ -2,20 +2,13 @@
 #define EKAT_MACROS_HPP
 
 #if defined __INTEL_COMPILER
-# define vector_ivdep _Pragma("ivdep")
-# ifdef _OPENMP
-#  define vector_simd _Pragma("omp simd")
-# else
-#  define vector_simd _Pragma("simd")
-# endif
+# define vector_simd _Pragma("omp simd")
 # define vector_novec _Pragma("novector")
 #elif defined(__GNUG__) && !defined(__clang__)
-# define vector_ivdep _Pragma("GCC ivdep")
-# define vector_simd _Pragma("GCC ivdep")
+# define vector_simd _Pragma("omp simd")
 # define vector_novec
 # define restrict __restrict__
 #else
-# define vector_ivdep
 # define vector_simd
 # define vector_novec
 # define restrict

--- a/src/ekat/ekat_macros.hpp
+++ b/src/ekat/ekat_macros.hpp
@@ -7,11 +7,9 @@
 #elif defined(__GNUG__) && !defined(__clang__)
 # define vector_simd _Pragma("omp simd")
 # define vector_novec
-# define restrict __restrict__
 #else
 # define vector_simd
 # define vector_novec
-# define restrict
 #endif
 
 // Annotate a loop with this symbol if vector_simd should work but

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -91,9 +91,6 @@ operator << (std::ostream& os, const Mask<n>& m) {
 #define ekat_masked_loop(mask, s)                         \
   vector_simd for (int s = 0; s < mask.n; ++s) if (mask[s])
 
-#define ekat_masked_loop_no_force_vec(mask, s)              \
-  vector_ivdep for (int s = 0; s < mask.n; ++s) if (mask[s])
-
 #define ekat_masked_loop_no_vec(mask, s)                    \
   vector_novec for (int s = 0; s < mask.n; ++s) if (mask[s])
 

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -22,12 +22,10 @@ struct TestMask {
   using Pack = ekat::Pack<int, PACKN>;
 
   static int sum_true (const Mask& m) {
-    int sum1 = 0, sum2 = 0, sum3 = 0;
+    int sum1 = 0, sum2 = 0;
     ekat_masked_loop(m, s) ++sum1;
-    ekat_masked_loop_no_force_vec(m, s) ++sum2;
-    ekat_masked_loop_no_vec(m, s) ++sum3;
+    ekat_masked_loop_no_vec(m, s) ++sum2;
     REQUIRE(sum1 == sum2);
-    REQUIRE(sum2 == sum3);
     return sum1;
   }
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
As explained in #136, Intel was complaining in Kokkos Serial builds, since the pragma simd is deprecated. In order to use pragma omp simd a special compiler flag is needed. The flag is `-qopenmp-simd` for intel, and `-fopenmp-simd` for GNU. Despite the name, pragma omp simd does _not_ require OpenMP features/libs. If OpenMP is also enabled (via `-qopenmp` or `-fopenmp`), the above flag has no effect (since it is already enabled by openmp).

Additionally:
* removed pragma ivdep. It was used only in the macro `ekat_masked_loop_no_force_vec`, which was never used (not even in scream), except for a unit test that only checked the macro itself...
* cleaned up the SetCompilersFlag macros, including removing unused code (brought in by the copy+paste from Homme's SetCompilersFlags).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
## Related Issues
Closes #136 