### PR TITLE
Fix error in ekat_catch_main.cpp

### DIFF
--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -75,7 +75,7 @@ int main (int argc, char **argv) {
 #endif
 
   // Run tests
-  int num_failed = catch_session.run(argc, argv);
+  int num_failed = catch_session.run();
 
   // Finalizes test session (finalizes kokkos).
   // Ekat provides a defalt impl, but the user can choose


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The command line was parsed twice, causing issues with input redirection args (i.e., "< some_stuff"). For instance, doing `./my_exec blah` would show the following
```
Starting catch session on rank 0 out of 1
Filters: blah blah
```
If "blah" is indeed a valid filter, this is ok: catch would have the filter "blah blah", which is a combo of two filters, doing the same thing, which is the same as having the single filter "blah". But when doing `./my_exec <my_file`, this would generate the nonexistent filter `<myfile <myfile`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This issue was uncovered by scream testing.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually inspected scream testing, to ensure this fixes it.
<!--- 
Anything else we need to know in evaluating this pull request?
 -->
## Additional Information

Note: this PR apparently won't solve the whole problem, cause a test with `EXE_ARGS` set to `<blah` will still not work, since we are no longer running test through a shell (so the redirection op '<' doesn't work). Another PR should fix that.