### PR TITLE
Added test-launcher printing capability

### DIFF
--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -91,20 +91,21 @@ OR
     )
 
     parser.add_argument("-e","--executable", help="The name of the executable to run",required=True)
-    #  parser.add_argument("exec_args",nargs=argparse.REMAINDER,help="Additional args to fwd to the executable")
+    parser.add_argument("-p","--print-omp-affinity", help="Print threads affinity at runtime",action="store_true")
 
     return parser.parse_known_args(args[1:])
 
 ###############################################################################
-def run_test(executable,exec_args):
+def run_test(executable,print_omp_affinity,exec_args):
 ###############################################################################
 
     print("execname: {}".format(executable))
 
     omp_env = []
     # Uncomment the next line if you want to print OMP env and bindings when the executable runs
-    # omp_env.append("OMP_DISPLAY_ENV=verbose")
-    # omp_env.append("OMP_DISPLAY_AFFINITY=true")
+    if print_omp_affinity:
+        omp_env.append("OMP_DISPLAY_ENV=verbose")
+        omp_env.append("OMP_DISPLAY_AFFINITY=true")
     omp_env.append("OMP_PROC_BIND=spread")
     omp_env.append("OMP_PLACES=threads")
 
@@ -123,6 +124,7 @@ def run_test(executable,exec_args):
 
     # If run with --resource-spec-file, we will have some special env var set
     if "CTEST_RESOURCE_GROUP_COUNT" in env:
+        print ("HAS RESOURCE SPECS")
         # Total number of resources for this test (for all ranks/threads)
         res_count = int(env["CTEST_RESOURCE_GROUP_COUNT"])
         my_res_id = myrank % res_count
@@ -158,6 +160,8 @@ def run_test(executable,exec_args):
         if ${TEST_LAUNCHER_ON_GPU}:
             expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
             exec_args.append(" --ekat-kokkos-device {}".format(ids[0]))
+    else:
+        print ("NO RESOURCE SPECS")
 
     cmd += " {}".format(executable)
     cmd += " {}".format(" ".join(exec_args))

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -37,7 +37,7 @@ function(EkatCreateUnitTest target_name target_srcs)
   #   Parse function inputs   #
   #---------------------------#
 
-  set(options EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION SERIAL THREADS_SERIAL RANKS_SERIAL)
+  set(options EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION SERIAL THREADS_SERIAL RANKS_SERIAL PRINT_OMP_AFFINITY)
   set(oneValueArgs DEP MPI_EXEC_NAME MPI_NP_FLAG)
   set(multiValueArgs
     MPI_RANKS THREADS
@@ -233,7 +233,11 @@ function(EkatCreateUnitTest target_name target_srcs)
   # Loop over MPI/OpenMP configs, and create tests #
   #------------------------------------------------#
 
-  set (launcher "${CMAKE_BINARY_DIR}/bin/test-launcher -e")
+  if (ecut_PRINT_OMP_AFFINITY)
+    set (launcher "${CMAKE_BINARY_DIR}/bin/test-launcher -p -e")
+  else()
+    set (launcher "${CMAKE_BINARY_DIR}/bin/test-launcher -e")
+  endif()
   if (ecut_EXE_ARGS)
     set(invokeExec "./${target_name} ${ecut_EXE_ARGS}")
   else()

--- a/tests/kokkos/CMakeLists.txt
+++ b/tests/kokkos/CMakeLists.txt
@@ -4,6 +4,7 @@ if (EKAT_TEST_DOUBLE_PRECISION)
   # Test kokkos utils
   EkatCreateUnitTest(kokkos_utils${DP_POSTFIX} kokkos_utils_tests.cpp
     LIBS ekat
+    PRINT_OMP_AFFINITY
     COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC}
   )
@@ -11,6 +12,7 @@ if (EKAT_TEST_DOUBLE_PRECISION)
   # Test workspace manager
   EkatCreateUnitTest(wsm${DP_POSTFIX} workspace_tests.cpp
     LIBS ekat
+    PRINT_OMP_AFFINITY
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC}
   )
@@ -20,6 +22,7 @@ if (EKAT_TEST_SINGLE_PRECISION)
   # Test kokkos utils
   EkatCreateUnitTest(kokkos_utils${SP_POSTFIX} kokkos_utils_tests.cpp
     LIBS ekat
+    PRINT_OMP_AFFINITY
     COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC}
   )
@@ -27,6 +30,7 @@ if (EKAT_TEST_SINGLE_PRECISION)
   # Test workspace manager
   EkatCreateUnitTest(wsm${SP_POSTFIX} workspace_tests.cpp
     LIBS ekat
+    PRINT_OMP_AFFINITY
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC}
   )


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We've been bitten in the past by tests not spreading correctly. Adding a simple option to test-launcher we can ask to print the OpenMP env and the threads affinity. For simplicity, I also added an option to EkatCreateUnitTest, that allows to trigger this behavior from inside a project's cmake script.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added the `PRINT_OMP_AFFINITY` option to the kokkos folder tests, and verified omp env and thread affinity is printed.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
