### PR TITLE
Go back to original spdlog remote

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = git@github.com:SNLComputation/yaml-cpp.git
 [submodule "extern/spdlog"]
 	path = extern/spdlog
-	url = git@github.com:E3SM-Project/spdlog.git
+	url = git@github.com:gabime/spdlog.git


### PR DESCRIPTION
I discovered that a simple update to v1.x branch removed the problematic compiler definitions, so forking spdlog and modifying it was totally unnecessary. This PR points the submodule back to original repo and updates the spdlog HEAD.

## Testing
Built on both mappy and summit.