### PR TITLE
Do not use try-catch blocks when parsing YAML files

### DIFF
--- a/src/ekat/ekat_parse_yaml_file.cpp
+++ b/src/ekat/ekat_parse_yaml_file.cpp
@@ -24,24 +24,17 @@ bool str2bool (const std::string& s) {
 }
 
 bool is_int (const std::string& s) {
-  try {
-    std::size_t n;
-    std::stoi(s,&n);
-    return n==s.size();
-  } catch (...) {
-    return false;
-  }
+  std::istringstream is(s);
+  int d;
+  is >> d;
+  return !is.fail() && is.eof();
 }
 
 bool is_double (const std::string& s) {
-  try {
-    std::size_t n;
-    std::stod(s,&n);
-    return n==s.size();
-    return true;
-  } catch (...) {
-    return false;
-  }
+  std::istringstream is(s);
+  double d;
+  is >> d;
+  return !is.fail() && is.eof();
 }
 
 // ---------- IMPLEMENTATION -------------- // 


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
These blocks were inside functions checking if the input string was an int or a double. This makes debugging with 'catch throw' a nightmare. The new impl is exception free.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## E3SM Stakeholder Feedback
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
No additional testing needed. Parser is already tested.
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
