### PR TITLE
Add utility to parse string representing nested lists

### DIFF
--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -41,6 +41,9 @@ public:
   // The name of the list
   const std::string& name () const { return m_name; }
 
+  // Change the name of the list
+  void rename (const std::string& name) { m_name = name; }
+
   // Parameters getters and setters
   template<typename T>
   T& get (const std::string& name);

--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -180,6 +180,7 @@ ParameterList parseNestedList (std::string str)
       auto close = find_closing(str,pos);
       auto substr = str.substr(pos,close-pos+1);
       auto sublist = parseNestedList(substr);
+      sublist.rename(strint("Entry",num_entries));
 
       list.set<std::string>(strint("Type",num_entries),"List");
       list.sublist(strint("Entry",num_entries)) = sublist;

--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -60,7 +60,7 @@ std::string upper_case (const std::string& s) {
   return s_up;
 }
 
-bool validNestedListFormat (const std::string& str)
+bool valid_nested_list_format (const std::string& str)
 {
   constexpr auto npos = std::string::npos;
   std::string separators = "[],";
@@ -134,7 +134,7 @@ bool validNestedListFormat (const std::string& str)
   return num_open==0;
 }
 
-ParameterList parseNestedList (std::string str)
+ParameterList parse_nested_list (std::string str)
 {
   constexpr auto npos = std::string::npos;
 
@@ -142,7 +142,7 @@ ParameterList parseNestedList (std::string str)
   strip(str,' ');
 
   // 2. Verify input is valid
-  EKAT_REQUIRE_MSG (validNestedListFormat(str),
+  EKAT_REQUIRE_MSG (valid_nested_list_format(str),
       "Error! Input std::string '" + str + "' is not a valid (nested) list.\n");
 
   // Find the closing bracket matching the open one at open_pos
@@ -179,7 +179,7 @@ ParameterList parseNestedList (std::string str)
       // NOTE: we *know* close!=npos, cause we already validated str.
       auto close = find_closing(str,pos);
       auto substr = str.substr(pos,close-pos+1);
-      auto sublist = parseNestedList(substr);
+      auto sublist = parse_nested_list(substr);
       sublist.rename(strint("Entry",num_entries));
 
       list.set<std::string>(strint("Type",num_entries),"List");

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -48,8 +48,8 @@ std::list<std::string> gather_tokens(const std::string& s,
 
 // Utils to verify/parse a string encoding nested lists,
 // such as '[a,b,[c,d],e]'
-bool validNestedListFormat (const std::string& str);
-ParameterList parseNestedList (std::string str);
+bool valid_nested_list_format (const std::string& str);
+ParameterList parse_nested_list (std::string str);
 
 // Computing similarity index between s1 and s2 using Jaro algorithm
 // For a quick description of the Jaro similarity index, see, e.g.,

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -1,6 +1,8 @@
 #ifndef EKAT_STRING_UTILS_HPP
 #define EKAT_STRING_UTILS_HPP
 
+#include <ekat/ekat_parameter_list.hpp>
+
 #include <string>
 #include <vector>
 #include <list>
@@ -43,6 +45,11 @@ std::string upper_case (const std::string& s);
 std::list<std::string> gather_tokens(const std::string& s,
                                      const std::vector<char>& delimiters,
                                      const std::string& atomic = "");
+
+// Utils to verify/parse a string encoding nested lists,
+// such as '[a,b,[c,d],e]'
+bool validNestedListFormat (const std::string& str);
+ParameterList parseNestedList (std::string str);
 
 // Computing similarity index between s1 and s2 using Jaro algorithm
 // For a quick description of the Jaro similarity index, see, e.g.,

--- a/tests/utils/string_utils_tests.cpp
+++ b/tests/utils/string_utils_tests.cpp
@@ -166,26 +166,26 @@ TEST_CASE("parse_nested_list") {
   using namespace ekat;
 
   // Ensure we can tell valid from unvalid strings
-  REQUIRE (validNestedListFormat(valid_1));
-  REQUIRE (validNestedListFormat(valid_2));
-  REQUIRE (validNestedListFormat(valid_3));
-  REQUIRE (validNestedListFormat(valid_4));
-  REQUIRE (validNestedListFormat(valid_5));
-  REQUIRE (validNestedListFormat(valid_6));
+  REQUIRE (valid_nested_list_format(valid_1));
+  REQUIRE (valid_nested_list_format(valid_2));
+  REQUIRE (valid_nested_list_format(valid_3));
+  REQUIRE (valid_nested_list_format(valid_4));
+  REQUIRE (valid_nested_list_format(valid_5));
+  REQUIRE (valid_nested_list_format(valid_6));
 
-  REQUIRE (not validNestedListFormat(invalid_1));
-  REQUIRE (not validNestedListFormat(invalid_2));
-  REQUIRE (not validNestedListFormat(invalid_3));
-  REQUIRE (not validNestedListFormat(invalid_4));
-  REQUIRE (not validNestedListFormat(invalid_5));
+  REQUIRE (not valid_nested_list_format(invalid_1));
+  REQUIRE (not valid_nested_list_format(invalid_2));
+  REQUIRE (not valid_nested_list_format(invalid_3));
+  REQUIRE (not valid_nested_list_format(invalid_4));
+  REQUIRE (not valid_nested_list_format(invalid_5));
 
   // Parse strings into lists
-  auto pl_1 = parseNestedList(valid_1);
-  auto pl_2 = parseNestedList(valid_2);
-  auto pl_3 = parseNestedList(valid_3);
-  auto pl_4 = parseNestedList(valid_4);
-  auto pl_5 = parseNestedList(valid_5);
-  auto pl_6 = parseNestedList(valid_6);
+  auto pl_1 = parse_nested_list(valid_1);
+  auto pl_2 = parse_nested_list(valid_2);
+  auto pl_3 = parse_nested_list(valid_3);
+  auto pl_4 = parse_nested_list(valid_4);
+  auto pl_5 = parse_nested_list(valid_5);
+  auto pl_6 = parse_nested_list(valid_6);
 
   // Test counters
   REQUIRE (pl_1.get<int>("Num Entries")==1);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
I wrote this for another library, but I can see it being used in the near future in SCREAM (and maybe beyond) to make specifying grouping of entities easier from input file. In particular, I want to group entities in one line in a command line, as follows:

```
My nested list: "[a, b, [c, d, [e]], f, [[g, h], i]]"
```
(i hope i got the parentheses correctly). This PR parses the string "[a, b, [c, d, [e]], f, [[g, h], i]]" and produces a nested ParameterList. Each list contains:

1. "Num Entries": how many entryes are in it. In this example, the outermost list has 4 entries
2. "Depth": how many lists are nested in the current list (counting the current list). So the outermost list has depth 3, while `[g,h]` has depth 1.
3. For i=0,...,NumEntries-1, "Type $i": whether the i-th entry is a "Value" or a "List".
4. For i=0,...NumEntries-1, "Entry $i": if the type is "Value", this is a string, otherwise it is another ParameterList.

So for the above string, the parsing the string, and printing the resulting parameter list would yield the following
```
[a,b,[c,d,[e]],f,[[g,h],i]]:
 Depth: 3
 Entry 0: a
 Entry 1: b
 Entry 3: f
 Num Entries: 5
 Type 0: Value
 Type 1: Value
 Type 2: List
 Type 3: Value
 Type 4: List
 Entry 2:
  Depth: 2
  Entry 0: c
  Entry 1: d
  Num Entries: 3
  Type 0: Value
  Type 1: Value
  Type 2: List
  Entry 2:
   Depth: 1
   Entry 0: e
   Num Entries: 1
   Type 0: Value
 Entry 4:
  Depth: 2
  Entry 1: i
  Num Entries: 2
  Type 0: List
  Type 1: Value
  Entry 0:
   Depth: 1
   Entry 0: g
   Entry 1: h
   Num Entries: 2
   Type 0: Value
   Type 1: Value
```
Notice that the name of the topmost list is the string that was parsed.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
I think this might soon be helpful in SCREAM.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added testing that verify we can correctly parse valid strings, and throw errors for invalid ones.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
