### PR TITLE
Manage jenkins jobs with repo scripts similar to scream

### DIFF
--- a/scripts/jenkins/jenkins.sh
+++ b/scripts/jenkins/jenkins.sh
@@ -1,0 +1,7 @@
+#! /bin/bash -xe
+
+export JENKINS_SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
+
+set -o pipefail
+$JENKINS_SCRIPT_DIR/jenkins_impl.sh 2>&1 | tee JENKINS_$DATE_STAMP

--- a/scripts/jenkins/jenkins_impl.sh
+++ b/scripts/jenkins/jenkins_impl.sh
@@ -1,0 +1,146 @@
+#! /bin/bash -x
+
+if [ -z "$WORKSPACE" ]; then
+    echo "Must run from Jenkins job"
+fi
+
+cd $WORKSPACE/${BUILD_ID}/
+
+WORK_DIR=$(pwd)
+
+rm -rf ekat-build ekat-install
+
+# setup env, use SCREAM env
+SCREAM_SCRIPTS=${WORK_DIR}/scream/components/scream/scripts
+source ${SCREAM_SCRIPTS}/jenkins/${NODE_NAME}_setup
+source ${SCREAM_SCRIPTS}/source_to_load_scream_env.sh
+
+# Merge origin master, to make sure we're up to date. If merge fails, exit.
+cd ${WORK_DIR}/ekat-src;
+git log -1
+git merge origin/master && cd ${WORK_DIR}
+if [ $? -ne 0 ]; then
+    echo "Error trying to merge origin/master"
+    exit 1;
+fi
+
+# Query scream for machine info
+MPICXX=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE cxx_compiler)
+MPICOM=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE c_compiler)
+MPIF90=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE f90_compiler)
+BATCHP=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE batch)
+COMP_J=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE comp_j)
+TEST_J=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE test_j)
+ISCUDA=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE cuda)
+
+# Build both SP and DP. We build both, even if the first fails,
+# so that we can catch issues of both builds in just one run.
+
+FAILED_SP=""
+FAILED_DP=""
+RET_SP=0
+RET_DP=0
+export CTEST_PARALLEL_LEVEL=${TEST_J}
+EKAT_THREAD_SETTINGS=""
+if [[ "$ISCUDA" == "True" ]]; then
+    EKAT_THREAD_SETTINGS="-DEKAT_TEST_THREAD_INC=2 -DEKAT_TEST_MAX_THREADS=14"
+fi
+
+# Build and test double precision
+mkdir -p ekat-build/ekat-sp && cd ekat-build/ekat-sp && rm -rf *
+
+cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+    -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-sp    \
+    -DCMAKE_BUILD_TYPE=DEBUG                                   \
+    -DCMAKE_CXX_COMPILER=${MPICXX}                             \
+    -DCMAKE_Fortran_COMPILER=${MPIF90}                         \
+    -DEKAT_DISABLE_TPL_WARNINGS=ON                             \
+    -DEKAT_ENABLE_TESTS=ON                                     \
+    -DEKAT_TEST_DOUBLE_PRECISION=OFF                           \
+    -DEKAT_TEST_SINGLE_PRECISION=ON                            \
+    ${EKAT_THREAD_SETTINGS}                                    \
+    ${WORK_DIR}/ekat-src
+
+if [ $? -ne 0 ]; then
+    echo "Something went wrong while configuring the SP case."
+    RET_SP=1
+else
+    make -j ${COMP_J}
+    if [ $? -ne 0 ]; then
+        echo "Something went wrong while building the SP case."
+        RET_SP=1
+    else
+        ${BATCHP} ctest --output-on-failure
+        if [ $? -ne 0 ]; then
+            echo "Something went wrong while testing the SP case."
+            RET_SP=1
+            FAILED_SP=$(cat Testing/Temporary/LastTestsFailed.log)
+        else
+            make install
+            if [ $? -ne 0 ]; then
+                echo "Something went wrong while installing the SP case."
+                RET_SP=1
+            fi
+        fi
+    fi
+fi
+cd ${WORK_DIR}
+
+# Build and test single precision
+mkdir -p ekat-build/ekat-dp && cd ekat-build/ekat-dp && rm -rf *
+
+cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+    -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-dp    \
+    -DCMAKE_BUILD_TYPE=DEBUG                                   \
+    -DCMAKE_CXX_COMPILER=${MPICXX}                             \
+    -DCMAKE_Fortran_COMPILER=${MPIF90}                         \
+    -DEKAT_DISABLE_TPL_WARNINGS=ON                             \
+    -DEKAT_ENABLE_TESTS=ON                                     \
+    -DEKAT_TEST_DOUBLE_PRECISION=ON                            \
+    -DEKAT_TEST_SINGLE_PRECISION=OFF                           \
+    ${EKAT_THREAD_SETTINGS}                                    \
+    ${WORK_DIR}/ekat-src
+
+if [ $? -ne 0 ]; then
+    echo "Something went wrong while configuring the DP case."
+    RET_DP=1
+else
+    make -j ${COMP_J}
+    if [ $? -ne 0 ]; then
+        echo "Something went wrong while building the DP case."
+        RET_DP=1
+    else
+        ${BATCHP} ctest --output-on-failure
+        if [ $? -ne 0 ]; then
+            echo "Something went wrong while testing the DP case."
+            RET_DP=1
+            FAILED_DP=$(cat Testing/Temporary/LastTestsFailed.log)
+        else
+            make install
+            if [ $? -ne 0 ]; then
+                echo "Something went wrong while installing the DP case."
+                RET_SP=1
+            fi
+        fi
+    fi
+fi
+cd ${WORK_DIR}
+
+# Print list of failed tests
+if [[ $RET_SP -ne 0 && "$FAILED_SP" != "" ]]; then
+    echo "List of failed SP tests:"
+    echo "$FAILED_SP"
+fi
+
+if [[ $RET_DP -ne 0 && "$FAILED_DP" != "" ]]; then
+    echo "List of failed DP tests:"
+    echo "$FAILED_DP"
+fi
+
+# Check if both builds succeded, and establish success/fail
+if [[ $RET_SP -ne 0 || $RET_DP -ne 0 ]]; then
+    exit 1;
+fi
+
+# All good, return 0
+exit 0;


### PR DESCRIPTION
Also, leverage utilities from SCREAM to make generalized jenkins script.

## Motivation
Recent churn in the SEMS modules revealed that EKAT was doing its own env loading, independent of what is in SCREAM. As I did some work to ensure that EKAT uses the SCREAM env in AT testing, I saw more opportunities to make the entire EKAT AT system a bit more like SCREAM's, with generalized (instead of machine-specific) test scripts.

I decided it was not worth taking the plunge and driving the scripting with python; things are much simpler on the EKAT side, so we can stick with bash for now, just using simple python tool to pick up needed python config items.

## Testing
Set up a mock Jenkins workspace and ran the new script; it worked.

Jenkins AT jobs have already been updated to reflect these changes.
