### PR TITLE
Allow --map-by as MPI res specification flag, plus test-launcher script to wrap tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,9 @@ endif()
 include(EkatSetCompilerFlags)
 SetCompilerFlags()
 
-############################
-##     EKAT VALGRIND SUPPORT ###
-############################
+##################################
+##    EKAT VALGRIND SUPPORT    ###
+##################################
 
 if (EKAT_ENABLE_VALGRIND)
   add_subdirectory(valgrind_support)
@@ -119,6 +119,18 @@ add_subdirectory(src/ekat)
 ############################
 ###     EKAT TESTING     ###
 ############################
+
+# Copy/install test-launcher to build/install folder
+if (Kokkos_ENABLE_CUDA)
+  set (TEST_LAUNCHER_ON_GPU True)
+else()
+  set (TEST_LAUNCHER_ON_GPU False)
+endif()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bin/test-launcher
+               ${CMAKE_BINARY_DIR}/bin/test-launcher)
+include(GNUInstallDirs)
+install (PROGRAMS ${CMAKE_BINARY_DIR}/bin/test-launcher
+         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # By default, we DO build ekat tests. This may change in the future
 option (EKAT_ENABLE_TESTS "Whether tests should be built." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,12 +120,15 @@ add_subdirectory(src/ekat)
 ###     EKAT TESTING     ###
 ############################
 
-# Copy/install test-launcher to build/install folder
+# Set some vars needed to configure test-launcher
+SetMpiRuntimeEnvVars()
 if (Kokkos_ENABLE_CUDA)
   set (TEST_LAUNCHER_ON_GPU True)
 else()
   set (TEST_LAUNCHER_ON_GPU False)
 endif()
+
+# Configure/install test-launcher to build/install folder
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bin/test-launcher
                ${CMAKE_BINARY_DIR}/bin/test-launcher)
 include(GNUInstallDirs)

--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -112,8 +112,8 @@ def run_test(executable,exec_args):
 
     # Check if we're run with MPI
     if "OMPI_COMM_WORLD_SIZE" in env:
-        nranks = int(env["OMPI_COMM_WORLD_SIZE"])
-        myrank = int(env["OMPI_COMM_WORLD_RANK"])
+        nranks = int(env["${EKAT_MPIRUN_COMM_WORLD_SIZE}"])
+        myrank = int(env["${EKAT_MPIRUN_COMM_WORLD_RANK}"])
     else:
         nranks = 1
         myrank = 0

--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -156,7 +156,7 @@ def run_test(executable,exec_args):
         # variable TEST_LAUNCHER_ON_GPU to either True or False
         if ${TEST_LAUNCHER_ON_GPU}:
             expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
-            exec_args.append(" --kokkos-device-id={}".format(ids[0]))
+            exec_args.append(" --ekat-kokkos-device {}".format(ids[0]))
 
     cmd += " {}".format(executable)
     cmd += " {}".format(" ".join(exec_args))

--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+import argparse, pathlib, os, sys, subprocess
+
+###############################################################################
+def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
+###############################################################################
+    """
+    Similar to assert except doesn't generate an ugly stacktrace. Useful for
+    checking user error, not programming error.
+
+    >>> expect(True, "error1")
+    >>> expect(False, "error2")
+    Traceback (most recent call last):
+        ...
+    SystemExit: ERROR: error2
+    """
+    if not condition:
+        msg = error_prefix + " " + error_msg
+        raise exc_type(msg)
+
+###############################################################################
+def run_cmd(cmd, input_str=None, from_dir=None, verbose=None, dry_run=False,
+            arg_stdout=subprocess.PIPE, arg_stderr=subprocess.PIPE, env=None, combine_output=False):
+###############################################################################
+    """
+    Wrapper around subprocess to make it much more convenient to run shell commands
+
+    >>> run_cmd('ls file_i_hope_doesnt_exist')[0] != 0
+    True
+    """
+    arg_stderr = subprocess.STDOUT if combine_output else arg_stderr
+    from_dir = str(from_dir) if from_dir else from_dir
+
+    if verbose:
+        print("RUN: {}\nFROM: {}".format(cmd, os.getcwd() if from_dir is None else from_dir))
+
+    if dry_run:
+        return 0, "", ""
+
+    if input_str is not None:
+        stdin = subprocess.PIPE
+        input_str = input_str.encode('utf-8')
+    else:
+        stdin = None
+
+    proc = subprocess.Popen(cmd,
+                            shell=True,
+                            stdout=arg_stdout,
+                            stderr=arg_stderr,
+                            stdin=stdin,
+                            cwd=from_dir,
+                            env=env)
+
+    output, errput = proc.communicate(input_str)
+    if output is not None:
+        try:
+            output = output.decode('utf-8', errors='ignore')
+            output = output.strip()
+        except AttributeError:
+            print("Something funcky for output")
+            pass
+    if errput is not None:
+        try:
+            errput = errput.decode('utf-8', errors='ignore')
+            errput = errput.strip()
+        except AttributeError:
+            print("Something funcky for errput")
+            pass
+
+    stat = proc.wait()
+
+    return stat, output, errput
+
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} <executable>
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Lightweight python wrapper for a test that handles thread binding.\033[0m
+    > {0} ./my_exec
+
+""".format(pathlib.Path(args[0]).name),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("-e","--executable", help="The name of the executable to run",required=True)
+    #  parser.add_argument("exec_args",nargs=argparse.REMAINDER,help="Additional args to fwd to the executable")
+
+    return parser.parse_known_args(args[1:])
+
+###############################################################################
+def run_test(executable,exec_args):
+###############################################################################
+
+    print("execname: {}".format(executable))
+
+    omp_env = []
+    omp_env.append("OMP_DISPLAY_ENV=verbose")
+    omp_env.append("OMP_DISPLAY_AFFINITY=true")
+    omp_env.append("OMP_PROC_BIND=spread")
+    omp_env.append("OMP_PLACES=threads")
+
+    env = os.environ
+
+    # Check if we're run with MPI
+    if "OMPI_COMM_WORLD_SIZE" in env:
+        nranks = int(env["OMPI_COMM_WORLD_SIZE"])
+        myrank = int(env["OMPI_COMM_WORLD_RANK"])
+    else:
+        nranks = 1
+        myrank = 0
+
+    # Start with empty cmd, and append to it
+    cmd = ""
+
+    # If run with --resource-spec-file, we will have some special env var set
+    if "CTEST_RESOURCE_GROUP_COUNT" in env:
+        # Total number of resources for this test (for all ranks/threads)
+        res_count = int(env["CTEST_RESOURCE_GROUP_COUNT"])
+        my_res_id = myrank % res_count
+
+        # Get the list of devices ids in my resource group
+        key = "CTEST_RESOURCE_GROUP_" + str(my_res_id)
+        expect(key in env, "Error! CTEST_RESOURCE_GROUP_COUNT found in the env, but can't find {}".format(key))
+        my_res_name = env[key]
+        expect (my_res_name=="devices", "Error! My ctest resource group should be 'devices'.")
+        key += "_DEVICES"
+        expect(key in env, "Error! CTEST_RESOURCE_GROUP_{} found in the env, but can't find {}".format(my_res_id,key))
+        my_res_str = env[key];
+
+        # Split the CTEST_RESOURCE_GROUP_[N]_DEVICE string into tokens, and get the slots ids
+        my_res = my_res_str.split(';')
+        ids = []
+        for res in my_res:
+            id_slots_tokens = res.split(',')
+            id_tokens = id_slots_tokens[0].split(':')
+            ids.append(id_tokens[1])
+
+        # Now get the chunk of ids that belongs to this rank
+        expect (len(ids) % nranks == 0, "Error! Number of ranks does not divide the number of resources.")
+        ids_per_rank = int(len(ids) / nranks)
+        my_ids = ids[myrank*ids_per_rank : (myrank+1)*ids_per_rank]
+        ids_str = "{" + "},{".join(my_ids) + "}"
+
+        #  omp_env.append("OMP_NUM_THREADS={}".format(len(my_ids)))
+        cmd = "taskset -c " + ",".join(my_ids)
+
+        # This file is to be run through cmake's configure_file, which will expand the
+        # variable TEST_LAUNCHER_ON_GPU to either True or False
+        if ${TEST_LAUNCHER_ON_GPU}:
+            expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
+            exec_args.append(" --kokkos-device-id={}".format(ids[0]))
+
+    cmd += " {}".format(executable)
+    cmd += " {}".format(" ".join(exec_args))
+
+    stat, out, _ = run_cmd (cmd,verbose=True,combine_output=True,env=env)
+    print (out)
+
+    return stat==0
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    options, rest = parse_command_line(sys.argv, description)
+    success = run_test(**vars(options), exec_args=rest)
+
+    sys.exit(0 if success else 1)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -102,8 +102,9 @@ def run_test(executable,exec_args):
     print("execname: {}".format(executable))
 
     omp_env = []
-    omp_env.append("OMP_DISPLAY_ENV=verbose")
-    omp_env.append("OMP_DISPLAY_AFFINITY=true")
+    # Uncomment the next line if you want to print OMP env and bindings when the executable runs
+    # omp_env.append("OMP_DISPLAY_ENV=verbose")
+    # omp_env.append("OMP_DISPLAY_AFFINITY=true")
     omp_env.append("OMP_PROC_BIND=spread")
     omp_env.append("OMP_PLACES=threads")
 
@@ -117,8 +118,8 @@ def run_test(executable,exec_args):
         nranks = 1
         myrank = 0
 
-    # Start with empty cmd, and append to it
-    cmd = ""
+    # Start with all env vars settings
+    cmd = " ".join(omp_env)
 
     # If run with --resource-spec-file, we will have some special env var set
     if "CTEST_RESOURCE_GROUP_COUNT" in env:
@@ -149,8 +150,8 @@ def run_test(executable,exec_args):
         my_ids = ids[myrank*ids_per_rank : (myrank+1)*ids_per_rank]
         ids_str = "{" + "},{".join(my_ids) + "}"
 
-        #  omp_env.append("OMP_NUM_THREADS={}".format(len(my_ids)))
-        cmd = "taskset -c " + ",".join(my_ids)
+        # Start placing on the correct cpu set
+        cmd += " taskset -c " + ",".join(my_ids)
 
         # This file is to be run through cmake's configure_file, which will expand the
         # variable TEST_LAUNCHER_ON_GPU to either True or False

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -280,6 +280,7 @@ function(EkatCreateUnitTest target_name target_srcs)
         set_tests_properties(${FULL_TEST_NAME} PROPERTIES ${ecut_PROPERTIES})
       endif()
 
+      set(RES_GROUPS "")
       foreach (rank RANGE 1 ${CURR_CORES})
         list (APPEND RES_GROUPS "devices:1")
       endforeach()

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -233,10 +233,11 @@ function(EkatCreateUnitTest target_name target_srcs)
   # Loop over MPI/OpenMP configs, and create tests #
   #------------------------------------------------#
 
+  set (launcher ${CMAKE_BINARY_DIR}/bin/test-launcher)
   if (ecut_EXE_ARGS)
-    set(invokeExec "./${target_name} ${ecut_EXE_ARGS}")
+    set(invokeExec "${launcher} -e ./${target_name} ${ecut_EXE_ARGS}")
   else()
-    set(invokeExec "./${target_name}")
+    set(invokeExec "${launcher} -e ./${target_name}")
   endif()
 
   foreach (NRANKS RANGE ${MPI_START_RANK} ${MPI_END_RANK} ${MPI_INCREMENT})

--- a/cmake/mpi/EkatMpiUtils.cmake
+++ b/cmake/mpi/EkatMpiUtils.cmake
@@ -43,6 +43,24 @@ function (DisableMpiCxxBindings)
   unset (DISTRO_NAME)
 endfunction()
 
+# Set MPI runtime env vars for comm world rank/size, depending on mpi distribution
+macro (SetMpiRuntimeEnvVars)
+  set (DISTRO_NAME)
+  GetMpiDistributionName (DISTRO_NAME)
+
+  if (DISTRO_NAME STREQUAL "openmpi")
+    set(EKAT_MPIRUN_COMM_WORLD_SIZE "OMPI_COMM_WORLD_SIZE")
+    set(EKAT_MPIRUN_COMM_WORLD_RANK "OMPI_COMM_WORLD_RANK")
+  elseif (DISTRO_NAME STREQUAL "mpich")
+    set(EKAT_MPIRUN_COMM_WORLD_SIZE "PMI_SIZE")
+    set(EKAT_MPIRUN_COMM_WORLD_RANK "PMI_RANK")
+  else ()
+    message (FATAL_ERROR "Unsupported MPI distribution.")
+  endif()
+
+  unset (DISTRO_NAME)
+endmacro()
+
 # Set the MPI cxx backend compiler var name
 macro (SetMpiCxxBackendCompilerVarName OUTPUT_VAR_NAME)
   set (DISTRO_NAME)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When running multiple tests, and/or MPI, and/or OpenMP tests, we get slow performance if 2+ tests and/or 2+ ranks and or 2+ threads end up on the same processing unit. This has become a big burden for SCREAM, where the nice test parallelization efforts are somewhat invalidated by having 20+ executables clashing on the same cores.

This PR does 2 things:
 - It allows (though not by default) to use `--map-by` instead of `-np` to specify mpi resources, by setting `MPI_NP_FLAG` to `--map-by` when calling `EkatCreateUnitTest`. If so, the macro will have ctest invoke the executable as `mpiexec --map-by ppr:$NRANKS:node:pe=$NTHREADS ...` instead of `mpiexec -np $NRANKS ...`.
  - It adds (and use) a python wrapper for the unit tests executables, called `test-launcher`. This script does very little in case ctest is a) not used (e.g., I run tests by hand) or b) invoked without the `--resource-spec-file <file>` option. But if one uses ctest with such option, this python wrapper ensures that all tests are run on different ranks, and all tests have enough resources to accommodate all ranks/threads.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This PR is highly desired by SCREAM.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually tested this branch with SCREAM, and noticed a tremendous speedup. For instance, running only the valgrind tests build for SCREAM, since tests were spread out across cores, we had test runtime going down from 100s to 5s for "fast tests".

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
