### PR TITLE
Ensure Comm is not created with a null MPI communicator

### DIFF
--- a/src/ekat/mpi/ekat_comm.cpp
+++ b/src/ekat/mpi/ekat_comm.cpp
@@ -1,4 +1,5 @@
-#include "ekat_comm.hpp"
+#include "ekat/mpi/ekat_comm.hpp"
+#include "ekat/ekat_assert.hpp"
 
 #include <cassert>
 
@@ -19,6 +20,9 @@ Comm::Comm(MPI_Comm mpi_comm)
 
 void Comm::reset_mpi_comm (MPI_Comm new_mpi_comm)
 {
+  EKAT_REQUIRE_MSG (new_mpi_comm!=MPI_COMM_NULL,
+      "Error! ekat::Comm requires non-null MPI comm.");
+
   m_mpi_comm = new_mpi_comm;
 
   MPI_Comm_size(m_mpi_comm,&m_size);

--- a/tests/mpi/comm.cpp
+++ b/tests/mpi/comm.cpp
@@ -64,6 +64,10 @@ TEST_CASE ("ekat_comm","") {
   REQUIRE (comm.root_rank()==0);
   REQUIRE (comm.am_i_root() == (comm.root_rank()==comm.rank()));
 
+  SECTION ("null") {
+    REQUIRE_THROWS (Comm(MPI_COMM_NULL));
+  }
+
   SECTION ("scan") {
     test_scan<int>(comm);
     test_scan<float>(comm);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The method `reset_mpi_comm` calls some MPI functions that _require_ the comm not to be MPI_COMM_NULL. We could support the null comm case, but then we'd have to ensure things like `am_i_root()` or `rank()` are not used inappropriately. Adding a check inside each of them would work, but we might as well prohibit creating a comm with MPI_COMM_NULL and be done with it...
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
CLDERA spotted this bug, after resetting a Comm with MPI_COMM_NULL. It was getting errors from MPI_Comm_size (rightfully so).

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a test to ensure `reset_mpi_comm(MPI_NULL_COMM)` throws.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
