### PR TITLE
Store a WS name to print with kernel assertions

### DIFF
--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -116,7 +116,7 @@ class WorkspaceManager
   //
   // Returns a Workspace object which provides access to sub-blocks.
   KOKKOS_INLINE_FUNCTION
-  Workspace get_workspace(const MemberType& team) const;
+  Workspace get_workspace(const MemberType& team, const char* name = "") const;
 
   // call from device
   //
@@ -251,7 +251,7 @@ class WorkspaceManager
 #endif
 
     KOKKOS_INLINE_FUNCTION
-    Workspace(const WorkspaceManager& parent, int ws_idx, const MemberType& team);
+    Workspace(const WorkspaceManager& parent, int ws_idx, const MemberType& team, const char* ws_name);
 
     friend struct unit_test::UnitWrap;
     friend class WorkspaceManager;
@@ -260,6 +260,7 @@ class WorkspaceManager
     const MemberType& m_team;
     const int m_ws_idx; // Workspace idx for m_team
     int& m_next_slot; // the next free ws slot to allocate
+    const char* m_ws_name;
   }; // class Workspace
 
 #ifndef KOKKOS_ENABLE_CUDA


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The calls to `EKAT_KERNEL_ASSERT` in the Workspace class did not help to see where the error originated. With this mod, one can attach a name to a Workspace when requesting it from the WSM, which will be printed after `KERNEL CHECK FAILED`. If the downstream app is using workspaces in several places of the code, this can help to narrow it down (provided the user gives names to the workspaces). 
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I hacked the wsm unit test, adding a string to a ws, and requesting more slots than available, and verified that the ws string was printed to screen after `KERNEL CHECK FAILED`.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
