### PR TITLE
Fix cmake error in detecting MPI distribution name

### DIFF
--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -1,12 +1,14 @@
 # Detect the library that provides MPI
 set (EKAT_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 macro (GetMpiDistributionName DISTRO_NAME)
-  if (MPI_C_COMPILER)
-    set (INCLUDE_DIRS ${MPI_C_INCLUDE_DIRS})
-    set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.c)
-  elseif (MPI_CXX_COMPILER)
+  if (MPI_CXX_COMPILER)
+    message ("MPI_CXX_COMPILER: ${MPI_CXX_COMPILER}")
     set (INCLUDE_DIRS ${MPI_CXX_INCLUDE_DIRS})
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.cxx)
+  elseif (MPI_C_COMPILER)
+    message ("MPI_C_COMPILER: ${MPI_C_COMPILER}")
+    set (INCLUDE_DIRS ${MPI_C_INCLUDE_DIRS})
+    set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.c)
   else ()
     string (CONCAT MSG
       "**************************************************************\n"

--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -25,7 +25,7 @@ macro (GetMpiDistributionName DISTRO_NAME)
                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${INCLUDE_DIRS}"
                OUTPUT_VARIABLE OUT_VAR)
 
-  if (RESULT)
+  if (NOT RESULT)
     message (FATAL_ERROR "Could not compile a simple MPI source file.")
   endif()
 

--- a/cmake/TryCompileMPI.c
+++ b/cmake/TryCompileMPI.c
@@ -1,7 +1,7 @@
 #include <mpi.h>
 #include <stdio.h>
 
-int main (int, char**)
+int main (int argc, char** argv)
 {
 #if defined(OMPI_MAJOR_VERSION)
 #pragma message("OpenMPI found")


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
There were two bugs in `GetMpiDistributionName`, which, in case the user had a valid MPI distribution, cancelled out:
- In C, functions cannot have unnamed parameters at the point of definition (but they can at the declaration), and in the file TryCompileMPI.c we had `int main(int, char**) {...}`.
- The result of `try_compile` is a bool, stating whether the compilation was successful or not. We were throwing an error as `if (RESULT)`, probably a leftover from when we used `execute_process`, in which a compilation failure would yield a nonzero exit code.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Manually verified that this fixes the problem.

## Additional Information
The problem was reported [here](https://github.com/E3SM-Project/EKAT/issues/188#issuecomment-1063261743). Thank you @abagusetty for spotting it!