### PR TITLE
Cuda bug fix in WorkspaceManager initialization

### DIFF
--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -314,6 +314,11 @@ class WorkspaceManager
 #endif
   view_1d<int> m_next_slot;
   view_2d<T> m_data;
+
+// operator() needs to be public
+public:
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const MemberType& team) const;
 }; // class WorkspaceManager
 
 template <typename T, typename D>


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This was sneaky. When using KOKKOS_LAMBDA, we cannot have the body (or any lambda called within it, or any class method called within) use any class member, due to the this pointer issue on CUDA. We were doing precisely that in the `init_all_metadata` method of `WorkspaceManager`. But then, why wasn't this error causing failures? That's where it gets sneaky: this was indeed buggy, causing bad initialization of the metadata...but other functions (like `take_many_and_reset`) would init metadata _again_, this time from within a device region, hence with valid access to class members. Basically we were initializing metadata with crap, but then re-initing it correctly during some WSM calls. The issue showed up b/c _some_ WSM methods do not call `init_slot_metadata`, like `take`. I am however unsure why `take` and `take_many` worked in our unit tests...

Solution: switch from KOKKOS_LAMBDA to functor implementation.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
We should probably add a cuda-memcheck build to our AT jobs...

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
