### PR TITLE
Print only rank0

### DIFF
--- a/src/ekat/ekat_session.cpp
+++ b/src/ekat/ekat_session.cpp
@@ -53,7 +53,7 @@ void initialize_ekat_session (bool print_config) {
   enable_default_fpes ();
 
   if (!Kokkos::is_initialized()) {
-    printf("Calling initialize_kokkos\n");
+    if (print_config) printf("Calling initialize_kokkos\n");
     ekat_impl::initialize_kokkos();
   }
 


### PR DESCRIPTION
Another case of output print on all all ranks. Allow the user to set `print_config=false` to not print to screen.  Previously `print_config` was an unused input to this function. This will be used in scream as `print_config = ekat_comm.am_i_root()`. 