### PR TITLE
Add MPI to the list of dependency that must be found when findint ekat

### DIFF
--- a/cmake/EkatConfig.cmake.in
+++ b/cmake/EkatConfig.cmake.in
@@ -8,4 +8,7 @@ find_dependency(yaml-cpp PATHS @CMAKE_INSTALL_PREFIX@)
 find_dependency(Kokkos PATHS @CMAKE_INSTALL_PREFIX@)
 find_dependency(spdlog PATHS @CMAKE_INSTALL_PREFIX@)
 
+# MPI is also a dependency, linked by ekat's main lib
+find_dependency(MPI)
+
 include (${CMAKE_CURRENT_LIST_DIR}/EkatTargets.cmake)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
PR #181 allows to use native compilers (rather than mpi wrappers), and link against MPI (which opens the door to conditional compilation of mpi files, although we haven't implemented it yet). This, however, makes MPI a required dependency for EKAT. So when installing EKAT, we must list MPI among its deps in the EkatConfig.cmake pkg config file.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
The CLDERA project (a small C/CXX lib that relies on EKAT for a bunch of utils) is using EKAT as submodule. When I installed CLDERA, the project linking against it was complaining that MPI::MPI_C was not a valid target, and perhaps a dependency wasn't listed somewhere.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Adding this like fixes the problem in my CLDERA installation.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
