### PR TITLE
WSM: allow passing refs rather than array of pointers to the take method

### DIFF
--- a/src/ekat/std_meta/ekat_std_utils.hpp
+++ b/src/ekat/std_meta/ekat_std_utils.hpp
@@ -3,11 +3,34 @@
 
 #include <algorithm>
 #include <memory>
+#include <type_traits>
 #include <vector>
 #include <string>
 #include <set>
 
 namespace ekat {
+
+// Check that a list of template args are all of the same type
+// NOTE: the 'type' type that specializations expose really only
+//       matters if 'SameType<Ts...>::value' is true.
+template<typename...Ts>
+struct SameType;
+
+template<typename T>
+struct SameType<T> : std::true_type {
+  using type = T;
+};
+
+template<typename T, typename...Ts>
+struct SameType<T,Ts...> :
+  std::conditional<SameType<Ts...>::value &&
+                   std::is_same<T,typename SameType<Ts...>::type>::value,
+                   std::true_type,
+                   std::false_type
+                  >::type
+{
+  using type = T;
+};
 
 // This function returns an iterator which is of the same type of c.begin()
 template<typename ContainerType, typename T>

--- a/tests/kokkos/workspace_tests.cpp
+++ b/tests/kokkos/workspace_tests.cpp
@@ -270,7 +270,8 @@ static void unittest_workspace()
           Kokkos::Array<Unmanaged<view_1d<int> >*, n_slots_per_team> ptrs = { {&ws1, &ws2, &ws3, &ws4} };
           Kokkos::Array<const char*, n_slots_per_team> names = { {"ws0", "ws1", "ws2", "ws3"} };
           if (r % 5 == 2) {
-            ws.take_many(names, ptrs);
+            // ws.take_many(names, ptrs);
+            ws.take_many_refs(names,ws1,ws2,ws3,ws4);
           }
           else if (r % 5 == 3) {
             ws.take_many_contiguous_unsafe(names, ptrs);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR is from an _old_ branch that I revived, and it's a quality-of-life improvement for the WorkspaceManager class.

In the following, the first syntax is heavier than the second:
```
   Kokkos::Array<const char*,3> names {"v1","v2","v3"};
   Unmanaged<view_1d> v1,v2,v3;
   
   // Old way
   Kokkos::Array<Unmanaged<view_1d>*,3> ptrs {&v1, &v2, &v3};
   wsm.take_many(names,ptrs);
   
   // New way
   wsm.take_many(names,v1,v2,v3);
```
This PR allows the second form (with a slightly different method name).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I changed the wsm test to use `take_many_refs` instead of `take_many`.

## Additional Information
I would _really_ like to actually just do
```
wsm.take_many_refs(v1,v2,v3);
```
since I don't really care about the views names. However, the way I tried to implement it (see [here](https://github.com/E3SM-Project/EKAT/blob/118c6059976cdbfca524ede5feb2516413267d09/src/ekat/ekat_workspace_impl.hpp#L428)), cause the test to crash. I don't understand the wsm metadata stuff well enough to debug, and since it's not a _crucial_ feature, I can just let it go.