### PR TITLE
Some safety fixes to the logic that generates the ekat_mpicxx wrapper script

### DIFF
--- a/cmake/mpi/EkatSetNvccWrapper.cmake
+++ b/cmake/mpi/EkatSetNvccWrapper.cmake
@@ -3,11 +3,18 @@
 #       of ekat_mpicxx.in relative to this file.
 set (MPICXX_WRAPPER_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../bin)
 macro (EkatSetNvccWrapper)
+  # One filename full path could contain symlinks while the other doesn't.
+  # This would cause the two string to compare different, while the actual
+  # files would be the same. So get the *real* files full paths first.
+  get_filename_component(cxx_compiler "${CMAKE_CXX_COMPILER}" REALPATH)
+  get_filename_component(ekat_mpicxx "${CMAKE_BINARY_DIR}/bin/ekat_mpicxx" REALPATH)
+
   # Check if ekat_mpicxx is already the CMAKE_CXX_COMPILER. This could happen if
   # one configures the project, then changes something that triggers cmake to run.
-  # If that happens, without this if guard, the value of MPICXX in the ekat_mpicxx
-  # script would be the ekat_mpicxx script itself, causing infinite recursion. 
-  if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "${CMAKE_BINARY_DIR}/bin/ekat_mpicxx")
+  # If that happens, without this if guard, we would generate an ekat_mpicxx
+  # where the value of MPICXX would ekat_mpicxx itself, causing infinite recursion
+  # every time the compiler is invoked.
+  if (NOT cxx_compiler STREQUAL ekat_mpicxx)
     SetMpiCxxBackendCompilerVarName("MPI_CXX_BACKEND_COMPILER_VAR_NAME")
     # Before starting the project, wrap mpicxx in the ekat_mpicxx script, which
     # takes care of setting OMPI_CXX to point to nvcc_wrapper


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The cmake logic to generate ekat_mpicxx (the scripts that wraps mpicxx, setting OMPI_CXX (or equivalent) to point to nvcc_wrapper) contains some guards to avoid infinite recursion. This logic boiled down to compare whether the CMAKE_CXX_COMPILER was already set to be the ekat_mpicxx wrapper. However, the logic was buggy in the (remote, but it happened to me) case where the two filenames compared were different string, yet pointing to the same file (due to some symlinks in the filesystem).

This micro PR fixes this.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## E3SM Stakeholder Feedback
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Hard to test this one. You would have to be on a particular filesystem, configure ekat, then modify something that triggers cmake to re-run with the next make. If you end up with `${CMAKE_CXX_COMPILER}` different from `${CMAKE_BINARY_DIR}/bin/ekat_mpicxx`, then you get the infinite recursion. I managed to trigger this bug on a gpu platform, and verified manually that this fix is indeed...a fix.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
