### PR TITLE
Fix setting of CUDA flags

### DIFF
--- a/cmake/EkatSetCompilerFlags.cmake
+++ b/cmake/EkatSetCompilerFlags.cmake
@@ -360,12 +360,12 @@ macro (SetCudaFlags targetName)
       set (FLAGS ${SCF_FLAGS})
     else ()
       # We need host-device lambdas
-      set (FLAGS "--expt-extended-lambda")
+      set (FLAGS --expt-extended-lambda)
 
       IsDebugBuild (SCF_DEBUG)
       if (SCF_DEBUG)
         # Turn off fused multiply add for debug so we can stay BFB with host
-        string (APPEND FLAGS " --fmad=false")
+        list (APPEND FLAGS --fmad=false)
       endif()
     endif()
 

--- a/cmake/pkg_build/EkatBuildKokkos.cmake
+++ b/cmake/pkg_build/EkatBuildKokkos.cmake
@@ -1,3 +1,5 @@
+include(EkatSetCompilerFlags)
+
 # Where ekat's tpls live
 set (EKAT_KOKKOS_SUBMODULE_PATH "" CACHE INTERNAL "")
 get_filename_component(EKAT_KOKKOS_SUBMODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../extern/kokkos ABSOLUTE)
@@ -68,6 +70,8 @@ macro(BuildKokkos)
        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/kokkos
     )
     set(Kokkos_LIBRARIES kokkos)
+    SetCudaFlags(kokkoscore)
+    SetOmpFlags(kokkoscore)
 
     if (EKAT_DISABLE_TPL_WARNINGS)
       include (EkatUtils)

--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -73,10 +73,6 @@ add_library(ekat ${EKAT_SOURCES})
 # Link MPI
 target_link_libraries (ekat PUBLIC MPI::MPI_C)
 
-# Set all sorts of flags on the ekat library
-SetOmpFlags(ekat CXX)
-SetCudaFlags(ekat)
-
 target_include_directories(ekat PUBLIC
   $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${EKAT_BINARY_DIR}/src>


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
After the PR that changed how EKAT handles compiler flags, CUDA/OMP flags were set on the ekat lib, but not on Kokkos itself. The biggest difference was the lack of `--fmad=false` on kokkos targets. This will likely not have any effect, though, to be safe, I moved the application of Cuda/Omp flags to kokkoscore, which is linked to ekat anyways.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
