### PR TITLE
Remove include paths logic when calling BuildEkat()

### DIFF
--- a/cmake/pkg_build/EkatBuildEkat.cmake
+++ b/cmake/pkg_build/EkatBuildEkat.cmake
@@ -80,15 +80,6 @@ macro (BuildEkat)
       EkatDisableAllWarning(ekat)
       EkatDisableAllWarning(ekat_test_main)
       EkatDisableAllWarning(ekat_test_session)
-      target_include_directories(ekat SYSTEM PUBLIC
-        $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>
-      )
-    else()
-      target_include_directories(ekat PUBLIC
-        $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>
-      )
     endif ()
 
     # Make sure that future includes of this script don't rebuild ekat


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
These lines should be seemingly innocuous, but removing them seems to fix hard-to-debug fails in SCREAM. Also, these lines should actually have zero effect, so we might as well remove them.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed by SCREAM

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Testing SCREAM with this ekat version now.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
