### PR TITLE
Fix (and simplify) YAML parser

### DIFF
--- a/src/ekat/ekat_parse_yaml_file.cpp
+++ b/src/ekat/ekat_parse_yaml_file.cpp
@@ -1,6 +1,7 @@
 #include "ekat/ekat_parse_yaml_file.hpp"
 #include "ekat/ekat_assert.hpp"
 
+#include <stdexcept>
 #include <yaml-cpp/yaml.h>
 
 #include <iostream>
@@ -13,74 +14,34 @@ void parse_node (const YAML::Node& node,
                  ParameterList& list);
 
 // Helpers
-bool is_bool (const std::string& key) {
-  return key=="true" || key=="false" ||
-         key=="TRUE" || key=="FALSE";
+bool is_bool (const std::string& s) {
+  return s=="true" || s=="false" ||
+         s=="TRUE" || s=="FALSE";
 }
 
-bool str2bool (const std::string& key) {
-  return (key=="true" || key=="TRUE");
+bool str2bool (const std::string& s) {
+  return (s=="true" || s=="TRUE");
 }
 
-bool is_int (const std::string& key) {
-  const auto& f = std::use_facet<std::ctype<char>>(std::locale());
-  constexpr auto digit = std::ctype_base::digit;
-  bool first_char = true;
-  for (auto ch : key) {
-    if (ch=='+' || ch=='-') {
-      // A sign is only allowed at the beginning
-      if (!first_char) {
-        return false;
-      }
-    } else if (!f.is(digit,ch)) {
-      return false;
-    }
-    first_char = false;
+bool is_int (const std::string& s) {
+  try {
+    std::size_t n;
+    std::stoi(s,&n);
+    return n==s.size();
+  } catch (...) {
+    return false;
   }
-  return true;
 }
 
-bool is_double (const std::string& key) {
-  const auto& f = std::use_facet<std::ctype<char>>(std::locale());
-  constexpr auto digit = std::ctype_base::digit;
-  bool point_found = false;
-  bool exp_found = false;
-  bool exp_symbol_found = false;
-  bool exp_symbol_just_found = false;
-  bool first_char = true;
-  for (auto ch : key) {
-    if (ch=='+' || ch=='-') {
-      // Ok to add +/- in front of a number
-      // Ok to add +/- after 'e'/'E', for the exponent
-      // Any other case is wrong
-      if (!first_char || !exp_symbol_just_found) {
-        return false;
-      }
-      exp_symbol_just_found = false;
-    } else if (ch=='.') {
-      if(point_found || exp_symbol_found) {
-        // Only one decimal point allowed, and it cannot be in the exponent
-        return false;
-      }
-      // Mark that we found the decimal point
-      point_found = true;
-      exp_symbol_just_found = false;
-    } else if (ch=='e' || ch=='E') {
-      // Mark that we found the exp letter (e or E)
-      exp_symbol_found = true;
-      exp_symbol_just_found = true;
-    } else if (f.is(digit,ch)) {
-      // If e/E was found, we found the exponent
-      exp_found = exp_symbol_found;
-      exp_symbol_just_found = false;
-    } else {
-      return false;
-    }
-    first_char = false;
+bool is_double (const std::string& s) {
+  try {
+    std::size_t n;
+    std::stod(s,&n);
+    return n==s.size();
+    return true;
+  } catch (...) {
+    return false;
   }
-
-  // If we found 'e' or 'E', we need to have found an exponent
-  return exp_found==exp_symbol_found;
 }
 
 // ---------- IMPLEMENTATION -------------- // 

--- a/tests/io/input.yaml
+++ b/tests/io/input.yaml
@@ -2,7 +2,7 @@
 ---
 Constants:
   One Double: 9.8
-  Two Doubles: [1.024e3, .1]
+  Three Doubles: [1.024e3, .1 , -1.0E-2]
   Two Logicals: [TRUE, false]
   One String: multiple words string
   Nested Sublist:
@@ -11,5 +11,5 @@ Options:
   My Bool: FALSE
   My Int: -2
   My String: string
-  My Real: 1.0
+  My Real: -1.0
 ...

--- a/tests/io/yaml_parser.cpp
+++ b/tests/io/yaml_parser.cpp
@@ -21,6 +21,7 @@ TEST_CASE ("yaml_parser","") {
   auto& options   = params.sublist("Options");
 
   REQUIRE (constants.isParameter("Two Logicals"));
+  REQUIRE (constants.isParameter("Three Doubles"));
   REQUIRE (constants.isParameter("One String"));
   REQUIRE (options.isParameter("My Int"));
   REQUIRE (options.isParameter("My Bool"));
@@ -31,6 +32,9 @@ TEST_CASE ("yaml_parser","") {
   REQUIRE (logicals.size()==2);
   REQUIRE (logicals[0] == 1);
   REQUIRE (logicals[1] == 0);
+
+  std::vector<double> doubles;
+  REQUIRE_NOTHROW(doubles = constants.get<std::vector<double>>("Three Doubles"));
 
   std::string str = "multiple words string";
   REQUIRE (constants.get<std::string>("One String") == str);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
There was an issue with the YAML parser, where negative doubles were parsed as strings. For some reason in my implementation I was not using the `std::stod` and `std::stoi` functions. Using those, the implementation of the parser is much simpler.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I modified the input file of the yaml parser unit test, to have also negative doubles.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
