### PR TITLE
Update spdlog submodule to point to E3SM fork of it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = git@github.com:SNLComputation/yaml-cpp.git
 [submodule "extern/spdlog"]
 	path = extern/spdlog
-	url = git@github.com:gabime/spdlog.git
+	url = git@github.com:E3SM-Project/spdlog.git


### PR DESCRIPTION
Needed for E3SM customization of spdlog's handling of level names

## Motivation

Between Kokkos, e3sm, and scream, we can have multiple levels of compiler wrapping going on (kokkos_launch_compiler, ekat_mpicxx, and e3sm_compile_wrap.py. spdlog was requiring that certain preprocessor definitions be quoted, e.g. SPDLOG_LEVEL_NAME_CRITICAL. Maintaining the correct level of quoting through all these layers of wrappers was causing problems. I forked spdlog into the E3SM project so I could change these things to not require quotes.

This change is needed in order to get SCREAM V1 cases building through CIME on summit.

## Testing

Tested on mappy and summit. 
