### PR TITLE
Support more types in comm operations, and allow users to extent to new types

### DIFF
--- a/src/ekat/mpi/ekat_comm.cpp
+++ b/src/ekat/mpi/ekat_comm.cpp
@@ -58,5 +58,39 @@ void Comm::check_mpi_inited () const
   assert (flag!=0);
 }
 
+template<>
+MPI_Datatype get_mpi_type <char> () {
+  return MPI_CHAR;
+}
+template<>
+MPI_Datatype get_mpi_type <short> () {
+  return MPI_SHORT;
+}
+template<>
+MPI_Datatype get_mpi_type <int> () {
+  return MPI_INT;
+}
+template<>
+MPI_Datatype get_mpi_type <long> () {
+  return MPI_LONG;
+}
+template<>
+MPI_Datatype get_mpi_type <long long> () {
+  return MPI_LONG_LONG;
+}
+template<>
+MPI_Datatype get_mpi_type <float> () {
+  return MPI_FLOAT;
+}
+template<>
+MPI_Datatype get_mpi_type <double> () {
+  return MPI_DOUBLE;
+}
+#if MPI_VERSION>3 || (MPI_VERSION==3 && MPI_SUBVERSION>=1)
+template<>
+MPI_Datatype get_mpi_type <bool> () {
+  return MPI_CXX_BOOL;
+}
+#endif
 
 } // namespace ekat

--- a/src/ekat/mpi/ekat_comm.hpp
+++ b/src/ekat/mpi/ekat_comm.hpp
@@ -62,30 +62,6 @@ public:
   Comm split (const int color) const;
 private:
 
-  template<typename T>
-  static MPI_Datatype get_mpi_type () {
-    // Sanity check
-    static_assert (
-        std::is_same<T,char>::value ||
-#if MPI_VERSION>3 || (MPI_VERSION==3 && MPI_SUBVERSION>=1)
-        // MPI started supporting C++ bool type only "recently"
-        std::is_same<T,bool>::value ||
-#endif
-        std::is_same<T,int>::value ||
-        std::is_same<T,long long>::value ||
-        std::is_same<T,float>::value ||
-        std::is_same<T,double>::value,
-        "Error! Type not supported for MPI operations.\n");
-
-    return std::is_same<T,char>::value ? MPI_CHAR :
-#if MPI_VERSION>3 || (MPI_VERSION==3 && MPI_SUBVERSION>=1)
-          (std::is_same<T,bool>::value ? MPI_CXX_BOOL :
-#endif
-          (std::is_same<T,int>::value ? MPI_INT :
-          (std::is_same<T,long long>::value ? MPI_LONG_LONG :
-          (std::is_same<T,float>::value ? MPI_FLOAT : MPI_DOUBLE))));
-  }
-
   // Checks (with an assert) that MPI is already init-ed.
   void check_mpi_inited () const;
 
@@ -94,6 +70,9 @@ private:
   int       m_size;
   int       m_rank;
 };
+
+template<typename T>
+MPI_Datatype get_mpi_type ();
 
 // ========================= IMPLEMENTATION =========================== //
 

--- a/src/ekat/mpi/ekat_comm.hpp
+++ b/src/ekat/mpi/ekat_comm.hpp
@@ -72,6 +72,7 @@ private:
         std::is_same<T,bool>::value ||
 #endif
         std::is_same<T,int>::value ||
+        std::is_same<T,long long>::value ||
         std::is_same<T,float>::value ||
         std::is_same<T,double>::value,
         "Error! Type not supported for MPI operations.\n");
@@ -81,7 +82,8 @@ private:
           (std::is_same<T,bool>::value ? MPI_CXX_BOOL :
 #endif
           (std::is_same<T,int>::value ? MPI_INT :
-          (std::is_same<T,float>::value ? MPI_FLOAT : MPI_DOUBLE)));
+          (std::is_same<T,long long>::value ? MPI_LONG_LONG :
+          (std::is_same<T,float>::value ? MPI_FLOAT : MPI_DOUBLE))));
   }
 
   // Checks (with an assert) that MPI is already init-ed.

--- a/tests/mpi/comm.cpp
+++ b/tests/mpi/comm.cpp
@@ -102,6 +102,7 @@ TEST_CASE ("ekat_comm","") {
     test_gather<bool>(comm);
 #endif
     test_gather<int>(comm);
+    test_gather<long long>(comm);
     test_gather<float>(comm);
     test_gather<double>(comm);
   }

--- a/tests/mpi/comm.cpp
+++ b/tests/mpi/comm.cpp
@@ -1,6 +1,35 @@
 #include <catch2/catch.hpp>
 #include "ekat/mpi/ekat_comm.hpp"
 
+// Instantiate get_mpi_type for a user defined type
+// to check that the user can extend comm functionalities
+// to new types
+struct TwoInts {
+  int i;
+  int j;
+  TwoInts () = default;
+  TwoInts (const int val) {
+    i = val;
+    j = -val;
+  }
+  TwoInts& operator= (const int val) {
+    i = val;
+    j = -val;
+    return *this;
+  }
+};
+
+bool operator== (const TwoInts& lhs, const TwoInts& rhs) {
+  return lhs.i==rhs.i && lhs.j==rhs.j;
+}
+
+namespace ekat {
+  template<>
+  MPI_Datatype get_mpi_type<TwoInts> () {
+    return MPI_2INT;
+  }
+}
+
 namespace {
 
 template<typename T>
@@ -101,10 +130,13 @@ TEST_CASE ("ekat_comm","") {
 #if MPI_VERSION>3 || (MPI_VERSION==3 && MPI_SUBVERSION>=1)
     test_gather<bool>(comm);
 #endif
+    test_gather<short>(comm);
     test_gather<int>(comm);
+    test_gather<long>(comm);
     test_gather<long long>(comm);
     test_gather<float>(comm);
     test_gather<double>(comm);
+    test_gather<TwoInts>(comm);
   }
 
   SECTION ("split") {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Applications may need to perform comm operations with more types, or even user defined derived types. We now provide built-in support for more C++ types (including `short`, `long`, `long long`). Furthermore, the `get_mpi_type` function is now a free function, with no default implementation. Support for types is added via specialization, so the user can support its own types.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
The CLDERA project needs to do reduction of `long long` integers.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added test for all newly added builtin types, as well as verified specialization logic works for new user-defined types.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
