### PR TITLE
Some meta-utils for type-list related metaprogramming

### DIFF
--- a/src/ekat/util/ekat_meta_utils.hpp
+++ b/src/ekat/util/ekat_meta_utils.hpp
@@ -14,7 +14,7 @@ using TypeList = std::tuple<Ts...>;
 template<typename TL>
 struct type_list_size : std::tuple_size<TL> {};
 
-// Cat two type lists
+// Concatenate two type lists
 template<typename TL1, typename TL2>
 struct CatTypeLists;
 

--- a/src/ekat/util/ekat_meta_utils.hpp
+++ b/src/ekat/util/ekat_meta_utils.hpp
@@ -1,0 +1,165 @@
+#ifndef EKAT_META_UTILS_HPP
+#define EKAT_META_UTILS_HPP
+
+#include <tuple>
+
+namespace ekat
+{
+
+// A parameter pack. To be used for template specializations
+template<typename... Ts>
+struct TypeList;
+
+template<typename T>
+struct TypeList<T> {
+  using head = T;
+  static constexpr int size = 1;
+};
+
+template<typename T, typename... Ts>
+struct TypeList<T,Ts...> {
+private:
+  using tail = TypeList<Ts...>;
+public:
+  using head = T;
+  static constexpr int size = 1 + tail::size;
+};
+
+// Cat two packs
+template<typename P1, typename P2>
+struct CatLists;
+
+template<typename... T1s, typename... T2s>
+struct CatLists<TypeList<T1s...>,TypeList<T2s...>> {
+  using type = TypeList<T1s...,T2s...>;
+};
+
+// Find position of first occurrence of type T in a TypeList, store in 'pos'.
+// If not found, set pos = -1.
+template<typename T, typename TypeList>
+struct FirstOf;
+
+template<typename T, typename H>
+struct FirstOf<T,TypeList<H>> {
+  static constexpr int pos = std::is_same<H,T>::value ? 0 : -1;
+};
+
+template<typename T, typename H, typename... Ts>
+struct FirstOf<T,TypeList<H,Ts...>> {
+private:
+  static constexpr int tail_pos = FirstOf<T,TypeList<Ts...>>::pos;
+public:
+  static constexpr int pos = std::is_same<H,T>::value ? 0 : (tail_pos>=0 ? 1+tail_pos : -1);
+};
+
+// Check if a TypeList contains unique types
+template<typename P>
+struct UniqueTypeList;
+
+template<typename T>
+struct UniqueTypeList<TypeList<T>> : std::true_type {};
+
+template<typename T, typename... Ts>
+struct UniqueTypeList<TypeList<T,Ts...>> {
+  static constexpr bool value = FirstOf<T,TypeList<Ts...>>::pos==-1 &&
+                                UniqueTypeList<TypeList<Ts...>>::value;
+};
+
+// Access N-th entry of a pack
+template<typename P, int N>
+struct AccessList;
+
+template<typename T, typename... Ts, int N>
+struct AccessList <TypeList<T,Ts...>,N> {
+private:
+  using pack = TypeList<T,Ts...>;
+  using tail = TypeList<Ts...>;
+  static_assert (N>=0 && N<pack::size, "Error! Index out of bounds.\n");
+
+public:
+  using type = typename AccessList<tail,N-1>::type;
+};
+
+template<typename T, typename... Ts>
+struct AccessList <TypeList<T,Ts...>,0> {
+  using type = T;
+};
+
+// A map of types
+template<typename KP, typename VP>
+struct TypeMap;
+
+template<typename... Ks, typename... Vs>
+struct TypeMap<TypeList<Ks...>,TypeList<Vs...>> : public std::tuple<Vs...> {
+  using keys = TypeList<Ks...>;
+  using vals = TypeList<Vs...>;
+  using self = TypeMap<keys,vals>;
+  static_assert (keys::size==vals::size, "Error! Keys and values have different sizes.\n");
+  static_assert (UniqueTypeList<keys>::value, "Error! Keys are not unique.\n");
+
+  template<typename K>
+  struct AtHelper {
+    static constexpr int pos = FirstOf<K,keys>::pos;
+    static_assert(pos>=0, "Error! Input type not found in this TypeMap.\n");
+    // For pos<0, expose whatever you want. This helper won't compile anyways
+    using type = typename std::conditional<pos<0,void,typename AccessList<vals,pos>::type>::type;
+  };
+
+  template<typename K>
+  using at_t = typename AtHelper<K>::type;
+
+  template<typename K>
+  at_t<K>& at () { return std::get<AtHelper<K>::pos>(*this); }
+
+  static constexpr int size = keys::size;
+};
+
+// Given a class template C, and a pack of template args T1,...,Tn,
+// create a pack containing the C<T1>,...,C<Tn>
+template<template<typename> class C, typename P>
+struct ApplyTemplate;
+
+template<template<typename> class C, typename T>
+struct ApplyTemplate<C,TypeList<T>> {
+  using type = TypeList<C<T>>;
+};
+
+template<template<typename> class C, typename T, typename... Ts>
+struct ApplyTemplate<C,TypeList<T,Ts...>> {
+private:
+  using head = TypeList<C<T>>;
+  using tail = typename ApplyTemplate<C,TypeList<Ts...>>::type;
+public:
+  using type = typename CatLists<head,tail>::type;
+};
+
+// Iterate over a TypeList
+// Requires a generic lambda that only accept an instance of the
+// pack types. Can only use input to deduce its type.
+//  auto l = [&](auto t) {
+//    using T = decltype(t);
+//    call_some_func<T>(...);
+//  };
+template<typename P>
+struct TypeListFor;
+
+template<typename T>
+struct TypeListFor<TypeList<T>> {
+  template<typename Lambda>
+  constexpr TypeListFor (Lambda&& l) {
+    l(T());
+  }
+};
+
+template<typename T, typename...Ts>
+struct TypeListFor<TypeList<T,Ts...>> {
+  template<typename Lambda>
+  constexpr TypeListFor (Lambda&& l) {
+    l(T());
+    TypeListFor<TypeList<Ts...>> pf(l);
+  }
+};
+
+} // namespace ekat
+
+#endif // EKAT_META_UTILS_HPP

--- a/src/ekat/util/ekat_meta_utils.hpp
+++ b/src/ekat/util/ekat_meta_utils.hpp
@@ -214,7 +214,8 @@ private:
     bool found = false;
     TypeListFor<keys>([&](auto t){
       using key_t = decltype(t);
-      const auto& value = map.at<key_t>();
+
+      const auto& value = map.template at<key_t>();
       if (check_eq(v,value)) {
         found = true;
         return;

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -5,6 +5,10 @@ EkatCreateUnitTest(debug_tools debug_tools_tests.cpp
   LIBS ekat)
 
 # Test utilities (c++)
+EkatCreateUnitTest(meta_utils meta_utils.cpp
+  LIBS ekat)
+
+# Test utilities (c++)
 EkatCreateUnitTest(util_cxx util_tests.cpp
   LIBS ekat)
 

--- a/tests/utils/meta_utils.cpp
+++ b/tests/utils/meta_utils.cpp
@@ -14,73 +14,108 @@ TEST_CASE ("meta_utils") {
   using L1 = TypeList<int,float,double>;
   using L2 = TypeList<char,void>;
   using L3 = TypeList<int,char>;
+  using L4 = TypeList<int,float,double>;
+  using L5 = TypeList<std::string,std::string,std::string>;
 
-  SECTION ("base") {
+  SECTION ("type_list") {
+    // Check size is correct
     REQUIRE (std::is_same<L1::head,int>::value);
     constexpr int L1size = L1::size;
     REQUIRE (L1size==3);
-  }
 
-  SECTION ("cat") {
+    // Check concat of two lists equals list of union of their types
     using L1L2 = typename CatLists<L1,L2>::type;
     REQUIRE (std::is_same<L1L2,TypeList<int,float,double,char,void>>::value);
     constexpr int L1L2size = L1L2::size;
     REQUIRE (L1L2size==5);
-  }
 
-  SECTION ("unique") {
+    // Check unique returns the expected value
     using L1L2 = typename CatLists<L1,L2>::type;
     using L1L3 = typename CatLists<L1,L3>::type;
 
     REQUIRE (UniqueTypeList<L1L2>::value);
     REQUIRE (not UniqueTypeList<L1L3>::value);
-  }
 
-  SECTION ("first_of") {
+    // Check we can find the first entry of a type in a list (if found)
     constexpr auto f_pos = FirstOf<float,L1>::pos;
     constexpr auto v_pos = FirstOf<void,L1>::pos;
 
     REQUIRE (f_pos==1);
     REQUIRE (v_pos==-1);
-  }
 
-  SECTION ("access") {
+    // Check access of type list
     REQUIRE (std::is_same<typename AccessList<L1,0>::type,int>::value);
     REQUIRE (std::is_same<typename AccessList<L1,1>::type,float>::value);
     REQUIRE (std::is_same<typename AccessList<L1,2>::type,double>::value);
   }
 
   SECTION ("type_map") {
-    using map_t = TypeMap<L2,L3>;
 
+    // Maps int/float/double to a string
+    using map_t = TypeMap<L4,L5>;
+
+    // Check map size
     constexpr auto map_size = map_t::size;
-    REQUIRE (map_size==2);
+    REQUIRE (map_size==3);
 
+    // Check all types in L4 (and only them) are present
+    REQUIRE (map_t::has_t<int>());
+    REQUIRE (map_t::has_t<float>());
+    REQUIRE (map_t::has_t<double>());
+    REQUIRE (not map_t::has_t<char>());
+
+    // Check all types in the map are mapped to a string.
+    // If type not in the string, return NotFound.
+    using NotFound = typename map_t::NotFound;
+    REQUIRE (std::is_same<map_t::at_t<int>,std::string>::value);
+    REQUIRE (std::is_same<map_t::at_t<float>,std::string>::value);
+    REQUIRE (std::is_same<map_t::at_t<double>,std::string>::value);
+    REQUIRE (std::is_same<map_t::at_t<char>,NotFound>::value);
+
+    // Create a map, and fill the mapped values
     map_t map;
-    auto i = map.at<char>();
-    auto c = map.at<void>();
-    REQUIRE (std::is_same<decltype(i),int>::value);
-    REQUIRE (std::is_same<decltype(c),char>::value);
+    map.at<int>() = "int";
+    map.at<float>() = "float";
+    map.at<double>() = "double";
+
+    // Check the map was filled correctly
+    REQUIRE (map.at<int>() == "int");
+    REQUIRE (map.at<float>() == "float");
+    REQUIRE (map.at<double>() == "double");
+
+    // Check we can find the inserted values, and not others
+    // Note: we need do specify <std::string>, otherwise the template
+    //       resolution would use char[], which is not in the mapped
+    //       values typelist, so it would return false.
+    REQUIRE (map.has_v<std::string>("int"));
+    REQUIRE (map.has_v<std::string>("float"));
+    REQUIRE (map.has_v<std::string>("double"));
+    REQUIRE (not map.has_v<std::string>("char"));
+    REQUIRE (not map.has_v(2));
   }
 
   SECTION ("apply_template") {
+    // Given a template type, instantiate it over all types in a type list
     using Templates = typename ApplyTemplate<TestVec,L1>::type;
-    // Templates should be a type list of TestVec<blah> types.
+
     REQUIRE (std::is_same<typename AccessList<Templates,0>::type,TestVec<int>>::value);
     REQUIRE (std::is_same<typename AccessList<Templates,1>::type,TestVec<float>>::value);
     REQUIRE (std::is_same<typename AccessList<Templates,2>::type,TestVec<double>>::value);
   }
 
   SECTION ("list_for") {
+    // Test for loop over a list of types
     using K = L1;
     using V = typename ApplyTemplate<TestVec,K>::type;
     using map_t = TypeMap<K,V>;
 
+    // Create a type map from int/float/double to std::vector, and fill it.
     map_t map;
     map.at<int>().resize(2);
     map.at<float>().resize(3);
     map.at<double>().resize(1);
 
+    // Check the sum of sizes of vectors is 6, by using a for loop over type list
     int size = 0;
     TypeListFor<K>([&](auto t) {
       const auto& m = map.at<decltype(t)>();

--- a/tests/utils/meta_utils.cpp
+++ b/tests/utils/meta_utils.cpp
@@ -18,23 +18,27 @@ TEST_CASE ("meta_utils") {
   using L5 = TypeList<std::string,std::string,std::string>;
 
   SECTION ("type_list") {
+    // Check access of type list
+    REQUIRE (std::is_same<type_list_get<L1,0>,int>::value);
+    REQUIRE (std::is_same<type_list_get<L1,1>,float>::value);
+    REQUIRE (std::is_same<type_list_get<L1,2>,double>::value);
+
     // Check size is correct
-    REQUIRE (std::is_same<L1::head,int>::value);
-    constexpr int L1size = L1::size;
+    REQUIRE (std::is_same<type_list_get<L1,0>,int>::value);
+    constexpr int L1size = type_list_size<L1>::value;
     REQUIRE (L1size==3);
 
     // Check concat of two lists equals list of union of their types
-    using L1L2 = typename CatLists<L1,L2>::type;
+    using L1L2 = type_list_cat<L1,L2>;
+    using L1L3 = type_list_cat<L1,L3>;
+
     REQUIRE (std::is_same<L1L2,TypeList<int,float,double,char,void>>::value);
-    constexpr int L1L2size = L1L2::size;
+    constexpr int L1L2size = type_list_size<L1L2>::value;
     REQUIRE (L1L2size==5);
 
     // Check unique returns the expected value
-    using L1L2 = typename CatLists<L1,L2>::type;
-    using L1L3 = typename CatLists<L1,L3>::type;
-
-    REQUIRE (UniqueTypeList<L1L2>::value);
-    REQUIRE (not UniqueTypeList<L1L3>::value);
+    REQUIRE (is_type_list_unique<L1L2>::value);
+    REQUIRE (not is_type_list_unique<L1L3>::value);
 
     // Check we can find the first entry of a type in a list (if found)
     constexpr auto f_pos = FirstOf<float,L1>::pos;
@@ -42,11 +46,6 @@ TEST_CASE ("meta_utils") {
 
     REQUIRE (f_pos==1);
     REQUIRE (v_pos==-1);
-
-    // Check access of type list
-    REQUIRE (std::is_same<typename AccessList<L1,0>::type,int>::value);
-    REQUIRE (std::is_same<typename AccessList<L1,1>::type,float>::value);
-    REQUIRE (std::is_same<typename AccessList<L1,2>::type,double>::value);
   }
 
   SECTION ("type_map") {
@@ -98,9 +97,9 @@ TEST_CASE ("meta_utils") {
     // Given a template type, instantiate it over all types in a type list
     using Templates = typename ApplyTemplate<TestVec,L1>::type;
 
-    REQUIRE (std::is_same<typename AccessList<Templates,0>::type,TestVec<int>>::value);
-    REQUIRE (std::is_same<typename AccessList<Templates,1>::type,TestVec<float>>::value);
-    REQUIRE (std::is_same<typename AccessList<Templates,2>::type,TestVec<double>>::value);
+    REQUIRE (std::is_same<type_list_get<Templates,0>,TestVec<int>>::value);
+    REQUIRE (std::is_same<type_list_get<Templates,1>,TestVec<float>>::value);
+    REQUIRE (std::is_same<type_list_get<Templates,2>,TestVec<double>>::value);
   }
 
   SECTION ("list_for") {

--- a/tests/utils/meta_utils.cpp
+++ b/tests/utils/meta_utils.cpp
@@ -28,7 +28,7 @@ TEST_CASE ("meta_utils") {
     constexpr int L1size = type_list_size<L1>::value;
     REQUIRE (L1size==3);
 
-    // Check concat of two lists equals list of union of their types
+    // Check concatenation of two lists equals list of union of their types
     using L1L2 = type_list_cat<L1,L2>;
     using L1L3 = type_list_cat<L1,L3>;
 

--- a/tests/utils/meta_utils.cpp
+++ b/tests/utils/meta_utils.cpp
@@ -1,0 +1,92 @@
+#include <catch2/catch.hpp>
+
+#include "ekat/util/ekat_meta_utils.hpp"
+
+// We can't define template alias inside the TEST_CASE block,
+// since, upon macro expansion, those blocks are at function scope.
+
+template<typename T>
+using TestVec = std::vector<T>;
+
+TEST_CASE ("meta_utils") {
+  using namespace ekat;
+
+  using L1 = TypeList<int,float,double>;
+  using L2 = TypeList<char,void>;
+  using L3 = TypeList<int,char>;
+
+  SECTION ("base") {
+    REQUIRE (std::is_same<L1::head,int>::value);
+    constexpr int L1size = L1::size;
+    REQUIRE (L1size==3);
+  }
+
+  SECTION ("cat") {
+    using L1L2 = typename CatLists<L1,L2>::type;
+    REQUIRE (std::is_same<L1L2,TypeList<int,float,double,char,void>>::value);
+    constexpr int L1L2size = L1L2::size;
+    REQUIRE (L1L2size==5);
+  }
+
+  SECTION ("unique") {
+    using L1L2 = typename CatLists<L1,L2>::type;
+    using L1L3 = typename CatLists<L1,L3>::type;
+
+    REQUIRE (UniqueTypeList<L1L2>::value);
+    REQUIRE (not UniqueTypeList<L1L3>::value);
+  }
+
+  SECTION ("first_of") {
+    constexpr auto f_pos = FirstOf<float,L1>::pos;
+    constexpr auto v_pos = FirstOf<void,L1>::pos;
+
+    REQUIRE (f_pos==1);
+    REQUIRE (v_pos==-1);
+  }
+
+  SECTION ("access") {
+    REQUIRE (std::is_same<typename AccessList<L1,0>::type,int>::value);
+    REQUIRE (std::is_same<typename AccessList<L1,1>::type,float>::value);
+    REQUIRE (std::is_same<typename AccessList<L1,2>::type,double>::value);
+  }
+
+  SECTION ("type_map") {
+    using map_t = TypeMap<L2,L3>;
+
+    constexpr auto map_size = map_t::size;
+    REQUIRE (map_size==2);
+
+    map_t map;
+    auto i = map.at<char>();
+    auto c = map.at<void>();
+    REQUIRE (std::is_same<decltype(i),int>::value);
+    REQUIRE (std::is_same<decltype(c),char>::value);
+  }
+
+  SECTION ("apply_template") {
+    using Templates = typename ApplyTemplate<TestVec,L1>::type;
+    // Templates should be a type list of TestVec<blah> types.
+    REQUIRE (std::is_same<typename AccessList<Templates,0>::type,TestVec<int>>::value);
+    REQUIRE (std::is_same<typename AccessList<Templates,1>::type,TestVec<float>>::value);
+    REQUIRE (std::is_same<typename AccessList<Templates,2>::type,TestVec<double>>::value);
+  }
+
+  SECTION ("list_for") {
+    using K = L1;
+    using V = typename ApplyTemplate<TestVec,K>::type;
+    using map_t = TypeMap<K,V>;
+
+    map_t map;
+    map.at<int>().resize(2);
+    map.at<float>().resize(3);
+    map.at<double>().resize(1);
+
+    int size = 0;
+    TypeListFor<K>([&](auto t) {
+      const auto& m = map.at<decltype(t)>();
+      size += m.size();
+    });
+
+    REQUIRE (size==6);
+  }
+}


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This kind of utilities are useful when handling several instantiation of a type, minimizing code duplication. For instance, I'm trying to use them in scream, to handle views of different arithmetic type in a structured way. One can do stuff like:
```
using scalars = TypeList<int,float,double>;
template<typename ST>
using view1d = KokkosTypes<MyDevice>::view_1d<ST>;
using views = ApplyTemplate<view_1d,scalars>::type; // -> TypeList<view1d<int>,view1d<float>,view1d<double>>;

using map_t = TypeMap<scalars,views>;
map_t my_views;
...
my_func(my_views.at<int>());
my_func(my_views.at<float>());
my_func(my_views.at<double>());
```
The last chunk can be done more generically with the `TypeListFor` util:
```
TypeListFor<scalars>([&](auto t){
  using T = decltype(t);
  my_func(my_views.at<T>());
});
```
which allows to add a new scalar type limiting the places in the code where an update is needed. In particular, all places that perform automatic operations on a bunch of different templated instantiations, without really caring about how many there are, or what the template instantiation is, can benefit from an agnostic implementation, which won't change if we add more supported types.

Basically, these meta-utility allow to have tuple-like structure, but access them by a type name rather than an index.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This is making my life easier in a refactor work in SCREAM. Nevertheless, I am putting the PR on hold until I can fully verify that it works well in scream, and that all pieces are indeed needed. Once that's verified (or if another repo/pr could benefit from this work), I will 'unlock' this pr.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a test for all meta-utilities. The only things I could not easily test are the static asserts correctness. I could not figure out a simple _run-time_ way of checking that static asserts fire when the template arguments are bad (the only way would be to use a helper cpp file, and try to compile it). However, I did test their correctness by hand.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
