### PR TITLE
Fix the include directories for EKAT's tpls

### DIFF
--- a/cmake/pkg_build/EkatBuildEkat.cmake
+++ b/cmake/pkg_build/EkatBuildEkat.cmake
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 # Where ekat's cmake scripts live
 set (EKAT_CMAKE_PATH ${CMAKE_CURRENT_LIST_DIR}/../ CACHE INTERNAL "")
 
@@ -72,6 +74,26 @@ macro (BuildEkat)
     setVars("BUILD_EKAT" FALSE)
 
     add_subdirectory (${EKAT_CMAKE_PATH}/../ ${CMAKE_BINARY_DIR}/externals/ekat)
+
+    set (EKAT_INCLUDE_DIRS
+       $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
+       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR})
+
+    if (EKAT_DISABLE_TPL_WARNINGS)
+      include (EkatUtils)
+      EkatDisableAllWarning(ekat)
+      EkatDisableAllWarning(ekat_test_main)
+      EkatDisableAllWarning(ekat_test_session)
+      target_include_directories(ekat SYSTEM PUBLIC
+        $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+      )
+    else()
+      target_include_directories(ekat PUBLIC
+        $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+      )
+    endif ()
 
     # Make sure that future includes of this script don't rebuild ekat
     set_property(GLOBAL PROPERTY EKAT_BUILT TRUE)

--- a/cmake/pkg_build/EkatBuildKokkos.cmake
+++ b/cmake/pkg_build/EkatBuildKokkos.cmake
@@ -58,10 +58,14 @@ macro(BuildKokkos)
 
     add_subdirectory(${Kokkos_SOURCE_DIR} ${Kokkos_BINARY_DIR})
 
-    set (Kokkos_INCLUDE_DIRS
-      ${Kokkos_SOURCE_DIR}/core/src
-      ${Kokkos_SOURCE_DIR}/algorithms/src
-      ${Kokkos_BINARY_DIR}
+    set (Kokkos_INCLUDE_DIRS_BUILD_INTERFACE
+       ${Kokkos_SOURCE_DIR}/core/src
+       ${Kokkos_SOURCE_DIR}/algorithms/src
+       ${Kokkos_BINARY_DIR}
+    )
+    set (Kokkos_INCLUDE_DIRS_INSTALL_INTERFACE
+       ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+       ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/kokkos
     )
     set(Kokkos_LIBRARIES kokkos)
 
@@ -69,6 +73,15 @@ macro(BuildKokkos)
       include (EkatUtils)
       EkatDisableAllWarning(kokkoscore)
       EkatDisableAllWarning(kokkoscontainers)
+      target_include_directories(kokkos SYSTEM INTERFACE
+          "$<BUILD_INTERFACE:${Kokkos_INCLUDE_DIRS_BUILD_INTERFACE}>"
+          "$<INSTALL_INTERFACE:${Kokkos_INCLUDE_DIRS_INSTALL_INTERFACE}>"
+      )
+    else()
+      target_include_directories(kokkos INTERFACE
+          "$<BUILD_INTERFACE:${Kokkos_INCLUDE_DIRS_BUILD_INTERFACE}>"
+          "$<INSTALL_INTERFACE:${Kokkos_INCLUDE_DIRS_INSTALL_INTERFACE}>"
+      )
     endif ()
 
     # Make sure it is processed only once

--- a/cmake/pkg_build/EkatBuildSpdlog.cmake
+++ b/cmake/pkg_build/EkatBuildSpdlog.cmake
@@ -49,14 +49,18 @@ macro (BuildSpdlog)
     option (SPDLOG_INSTALL "Spdlog install location" ON)
     add_subdirectory (${SPDLOG_SOURCE_DIR} ${SPDLOG_BINARY_DIR})
 
-    set (SPDLOG_INCLUDE_DIRS
-       $<BUILD_INTERFACE:${SPDLOG_SOURCE_DIR}/include>
-       $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/spdlog/include>)
     set (SPDLOG_LIBRARIES spdlog)
 
     if (EKAT_DISABLE_TPL_WARNINGS)
       include (EkatUtils)
       EkatDisableAllWarning(spdlog)
+      target_include_directories(spdlog SYSTEM PUBLIC
+         $<BUILD_INTERFACE:${SPDLOG_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/spdlog/include>)
+    else()
+      target_include_directories(spdlog PUBLIC
+         $<BUILD_INTERFACE:${SPDLOG_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/spdlog/include>)
     endif ()
 
     # Make sure it is processed only once

--- a/cmake/pkg_build/EkatBuildYamlCpp.cmake
+++ b/cmake/pkg_build/EkatBuildYamlCpp.cmake
@@ -48,14 +48,18 @@ macro (BuildYamlcpp)
     option (YAML_CPP_BUILD_TESTS "Enable yaml-cpp tests" OFF)
     add_subdirectory (${YAMLCPP_SOURCE_DIR} ${YAMLCPP_BINARY_DIR})
 
-    set (YAMLCPP_INCLUDE_DIRS
-       $<BUILD_INTERFACE:${YAMLCPP_SOURCE_DIR}/include>
-       $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/yaml-cpp/include>)
     set (YAMLCPP_LIBRARIES yaml-cpp)
 
     if (EKAT_DISABLE_TPL_WARNINGS)
       include (EkatUtils)
       EkatDisableAllWarning(yaml-cpp)
+      target_include_directories(yaml-cpp SYSTEM PUBLIC
+         $<BUILD_INTERFACE:${YAMLCPP_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/yaml-cpp/include>)
+    else()
+      target_include_directories(yaml-cpp PUBLIC
+         $<BUILD_INTERFACE:${YAMLCPP_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/yaml-cpp/include>)
     endif ()
 
     # Make sure it is processed only once

--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -132,7 +132,7 @@ add_library(ekat_test_main util/ekat_catch_main.cpp)
 target_link_libraries(ekat_test_main PUBLIC ekat)
 target_include_directories(ekat_test_main PUBLIC
   $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/extern/Catch2/single_include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>)
 
 
 install (TARGETS ekat_test_main


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The tpls include directories were generating warnings, even if EKAT_DISABLE_TPL_WARNINGS=ON. This was easily fixed by adding the include dirs of the tpl with SYSTEM, in case tpl warnings were to be disabled.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
None needed.
<!--- 
Anything else we need to know in evaluating this pull request?
 -->
## Additional Information
This fix would have been much easier if `target_link_libraries` supported the `SYSTEM` option, like `target_include_directories` does. Alas, CMake does not have that.