### PR TITLE
Add CMAKE_CUDA_ARCHITECTURES in our cuda arch machine files

### DIFF
--- a/cmake/machine-files/kokkos/nvidia-a100.cmake
+++ b/cmake/machine-files/kokkos/nvidia-a100.cmake
@@ -2,3 +2,7 @@ include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
 
 # Enable A100 arch in kokkos
 option(Kokkos_ARCH_AMPERE80 "" ON)
+
+# This var is needed by relatively recent CMake when CUDA language is enabled
+# If not defined, CMake issues a warning
+set (CMAKE_CUDA_ARCHITECTURES 80 CACHE STRING "")

--- a/cmake/machine-files/kokkos/nvidia-p100.cmake
+++ b/cmake/machine-files/kokkos/nvidia-p100.cmake
@@ -2,3 +2,7 @@ include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
 
 # Enable P100 arch in kokkos
 option(Kokkos_ARCH_PASCAL60 "" ON)
+
+# This var is needed by relatively recent CMake when CUDA language is enabled
+# If not defined, CMake issues a warning
+set (CMAKE_CUDA_ARCHITECTURES 60 CACHE STRING "")

--- a/cmake/machine-files/kokkos/nvidia-v100.cmake
+++ b/cmake/machine-files/kokkos/nvidia-v100.cmake
@@ -2,3 +2,7 @@ include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
 
 # Enable V100 arch in kokkos
 option(Kokkos_ARCH_VOLTA70 "" ON)
+
+# This var is needed by relatively recent CMake when CUDA language is enabled
+# If not defined, CMake issues a warning
+set (CMAKE_CUDA_ARCHITECTURES 70 CACHE STRING "")


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Having this var set allows to get rid of a CMake dev warning, which arise when the user enables CUDA language.

Note: ekat does not enable CUDA as a language, but since we provide machine files, we might as well set these vars, as a courtesy to downstream projects, which might use these mach files, and then, independently, enable CUDA.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Manually verified it removes the warning when configuring SCREAM on CUDA.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
None needed.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
