### PR TITLE
Add support for enabling cuda-memcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ if (EKAT_ENABLE_CUDA_MEMCHECK AND NOT Kokkos_ENABLE_CUDA)
   message(FATAL_ERROR "Makes no sense to turn on cuda-memcheck without CUDA")
 endif()
 
+if (EKAT_ENABLE_CUDA_MEMCHECK AND EKAT_ENABLE_VALGRIND)
+  message(FATAL_ERROR "Cannot simultanously enable valgrind and cuda-memcheck")
+endif()
+
 ###########################################
 ###   Package ekat as a CMake package   ###
 ###########################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set (EKAT_TPL_LIBRARIES ${EKAT_TPL_LIBRARIES_INTERNAL} CACHE INTERNAL "List of E
 option (EKAT_MPI_ERRORS_ARE_FATAL " Whether EKAT should crash when MPI errors happen." ON)
 option (EKAT_DEFAULT_BFB "Whether EKAT should default to BFB behavior whenever possible/appropriate." ${EKAT_IS_DEBUG_BUILD})
 option (EKAT_ENABLE_VALGRIND "Whether to run tests with valgrind" OFF)
+option (EKAT_ENABLE_CUDA_MEMCHECK "Whether to run tests with cuda-memcheck" OFF)
 option (EKAT_ENABLE_COVERAGE "Whether to enable code coverage" OFF)
 
 if (EKAT_ENABLE_COVERAGE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -141,6 +142,10 @@ option (EKAT_ENABLE_TESTS "Whether tests should be built." ON)
 if (EKAT_ENABLE_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif()
+
+if (EKAT_ENABLE_CUDA_MEMCHECK AND NOT Kokkos_ENABLE_CUDA)
+  message(FATAL_ERROR "Makes no sense to turn on cuda-memcheck without CUDA")
 endif()
 
 ###########################################

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Here are some of EKAT's cmake config options:
 - EKAT_DEFAULT_BFB: in certain kernels, whether to default to a BFB, serialized, implementation.
 - EKAT_DISABLE_TPL_WARNINGS: whether warnings from TPLs should be disabled.
 - EKAT_ENABLE_VALGRIND: whether tests should be run through valgrind.
+- EKAT_ENABLE_CUDA_MEMCHECK: whether tests should be run through cuda-memcheck.
 - EKAT_ENABLE_COVERAGE: whether to enable code coverage in the compiler.
 
 Once CMake configuration has completed, you can build and test EKAT with the usual `make` and `ctest` commands.

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -245,10 +245,12 @@ function(EkatCreateUnitTest target_name target_srcs)
       # Create the test name
       set(FULL_TEST_NAME ${target_name}_ut_np${NRANKS}_omp${NTHREADS})
 
-      # Setup valgrind commmand modifications
+      # Setup valgrind/memcheck commmand modifications
       if (EKAT_ENABLE_VALGRIND)
         set(VALGRIND_SUP_FILE "${CMAKE_BINARY_DIR}/mpi.supp")
         set(invokeExecCurr "valgrind --error-exitcode=1 --suppressions=${VALGRIND_SUP_FILE} ${invokeExec}")
+      elseif(EKAT_ENABLE_CUDA_MEMCHECK)
+        set(invokeExecCurr "cuda-memcheck --error-exitcode 1 ${invokeExec}")
       else()
         set(invokeExecCurr "${invokeExec}")
       endif()


### PR DESCRIPTION
Add support for running cuda-memcheck on all tests. You can do this via cmake setting: `EKAT_ENABLE_CUDA_MEMCHECK=ON`.

## Motivation

Cuda memory problems have caused a lot of disruption to our weaver AT testing. Detecting and fixing cuda memory errors will help keep things running smoothly.
