### PR TITLE
test-launcher: A number of minor improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ option (EKAT_DEFAULT_BFB "Whether EKAT should default to BFB behavior whenever p
 option (EKAT_ENABLE_VALGRIND "Whether to run tests with valgrind" OFF)
 option (EKAT_ENABLE_CUDA_MEMCHECK "Whether to run tests with cuda-memcheck" OFF)
 option (EKAT_ENABLE_COVERAGE "Whether to enable code coverage" OFF)
+option (EKAT_TEST_LAUNCHER_NO_BUFFER "Whether test-launcher should buffer all out and print all at once. Useful for avoiding interleaving output when multiple tests are running concurrently" OFF)
 
 if (EKAT_ENABLE_COVERAGE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   message(FATAL_ERROR "Code coverage will only work with Debug build type")

--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -59,14 +59,13 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None, dry_run=False,
             output = output.strip()
         except AttributeError:
             print("Something funky for output")
-            pass
+
     if errput is not None:
         try:
             errput = errput.decode('utf-8', errors='ignore')
             errput = errput.strip()
         except AttributeError:
             print("Something funky for errput")
-            pass
 
     stat = proc.wait()
 
@@ -90,12 +89,14 @@ OR
     )
 
     parser.add_argument("-e","--executable", help="The name of the executable to run",required=True)
+    parser.add_argument("-b","--buffer-output", action="store_true",
+                        help="Buffer all out and print all at once. Useful for avoiding interleaving output when multiple tests are running concurrently")
     parser.add_argument("-p","--print-omp-affinity", help="Print threads affinity at runtime",action="store_true")
 
     return parser.parse_known_args(args[1:])
 
 ###############################################################################
-def run_test(executable,print_omp_affinity,exec_args):
+def run_test(executable,buffer_output,print_omp_affinity,exec_args):
 ###############################################################################
 
     print("execname: {}".format(executable))
@@ -139,7 +140,7 @@ def run_test(executable,print_omp_affinity,exec_args):
         expect (my_res_name=="devices", "Error! My ctest resource group should be 'devices'.")
         key += "_DEVICES"
         expect(key in env, "Error! CTEST_RESOURCE_GROUP_{} found in the env, but can't find {}".format(my_res_id,key))
-        my_res_str = env[key];
+        my_res_str = env[key]
 
         # Split the CTEST_RESOURCE_GROUP_[N]_DEVICE string into tokens, and get the slots ids
         my_res = my_res_str.split(';')
@@ -176,7 +177,7 @@ def run_test(executable,print_omp_affinity,exec_args):
     cmd += " {}".format(executable)
     cmd += " {}".format(" ".join(exec_args))
 
-    if "SCREAM_TEST_LAUNCHER_NO_BUFFER" in env:
+    if buffer_output:
         stat, out, _ = run_cmd(cmd,verbose=True,combine_output=True,env=env)
         sys.stdout.flush()
         sys.stdout.write(out)

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -233,11 +233,16 @@ function(EkatCreateUnitTest target_name target_srcs)
   # Loop over MPI/OpenMP configs, and create tests #
   #------------------------------------------------#
 
+  # Set up launcher prefix
+  set(launcher "${CMAKE_BINARY_DIR}/bin/test-launcher")
   if (ecut_PRINT_OMP_AFFINITY)
-    set (launcher "${CMAKE_BINARY_DIR}/bin/test-launcher -p -e")
-  else()
-    set (launcher "${CMAKE_BINARY_DIR}/bin/test-launcher -e")
+    string(APPEND launcher " -p")
   endif()
+  if (EKAT_TEST_LAUNCHER_NO_BUFFER)
+    string(APPEND launcher " -b")
+  endif()
+  string(APPEND launcher " -e")
+
   if (ecut_EXE_ARGS)
     set(invokeExec "./${target_name} ${ecut_EXE_ARGS}")
   else()


### PR DESCRIPTION
1) Fix spelling of funky
2) Respect user env settings for OMP vars if they are already set
3) Stringify and sort ids, this will remove leading zeroes
4) Add support for buffered output. This is important if we are running
   multiple tests simultaneously with verbosity

These changes are needed for the upcoming psutil/taskset changes to test-all-scream.

## Motivation

These changes are needed for the upcoming psutil/taskset changes to test-all-scream.

## Testing

Tested via scripts-tests (TestTestAllScream.test_mpirank_and_thread_spreading)