### PR TITLE
Add reset() for WSM

### DIFF
--- a/src/ekat/ekat_workspace.hpp
+++ b/src/ekat/ekat_workspace.hpp
@@ -126,6 +126,13 @@ class WorkspaceManager
   void setup(T* data, int size, int max_used, TeamPolicy policy,
              const double& overprov_factor=GPU_DEFAULT_OVERPROVISION_FACTOR);
 
+  // call from host.
+  //
+  // Reset the internal structures that might have changed when taking and releasing blocks.
+  // This is useful when using the WorkspaceManager inside an iterative method, where setup()
+  // is called during an initialization phase, but the WSM is used inside an iteration loop.
+  void reset_internals();
+
   class Workspace;
 
   // call from device

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -148,6 +148,23 @@ void WorkspaceManager<T, D>::setup (T* data, int size, int max_used, TeamPolicy 
 }
 
 template <typename T, typename D>
+void WorkspaceManager<T, D>::reset_internals()
+{
+#ifndef NDEBUG
+  Kokkos::deep_copy(m_active, false);
+  Kokkos::deep_copy(m_counts, 0);
+  Kokkos::deep_copy(m_high_water, 0);
+  Kokkos::deep_copy(m_next_slot, 0);
+#endif
+
+  auto policy = ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_max_ws_idx, m_max_used);
+  Kokkos::parallel_for(
+    "WorkspaceManager reset",
+    policy,
+    *this);
+}
+
+template <typename T, typename D>
 KOKKOS_INLINE_FUNCTION
 typename WorkspaceManager<T, D>::Workspace
 WorkspaceManager<T, D>::get_workspace(const MemberType& team, const char* ws_name) const
@@ -171,7 +188,7 @@ void WorkspaceManager<T, D>::init_all_metadata(const int max_ws_idx, const int m
   auto policy = ExeSpaceUtils<ExeSpace>::get_default_team_policy(max_ws_idx, max_used);
 
   Kokkos::parallel_for(
-    "WorkspaceManager ctor",
+    "WorkspaceManager setup",
     policy,
     *this);
 }


### PR DESCRIPTION
Adds a `WorkspaceManager::reset_internals()`. We need this for using the WSM inside an iterative process where `setup()` occurs in an initialization phase. This new function resets the internal data of the WSM to "start over" working through the allocated data at each iteration.

## Testing
Altered a WSM test case to run over multiple steps.