### PR TITLE
Add default constructor and setup() to WSM

### DIFF
--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -321,6 +321,7 @@ class WorkspaceManager
 
   TeamUtils<T,ExeSpace> m_tu;
   int m_max_ws_idx, m_reserve, m_size, m_total, m_max_used;
+  bool is_initialized=false;
 #ifndef NDEBUG
   view_1d<int> m_num_used;
   view_1d<int> m_high_water;

--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -80,6 +80,9 @@ class WorkspaceManager
   //
 
   // Constructor, call from host
+  WorkspaceManager() = default;
+
+  // Constructor, call from host
   //   size: The number of T's per sub-block
   //   max_used: The maximum number of active sub-blocks
   //   policy: The team policy for Kokkos kernels using this WorkspaceManager
@@ -109,6 +112,19 @@ class WorkspaceManager
   // Will report usage statistics for your workspaces. These statistics will
   // have much more detail for debug builds.
   void report() const;
+
+  // call from host.
+  //
+  // Setup routine for the WSM if the user used the empty constructor
+  void setup(int size, int max_used, TeamPolicy policy,
+             const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
+
+  // call from host.
+  //
+  // Setup routine for the WSM if the user used the empty constructor.
+  // Same as above, but here the user initializes the data.
+  void setup(T* data, int size, int max_used, TeamPolicy policy,
+             const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
 
   class Workspace;
 

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -15,23 +15,16 @@ namespace ekat {
 
 template <typename T, typename D>
 WorkspaceManager<T, D>::WorkspaceManager(int size, int max_used, TeamPolicy policy,
-                                         const double& overprov_factor) :
-  m_tu(policy, overprov_factor)
+                                         const double& overprov_factor)
 {
-  compute_internals(size, max_used);
-  m_data = decltype(m_data) (Kokkos::ViewAllocateWithoutInitializing("Workspace.m_data"),
-                             m_max_ws_idx, m_total*m_max_used);
-  init_all_metadata(m_max_ws_idx, m_max_used);
+  setup(size, max_used, policy, overprov_factor);
 }
 
 template <typename T, typename D>
 WorkspaceManager<T, D>::WorkspaceManager(T* data, int size, int max_used,
-                                         TeamPolicy policy, const double& overprov_factor) :
-  m_tu(policy, overprov_factor)
+                                         TeamPolicy policy, const double& overprov_factor)
 {
-  compute_internals(size, max_used);
-  m_data = decltype(m_data) (data, m_max_ws_idx, m_total*m_max_used);
-  init_all_metadata(m_max_ws_idx, m_max_used);
+  setup(data, size, max_used, policy, overprov_factor);
 }
 
 template <typename T, typename D>

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -2,6 +2,7 @@
 #define EKAT_WSM_IMPL_HPP
 
 #include "ekat/ekat_assert.hpp"
+#include "ekat/ekat_workspace.hpp"
 
 #include <map>
 
@@ -122,6 +123,29 @@ void WorkspaceManager<T, D>::report() const
               << data.takes << " takes and " << data.releases << " releases." << std::endl;
   }
 #endif
+}
+
+template <typename T, typename D>
+void WorkspaceManager<T, D>::setup (int size, int max_used, TeamPolicy policy,
+                                    const double& overprov_factor)
+{
+  m_tu = TeamUtils<T,ExeSpace>(policy, overprov_factor);
+
+  compute_internals(size, max_used);
+  m_data = decltype(m_data) (Kokkos::ViewAllocateWithoutInitializing("Workspace.m_data"),
+                             m_max_ws_idx, m_total*m_max_used);
+  init_all_metadata(m_max_ws_idx, m_max_used);
+}
+
+template <typename T, typename D>
+void WorkspaceManager<T, D>::setup (T* data, int size, int max_used, TeamPolicy policy,
+                                    const double& overprov_factor)
+{
+  m_tu = TeamUtils<T,ExeSpace>(policy, overprov_factor);
+
+  compute_internals(size, max_used);
+  m_data = decltype(m_data) (data, m_max_ws_idx, m_total*m_max_used);
+  init_all_metadata(m_max_ws_idx, m_max_used);
 }
 
 template <typename T, typename D>

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -441,16 +441,6 @@ class TeamUtils : public TeamUtilsCommonBase<ValueType, ExeSpace>
   TeamUtils(const TeamPolicy& policy, const double& = 1.0) :
     TeamUtilsCommonBase<ValueType, ExeSpace>(policy)
   { }
-
-  TeamUtils& operator= (const TeamUtils& src)
-  {
-    this->_team_size = src._team_size;
-    this->_num_teams = src._num_teams;
-    this->_max_threads = src._max_threads;
-    this->_league_size = src._league_size;
-
-    return *this;
-  }
 };
 
 /*
@@ -467,16 +457,6 @@ class TeamUtils<ValueType, Kokkos::OpenMP> : public TeamUtilsCommonBase<ValueTyp
   TeamUtils(const TeamPolicy& policy, const double& = 1.0) :
     TeamUtilsCommonBase<ValueType,Kokkos::OpenMP>(policy)
   { }
-
-  TeamUtils& operator= (const TeamUtils& src)
-  {
-    this->_team_size = src._team_size;
-    this->_num_teams = src._num_teams;
-    this->_max_threads = src._max_threads;
-    this->_league_size = src._league_size;
-
-    return *this;
-  }
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION
@@ -519,21 +499,6 @@ class TeamUtils<ValueType,Kokkos::Cuda> : public TeamUtilsCommonBase<ValueType,K
     if (_need_ws_sharing) {
       _rand_pool = RandomGenerator(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     }
-  }
-
-  TeamUtils& operator= (const TeamUtils& src)
-  {
-    this->_num_ws_slots = src._num_ws_slots;
-    this->_need_ws_sharing = src._need_ws_sharing;
-    this->_open_ws_slots = src._open_ws_slots;
-    this->_rand_pool = src._rand_pool;
-
-    this->_team_size = src._team_size;
-    this->_num_teams = src._num_teams;
-    this->_max_threads = src._max_threads;
-    this->_league_size = src._league_size;
-
-    return *this;
   }
 
   // How many ws slots are there

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -382,6 +382,8 @@ class TeamUtilsCommonBase
 protected:
   int _team_size, _num_teams, _max_threads, _league_size;
 
+  TeamUtilsCommonBase() = default;
+
   template <typename TeamPolicy>
   TeamUtilsCommonBase(const TeamPolicy& policy)
   {
@@ -433,10 +435,22 @@ template <typename ValueType, typename ExeSpace = Kokkos::DefaultExecutionSpace>
 class TeamUtils : public TeamUtilsCommonBase<ValueType, ExeSpace>
 {
  public:
+  TeamUtils() = default;
+
   template <typename TeamPolicy>
   TeamUtils(const TeamPolicy& policy, const double& = 1.0) :
     TeamUtilsCommonBase<ValueType, ExeSpace>(policy)
   { }
+
+  TeamUtils& operator= (const TeamUtils& src)
+  {
+    this->_team_size = src._team_size;
+    this->_num_teams = src._num_teams;
+    this->_max_threads = src._max_threads;
+    this->_league_size = src._league_size;
+
+    return *this;
+  }
 };
 
 /*
@@ -447,10 +461,22 @@ template <typename ValueType>
 class TeamUtils<ValueType, Kokkos::OpenMP> : public TeamUtilsCommonBase<ValueType,Kokkos::OpenMP>
 {
  public:
+  TeamUtils() = default;
+
   template <typename TeamPolicy>
   TeamUtils(const TeamPolicy& policy, const double& = 1.0) :
     TeamUtilsCommonBase<ValueType,Kokkos::OpenMP>(policy)
   { }
+
+  TeamUtils& operator= (const TeamUtils& src)
+  {
+    this->_team_size = src._team_size;
+    this->_num_teams = src._num_teams;
+    this->_max_threads = src._max_threads;
+    this->_league_size = src._league_size;
+
+    return *this;
+  }
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION
@@ -478,6 +504,8 @@ class TeamUtils<ValueType,Kokkos::Cuda> : public TeamUtilsCommonBase<ValueType,K
   RandomGenerator _rand_pool;
 
  public:
+  TeamUtils() = default;
+
   template <typename TeamPolicy>
   TeamUtils(const TeamPolicy& policy, const double& overprov_factor = 1.0) :
     TeamUtilsCommonBase<ValueType,Kokkos::Cuda>(policy),
@@ -491,6 +519,21 @@ class TeamUtils<ValueType,Kokkos::Cuda> : public TeamUtilsCommonBase<ValueType,K
     if (_need_ws_sharing) {
       _rand_pool = RandomGenerator(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     }
+  }
+
+  TeamUtils& operator= (const TeamUtils& src)
+  {
+    this->_num_ws_slots = src._num_ws_slots;
+    this->_need_ws_sharing = src._need_ws_sharing;
+    this->_open_ws_slots = src._open_ws_slots;
+    this->_rand_pool = src._rand_pool;
+
+    this->_team_size = src._team_size;
+    this->_num_teams = src._num_teams;
+    this->_max_threads = src._max_threads;
+    this->_league_size = src._league_size;
+
+    return *this;
   }
 
   // How many ws slots are there

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -380,7 +380,7 @@ template <typename ValueType, typename ExeSpace = Kokkos::DefaultExecutionSpace>
 class TeamUtilsCommonBase
 {
 protected:
-  int _team_size, _num_teams, _max_threads, _league_size;
+  int _team_size=0, _num_teams, _max_threads, _league_size;
 
   TeamUtilsCommonBase() = default;
 
@@ -408,13 +408,25 @@ protected:
 public:
 
   // How many thread teams can run concurrently
-  int get_num_concurrent_teams() const { return _num_teams; }
+  int get_num_concurrent_teams() const
+  {
+    EKAT_ASSERT_MSG (_team_size>0, "Error! TeamUtils not yet inited.\n");
+    return _num_teams;
+  }
 
   // How many threads can run concurrently
-  int get_max_concurrent_threads() const { return _max_threads; }
+  int get_max_concurrent_threads() const
+  {
+    EKAT_ASSERT_MSG (_team_size>0, "Error! TeamUtils not yet inited.\n");
+    return _max_threads;
+  }
 
   // How many ws slots are there
-  int get_num_ws_slots() const { return _num_teams; }
+  int get_num_ws_slots() const
+  {
+    EKAT_ASSERT_MSG (_team_size>0, "Error! TeamUtils not yet inited.\n");
+    return _num_teams;
+  }
 
   /*
    * Of the C concurrently running teams, which "slot" is open
@@ -508,7 +520,11 @@ class TeamUtils<ValueType,Kokkos::Cuda> : public TeamUtilsCommonBase<ValueType,K
   TeamUtils& operator= (const TeamUtils& src) = default;
 
   // How many ws slots are there
-  int get_num_ws_slots() const { return _num_ws_slots; }
+  int get_num_ws_slots() const
+  {
+    EKAT_ASSERT_MSG (_team_size>0, "Error! TeamUtils not yet inited.\n");
+    return _num_ws_slots;
+  }
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -150,7 +150,7 @@ void view_reduction (const TeamMember& team,
       result += ekat::reduce_sum<Serialize>(packed_result);
     }
   }
-      
+
   // If last pack has garbage, we did not include it in the main reduction,
   // so manually add the last pack (only the non-garbage part)
   if (has_garbage_end) {
@@ -441,6 +441,8 @@ class TeamUtils : public TeamUtilsCommonBase<ValueType, ExeSpace>
   TeamUtils(const TeamPolicy& policy, const double& = 1.0) :
     TeamUtilsCommonBase<ValueType, ExeSpace>(policy)
   { }
+
+  TeamUtils& operator= (const TeamUtils& src) = default;
 };
 
 /*
@@ -457,6 +459,8 @@ class TeamUtils<ValueType, Kokkos::OpenMP> : public TeamUtilsCommonBase<ValueTyp
   TeamUtils(const TeamPolicy& policy, const double& = 1.0) :
     TeamUtilsCommonBase<ValueType,Kokkos::OpenMP>(policy)
   { }
+
+  TeamUtils& operator= (const TeamUtils& src) = default;
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION
@@ -500,6 +504,8 @@ class TeamUtils<ValueType,Kokkos::Cuda> : public TeamUtilsCommonBase<ValueType,K
       _rand_pool = RandomGenerator(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     }
   }
+
+  TeamUtils& operator= (const TeamUtils& src) = default;
 
   // How many ws slots are there
   int get_num_ws_slots() const { return _num_ws_slots; }

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -477,7 +477,10 @@ class TeamUtils<ValueType, Kokkos::OpenMP> : public TeamUtilsCommonBase<ValueTyp
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION
   int get_workspace_idx(const MemberType& /*team_member*/) const
-  { return omp_get_thread_num() / this->_team_size; }
+  {
+    EKAT_KERNEL_ASSERT_MSG (this->_team_size>0, "Error! TeamUtils not yet inited.\n");
+    return omp_get_thread_num() / this->_team_size;
+  }
 };
 #endif
 
@@ -522,7 +525,7 @@ class TeamUtils<ValueType,Kokkos::Cuda> : public TeamUtilsCommonBase<ValueType,K
   // How many ws slots are there
   int get_num_ws_slots() const
   {
-    EKAT_ASSERT_MSG (_team_size>0, "Error! TeamUtils not yet inited.\n");
+    EKAT_ASSERT_MSG (this->_team_size>0, "Error! TeamUtils not yet inited.\n");
     return _num_ws_slots;
   }
 
@@ -530,6 +533,8 @@ class TeamUtils<ValueType,Kokkos::Cuda> : public TeamUtilsCommonBase<ValueType,K
   KOKKOS_INLINE_FUNCTION
   int get_workspace_idx(const MemberType& team_member) const
   {
+    EKAT_KERNEL_ASSERT_MSG (this->_num_teams>0, "Error! TeamUtils not yet inited.\n");
+
     if (!_need_ws_sharing) {
       return team_member.league_rank();
     }


### PR DESCRIPTION
Add an empty constructor and a setup() function to WSM

## Motivation
In SCREAM AD, we were having to construct a WSM object inside the `run_impl()` of various processes, which often was a significant amount of time. This is unnecessary since at initialization we have all the info needed for the WSM construction. To make the WSM a class variable we need an empty constructor with a setup method.

## Testing
I added a test that makes sure the empty constructor+setup() correctly sets size and can take and release blocks

## Additional Information
I needed to add an empty constructor for `TeamUtils` and `TeamUtilsCommonBase` as well.