### PR TITLE
Avoid slamming the login node with compilation jobs during jenkins testing

### DIFF
--- a/scripts/jenkins/jenkins_impl.sh
+++ b/scripts/jenkins/jenkins_impl.sh
@@ -65,7 +65,7 @@ if [ $? -ne 0 ]; then
     echo "Something went wrong while configuring the SP case."
     RET_SP=1
 else
-    make -j ${COMP_J}
+    ${BATCHP} make -j ${COMP_J}
     if [ $? -ne 0 ]; then
         echo "Something went wrong while building the SP case."
         RET_SP=1
@@ -105,7 +105,7 @@ if [ $? -ne 0 ]; then
     echo "Something went wrong while configuring the DP case."
     RET_DP=1
 else
-    make -j ${COMP_J}
+    ${BATCHP} make -j ${COMP_J}
     if [ $? -ne 0 ]; then
         echo "Something went wrong while building the DP case."
         RET_DP=1


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
It is not nice to use a lot of the login node resources to build code. Even though EKAT is relatively small, if a few users are doing the same thing, we can quickly clobber the node, slowing everything down for everyone.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->