### PR TITLE
Split EkatCreateUnitTest in two macros

### DIFF
--- a/tests/ekat_test_config.h.in
+++ b/tests/ekat_test_config.h.in
@@ -10,7 +10,7 @@
 
 #ifdef EKAT_TEST_DOUBLE_PRECISION
 using Real = double;
-#elif EKAT_TEST_SINGLE_PRECISION
+#elif defined(EKAT_TEST_SINGLE_PRECISION)
 using Real = float;
 #endif
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
A recent change made it possible to create a unit test with an existing executable. However, the user still had to pass an empty argument for the exec sources. This PR fixes this, by splitting the existing macro into two macros: one to create the executable (`EkatCreateUnitTestExec`), and the other to create the tests (`EkatCreateUnitTestFromExec`). The old macro `EkatCreateUnitTest` is still available (but does not support the `TEST_EXE` optional arg anymore), and simply calls the other two in sequence (plus some logic to split the optional arg among the two macros).

To create structurally different tests with the same exec, one can now do
```
EkatCreateUnitTestExec(my_exe src1 [src2..] <options_for_building_exec> )

EkatCreateUnitTestFromExec (test1 my_exe <options_for_test1>)
EkatCreateUnitTestFromExec (test2 my_exe <options_for_test2>)
```
or even
```
EkatCreateUnitTest (test1 src1 [src2] <options_for_building_exec> <options_for_test1>)
EkatCreateUnitTestFromExec (test2 test1 <options_for_test2>)
```
(`EkatCreateUnitTest` makes the exec name coincide with the root test name).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually verified that the two macros work as expected. All existing EKAT tests use the old macro, which is now implemented in terms of the two new ones, making them "tested".
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
