### PR TITLE
Reinstate running tests in a shell

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -234,7 +234,6 @@ function(EkatCreateUnitTest target_name target_srcs)
 
   if (ecut_EXE_ARGS)
     set(invokeExec "./${target_name} ${ecut_EXE_ARGS}")
-    separate_arguments(invokeExec)
   else()
     set(invokeExec "./${target_name}")
   endif()
@@ -252,15 +251,12 @@ function(EkatCreateUnitTest target_name target_srcs)
         set(invokeExecCurr "${invokeExec}")
       endif()
 
-      # Create the test. But first: atomize the extra args so we can run
-      # outside of a shell process.
-      set(mpi_extra_args_sep ${ecut_MPI_EXTRA_ARGS})
-      separate_arguments(mpi_extra_args_sep)
+      # Create the test.
       if (ecut_MPI_EXEC_NAME)
         add_test(NAME ${FULL_TEST_NAME}
-                 COMMAND ${ecut_MPI_EXEC_NAME} ${ecut_MPI_NP_FLAG} ${NRANKS} ${mpi_extra_args_sep} ${invokeExecCurr})
+                 COMMAND sh -c "${ecut_MPI_EXEC_NAME} ${ecut_MPI_NP_FLAG} ${NRANKS} ${ecut_MPI_EXTRA_ARGS} ${invokeExecCurr}")
       else()
-        add_test(NAME ${FULL_TEST_NAME} COMMAND ${invokeExecCurr})
+        add_test(NAME ${FULL_TEST_NAME} COMMAND sh -c "${invokeExecCurr}")
       endif()
 
       # Set test properties

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -19,3 +19,10 @@ EkatCreateUnitTest(upper_bound upper_bound_test.cpp
 # Test math utils
 EkatCreateUnitTest(math_util math_util_tests.cpp
   LIBS ekat)
+
+# Test that failure are indeed spotted. Also, verify that redirection
+# of input is not parsed as test filter, by fwding a file
+EkatCreateUnitTest(regress_fail regress_fail.cpp
+  LIBS ekat EXE_ARGS " < CTestTestfile.cmake"
+  PROPERTIES WILL_FAIL true
+  )

--- a/tests/utils/regress_fail.cpp
+++ b/tests/utils/regress_fail.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch.hpp>
+
+#include "ekat/ekat_assert.hpp"
+
+namespace {
+
+TEST_CASE ("doomed") {
+  REQUIRE(false);
+}
+
+} // anonymous namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Running tests in a shell is necessary to be able to use some shell-specific features. E.g., input/output redirection only works in a shell. Without a shell, something like `./my_exec < my_infile` is parsed as "run my_exec, and pass the two strings '<' and 'my_infile' to its argv inputs". For catch2 tests, this means that the test will try to use the two filters "<" and "my_infile", likely finding that no test has to be run.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
The lack of input redirection was causing some tests to "pass" in SCREAM, because the string "<namelist.nl" was interpreted as a string to filter the tests with, causing no test to be run, hence the test "passed".

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a nano test, that simply contains `REQUIRE(false)`, and told ctest that the test should fail. Then, I added an input redirection as EXE_ARGS for this test. If the redirection works, the executable is run, a non-zero return code follows, and ctest is happy. However, if for some reason we break again the input redirection, the EXE_ARGS are interpreted as test filter, no test is run, the executable returns 0, and ctest will crap out.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
