### PR TITLE
test-launcher: more updates

### DIFF
--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -75,20 +75,19 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None, dry_run=False,
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n{0} <executable>
+        usage="""\n{0} -- <executable> [<exe-args>]
 OR
 {0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Lightweight python wrapper for a test that handles thread binding.\033[0m
-    > {0} ./my_exec
+    > {0} -- ./my_exec
 
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    parser.add_argument("-e","--executable", help="The name of the executable to run",required=True)
     parser.add_argument("-b","--buffer-output", action="store_true",
                         help="Buffer all out and print all at once. Useful for avoiding interleaving output when multiple tests are running concurrently")
     parser.add_argument("-p","--print-omp-affinity", help="Print threads affinity at runtime",action="store_true")
@@ -96,10 +95,11 @@ OR
     return parser.parse_known_args(args[1:])
 
 ###############################################################################
-def run_test(executable,buffer_output,print_omp_affinity,exec_args):
+def run_test(buffer_output,print_omp_affinity,exec_args):
 ###############################################################################
 
-    print("execname: {}".format(executable))
+    expect(exec_args, "Nothing to run?")
+    print("execname: {}".format(exec_args[1]))
 
     env = os.environ
 
@@ -163,19 +163,19 @@ def run_test(executable,buffer_output,print_omp_affinity,exec_args):
         ids_per_rank = int(len(ids) / nranks)
         my_ids = ids[myrank*ids_per_rank : (myrank+1)*ids_per_rank]
 
-        # Start placing on the correct cpu set
-        cmd += " taskset -c " + ",".join(my_ids)
-
         # This file is to be run through cmake's configure_file, which will expand the
         # variable TEST_LAUNCHER_ON_GPU to either True or False
         if ${TEST_LAUNCHER_ON_GPU}:
             expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
             exec_args.append(" --ekat-kokkos-device {}".format(ids[0]))
+        else:
+            # Start placing on the correct cpu set
+            cmd += " taskset -c " + ",".join(my_ids)
+
     else:
         print ("NO RESOURCE SPECS")
 
-    cmd += " {}".format(executable)
-    cmd += " {}".format(" ".join(exec_args))
+    cmd += " {}".format(" ".join(exec_args[1:]))
 
     if buffer_output:
         stat, out, _ = run_cmd(cmd,verbose=True,combine_output=True,env=env)

--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -98,8 +98,8 @@ OR
 def run_test(buffer_output,print_omp_affinity,exec_args):
 ###############################################################################
 
-    expect(exec_args, "Nothing to run?")
-    print("execname: {}".format(exec_args[1]))
+    expect(len(exec_args) >= 2 and exec_args[0] == "--",
+           "Expected exec_args='-- <exe> [<exe-args>], got: {}".format(exec_args))
 
     env = os.environ
 

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -241,7 +241,7 @@ function(EkatCreateUnitTest target_name target_srcs)
   if (EKAT_TEST_LAUNCHER_NO_BUFFER)
     string(APPEND launcher " -b")
   endif()
-  string(APPEND launcher " -e")
+  string(APPEND launcher " --")
 
   if (ecut_EXE_ARGS)
     set(invokeExec "./${target_name} ${ecut_EXE_ARGS}")


### PR DESCRIPTION
1) Refactor argument handling to avoid conflicts with options for
the executable. Use -- instead of -e.
2) Do not use taskset on GPU machines. taskset is for specifying CPUs
but the incoming data from the ctest resource file is specific to GPUs,
so it makes no sense to use that same data for tasksetting.

## Motivation

This is part of the effort to get things working on Lassen.

## Testing

./scripts-tests -f -m mappy TestTestAllScream.test_mpirank_and_thread_spreading