### PR TITLE
Allow more styles and characters in parse_nested_list

### DIFF
--- a/tests/utils/string_utils_tests.cpp
+++ b/tests/utils/string_utils_tests.cpp
@@ -151,17 +151,20 @@ TEST_CASE("string","string") {
 
 TEST_CASE("parse_nested_list") {
   std::string valid_1 = "[a]";
-  std::string valid_2 = "[a,b]";
+  std::string valid_2 = "{a,b}";
   std::string valid_3 = "[a,[b,c]]";
-  std::string valid_4 = "[[a,b],c]";
-  std::string valid_5 = "[[a]]";
+  std::string valid_4 = "((a,b),c)";
+  std::string valid_5 = "<<a>>";
   std::string valid_6 = "[[a,[b,c]],d]";
 
   std::string invalid_1 = "[]";
   std::string invalid_2 = "[,b]";
-  std::string invalid_3 = "[a[b,c]]";
+  std::string invalid_3 = "(a(b,c))";
   std::string invalid_4 = "[,,c]";
   std::string invalid_5 = "[a,]";
+  std::string invalid_6 = "[a)";
+  std::string invalid_7 = "{a)";
+  std::string invalid_8 = "<a}";
 
   using namespace ekat;
 
@@ -178,6 +181,9 @@ TEST_CASE("parse_nested_list") {
   REQUIRE (not valid_nested_list_format(invalid_3));
   REQUIRE (not valid_nested_list_format(invalid_4));
   REQUIRE (not valid_nested_list_format(invalid_5));
+  REQUIRE (not valid_nested_list_format(invalid_6));
+  REQUIRE (not valid_nested_list_format(invalid_7));
+  REQUIRE (not valid_nested_list_format(invalid_8));
 
   // Parse strings into lists
   auto pl_1 = parse_nested_list(valid_1);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Turns out that you cannot use `[a,b]` as a key in a YAML file, but you can use `(a,b)`. So I added support for more brackets styles, as well as added more special characters to the list of valid ones.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
I am meaning to use nested list strings as keys of YAML sublists in SCREAM, so this should help.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a couple more tests to strings utils.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
