### PR TITLE
Fix EkatCreateUnitTest

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -278,9 +278,11 @@ function(EkatCreateUnitTest target_name target_srcs)
         set_tests_properties(${FULL_TEST_NAME} PROPERTIES ${ecut_PROPERTIES})
       endif()
 
-      foreach (rank RANGE 1 ${NRANKS})
-        set (RES_GROUPS "${RES_GROUPS},devices:1")
+      foreach (rank RANGE 1 ${CURR_CORES})
+        list (APPEND RES_GROUPS "devices:1")
       endforeach()
+      string(REPLACE ";" "," RES_GROUPS "${RES_GROUPS}")
+
       set_property(TEST ${FULL_TEST_NAME} PROPERTY RESOURCE_GROUPS "${RES_GROUPS}")
     endforeach()
   endforeach()

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -278,7 +278,6 @@ function(EkatCreateUnitTest target_name target_srcs)
         set_tests_properties(${FULL_TEST_NAME} PROPERTIES ${ecut_PROPERTIES})
       endif()
 
-      set (RES_GROUPS "devices:1")
       foreach (rank RANGE 1 ${NRANKS})
         set (RES_GROUPS "${RES_GROUPS},devices:1")
       endforeach()


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Recent changes to the macro introduced a bug, only exposed when testing through ctest, with a resource specification file. In particular, the macro set the `RESOURCE_GROUPS` property to request $nranks+1 copies of `device:1`, rather than $nranks copies. When the resources are indeed limited (as it happens on weaver, e.g.), this caused tests to crap out.

Additionally, I modified the number of devices requested to $nranks*$nthreads, to guarantee more space to omp tests.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This is needed by scream, where weaver testing is failing due to the resources mis-specification.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
