### PR TITLE
For Catch2 unit tests, suppress colored output in ctest tests

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -254,6 +254,10 @@ function(EkatCreateUnitTest test_name test_srcs)
   else()
     set(invokeExec "./${target_name}")
   endif()
+  if (NOT ecut_EXCLUDE_MAIN_CPP)
+    set (invokeExec "${invokeExec} --use-colour no")
+  endif()
+
 
   foreach (NRANKS RANGE ${MPI_START_RANK} ${MPI_END_RANK} ${MPI_INCREMENT})
     foreach (NTHREADS RANGE ${THREAD_START} ${THREAD_END} ${THREAD_INCREMENT})


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
While the colors are nice when running tests manually, they create awful strings when the output is redirected to a file (like the LastTest.log file that ctest generates). E.g.,

```
^[[1;31m^[[0m^[[1;33m^[[0m^[[1;32m===============================================================================^[[0m
^[[1;32mAll tests passed^[[0m
```
In the macro `EkatCreateUnitTest`, we suppress colors in the test output if we are linking `ekat_catch_main`. Notice that this only affects output when running `ctest`. If one runs the executable manually, the colors are still used (unless the `--use-colour no` option is used).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually verified it works.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
