### PR TITLE
Remove lower bound limiter from LinInterp

### DIFF
--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -67,7 +67,7 @@ struct LinInterp
   // ------ public API -------
   //
 
-  LinInterp(int ncol, int km1, int km2, Scalar minthresh);
+  LinInterp(int ncol, int km1, int km2);
 
   // Simple getters
   KOKKOS_INLINE_FUNCTION
@@ -153,7 +153,6 @@ struct LinInterp
   int m_km2;
   int m_km1_pack;
   int m_km2_pack;
-  Scalar m_minthresh;
   TeamPolicy m_policy;
   view_2d<IntPack> m_indx_map; // [x2_idx] -> x1_idx
 };

--- a/src/ekat/util/ekat_lin_interp_impl.hpp
+++ b/src/ekat/util/ekat_lin_interp_impl.hpp
@@ -7,12 +7,11 @@ namespace ekat {
 // Never include this header directly, only ekat_lin_interp.hpp should include it
 
 template <typename ScalarT, int PackSize, typename DeviceT>
-LinInterp<ScalarT, PackSize, DeviceT>::LinInterp(int ncol, int km1, int km2, Scalar minthresh) :
+LinInterp<ScalarT, PackSize, DeviceT>::LinInterp(int ncol, int km1, int km2) :
   m_km1(km1),
   m_km2(km2),
   m_km1_pack(ekat::npack<Pack>(km1)),
   m_km2_pack(ekat::npack<Pack>(km2)),
-  m_minthresh(minthresh),
   m_policy(ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_km2_pack)),
   m_indx_map("m_indx_map", ncol, ekat::npack<IntPack>(km2))
 {}
@@ -121,8 +120,6 @@ void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp_impl(
 
       y2(k2) = y1p + (y1p1-y1p)*(x2p-x1p)/(x1p1-x1p);
     }
-
-    y2(k2).set(y2(k2) < m_minthresh, m_minthresh);
   });
 }
 

--- a/tests/algorithm/lin_interp_ref.f90
+++ b/tests/algorithm/lin_interp_ref.f90
@@ -12,22 +12,21 @@ module ekat_ut
 
 contains
 
-  subroutine linear_interp_c(x1,x2,y1,y2,km1,km2,ncol,minthresh) bind(c)
+  subroutine linear_interp_c(x1,x2,y1,y2,km1,km2,ncol) bind(c)
 
     integer(kind=c_int), value, intent(in) :: km1, km2, ncol
-    real(kind=c_real), value, intent(in) :: minthresh
     real(kind=c_real), intent(in) :: x1(ncol,km1), y1(ncol,km1)
     real(kind=c_real), intent(in) :: x2(ncol,km2)
     real(kind=c_real), intent(out) :: y2(ncol,km2)
 
-    call linear_interp(x1,x2,y1,y2,km1,km2,ncol,minthresh)
+    call linear_interp(x1,x2,y1,y2,km1,km2,ncol)
 
   end subroutine linear_interp_c
 
   !==============================================================
   ! Linear interpolation to get values on various grids
 
-  subroutine linear_interp(x1,x2,y1,y2,km1,km2,ncol,minthresh)
+  subroutine linear_interp(x1,x2,y1,y2,km1,km2,ncol)
     use iso_c_binding
     implicit none
 
@@ -35,7 +34,6 @@ contains
     integer(kind=c_int), intent(in) :: ncol
     real(kind=c_real), intent(in) :: x1(ncol,km1), y1(ncol,km1)
     real(kind=c_real), intent(in) :: x2(ncol,km2)
-    real(kind=c_real), intent(in) :: minthresh
     real(kind=c_real), intent(out) :: y2(ncol,km2)
 
     integer :: k1, k2, i
@@ -52,10 +50,6 @@ contains
                    y2(i,k2) = y1(i,k1-1) + (y1(i,k1)-y1(i,k1-1))*(x2(i,k2)-x1(i,k1-1))/(x1(i,k1)-x1(i,k1-1))
                 endif
              enddo ! end k1 loop
-          endif
-
-          if (y2(i,k2) .lt. minthresh) then
-             y2(i,k2) = minthresh
           endif
 
        enddo ! end k2 loop

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -12,7 +12,7 @@
 extern "C" {
 
 // This will link to the fortran reference implementation
-void linear_interp_c(const Real* x1, const Real* x2, const Real* y1, Real* y2, int km1, int km2, int ncol, Real minthresh);
+void linear_interp_c(const Real* x1, const Real* x2, const Real* y1, Real* y2, int km1, int km2, int ncol);
 
 }
 
@@ -68,7 +68,6 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
 
   std::default_random_engine generator;
   std::uniform_int_distribution<int> k_dist(10,100);
-  const Real minthresh = 0.000001;
   const int ncol = 10;
 
   // increase iterations for a more-thorough soak
@@ -88,7 +87,7 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
     // Views for testing TeamThreadRange
     using LIV = ekat::LinInterp<Real,EKAT_TEST_POSSIBLY_NO_PACK_SIZE>;
     using Pack = ekat::Pack<Real,EKAT_TEST_PACK_SIZE>;
-    LIV vect(ncol, km1, km2, minthresh);
+    LIV vect(ncol, km1, km2);
     const int km1_pack = ekat::npack<Pack>(km1);
     const int km2_pack = ekat::npack<Pack>(km2);
     typename LIV::template view_2d<Pack>
@@ -98,7 +97,7 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
       y2kv("y2kv", ncol, km2_pack);
 
     // Views for testing ThreadVectorRange
-    LIV vect1(ncol, km1, km2, minthresh);
+    LIV vect1(ncol, km1, km2);
     const int outer_dim = 2;
     const int inner_dim = ncol/outer_dim;
     typename LIV::KT::view_3d<Pack>
@@ -168,7 +167,7 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
 
     // Run fortran and store results in y2_f90
     {
-      linear_interp_c(x1f.data(), x2f.data(), y1f.data(), y2f.data(), km1, km2, ncol, minthresh);
+      linear_interp_c(x1f.data(), x2f.data(), y1f.data(), y2f.data(), km1, km2, ncol);
 
       std::vector<Real> y2c(ncol*km2);
       ekat::transpose<ekat::TransposeDirection::f2c>(y2f.data(), y2c.data(), ncol, km2);
@@ -291,7 +290,7 @@ TEST_CASE("lin_interp_api", "lin_interp")
 
   using LIV = ekat::LinInterp<Real,EKAT_TEST_POSSIBLY_NO_PACK_SIZE>;
   using Pack = ekat::Pack<Real,EKAT_TEST_PACK_SIZE>;
-  LIV vect(ncol, km1, km2, 0);
+  LIV vect(ncol, km1, km2);
   const int km1_pack = ekat::npack<Pack>(km1);
   const int km2_pack = ekat::npack<Pack>(km2);
 
@@ -335,7 +334,6 @@ TEST_CASE("lin_interp_identity", "lin_interp") {
 
   std::default_random_engine generator;
   std::uniform_int_distribution<int> k_dist(10,100);
-  const Real minthresh = 0.000001;
   const int ncol = 10;
 
   real_pdf x_dist(0.0,1.0);
@@ -347,7 +345,7 @@ TEST_CASE("lin_interp_identity", "lin_interp") {
     const int km2 = km1;
 
     // Views for testing TeamThreadRange
-    LIV vect(ncol, km1, km2, minthresh);
+    LIV vect(ncol, km1, km2);
     const int km1_pack = ekat::npack<Pack>(km1);
     const int km2_pack = ekat::npack<Pack>(km2);
     packed_view_2d
@@ -410,7 +408,6 @@ TEST_CASE("lin_interp_avg", "lin_interp") {
 
   std::default_random_engine generator;
   std::uniform_int_distribution<int> k_dist(10,100);
-  const Real minthresh = 0.000001;
   const int ncol = 10;
 
   // Generate increments for x1/y1, so that we get fairly
@@ -427,7 +424,7 @@ TEST_CASE("lin_interp_avg", "lin_interp") {
     const int km2 = km1-1;
 
     // Views for testing TeamThreadRange
-    LIV vect(ncol, km1, km2, minthresh);
+    LIV vect(ncol, km1, km2);
     const int km1_pack = ekat::npack<Pack>(km1);
     const int km2_pack = ekat::npack<Pack>(km2);
     packed_view_2d
@@ -503,7 +500,6 @@ TEST_CASE("lin_interp_down_sampling", "lin_interp") {
 
   std::default_random_engine generator;
   std::uniform_int_distribution<int> k_dist(10,100);
-  const Real minthresh = 0.000001;
   const int ncol = 10;
 
   real_pdf x_dist(0.0,1.0);
@@ -515,7 +511,7 @@ TEST_CASE("lin_interp_down_sampling", "lin_interp") {
     const int km1 = km2*2;
 
     // Views for testing TeamThreadRange
-    LIV vect(ncol, km1, km2, minthresh);
+    LIV vect(ncol, km1, km2);
     const int km1_pack = ekat::npack<Pack>(km1);
     const int km2_pack = ekat::npack<Pack>(km2);
     packed_view_2d
@@ -581,7 +577,6 @@ TEST_CASE("lin_interp_monotone", "lin_interp") {
 
   std::default_random_engine generator;
   std::uniform_int_distribution<int> k_dist(10,100);
-  const Real minthresh = 0.000001;
   const int ncol = 10;
 
   real_pdf x_dist(0.0,1.0);
@@ -604,7 +599,7 @@ TEST_CASE("lin_interp_monotone", "lin_interp") {
     const int km2 = k_dist(generator);
 
     // Views for testing TeamThreadRange
-    LIV vect(ncol, km1, km2, minthresh);
+    LIV vect(ncol, km1, km2);
     const int km1_pack = ekat::npack<Pack>(km1);
     const int km2_pack = ekat::npack<Pack>(km2);
     packed_view_2d


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The current impl of LinInterp forces a user to specify a (lower bound) limiter for the output, even if the application has no conceptual limit. In case the app does not have an a priori lower bound, the user is forced to set some very low number.

The user can easily implement a limiter after LinInterp is done (like a for-loop) or pad the input `x` and `y` values to implement a limiter. Notice that `y2` greater than `max(y1)` or smaller than `min(y1)` can only happen when extrapolation is needed. In this case, one could do
```
x1padded = [x1(:) very_big_value]
y1padded = [y1(:) y1(end)]
```
to enforece `y2=y1(end)` if `x2>x1(end)`, and similarly for the left of the interval. Ramp extrapolation can also be achieved by fixing the padding for y to a value that gives the desired slope, i.e., to control `(y_far_away-y1(end))/(x_far_away-x1(end))`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
No additional testing is necessary
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
