### PR TITLE
--kokkos-ndevices -> --kokkos-num-devices

### DIFF
--- a/src/ekat/ekat_session.cpp
+++ b/src/ekat/ekat_session.cpp
@@ -30,7 +30,7 @@ void initialize_kokkos () {
     nd = 1;
   }
   std::stringstream ss;
-  ss << "--kokkos-ndevices=" << nd;
+  ss << "--kokkos-num-devices=" << nd;
   const auto key = ss.str();
   std::vector<char> str(key.size()+1);
   std::copy(key.begin(), key.end(), str.begin());


### PR DESCRIPTION
With the Kokkos versions that ship with EKAT and E3SM, we see the warning
```
Warning: command line argument '--kokkos-ndevices' is deprecated. Use '--kokkos-num-devices' instead. Raised by Kokkos::initialize(int narg, char* argc[]).
```
when initializing Cuda. This PR fixes this.