### PR TITLE
Fixes a compilation issue with nvcc.

### DIFF
--- a/src/ekat/io/ekat_yaml.cpp
+++ b/src/ekat/io/ekat_yaml.cpp
@@ -126,7 +126,7 @@ void parse_node<YAML::NodeType::Sequence> (
   EKAT_REQUIRE_MSG (node.Type()==YAML::NodeType::Sequence,
                       "Error! Actual node type incompatible with template parameter.\n");
 
-  // The following fancy typemap/typelist code defaults the nvcc compiler(s)
+  // The following fancy typemap/typelist code defeats the nvcc compiler(s)
   // available on Summit, so we're backpedaling for now. The code below this
   // block comment does the same thing. -JNJ, 5/27/2022
   /*
@@ -151,9 +151,9 @@ void parse_node<YAML::NodeType::Sequence> (
   });
   */
   // Yes, I know. The C preprocessor! Too bad the fancy C++ template stuff
-  // isn't up to the task. Here we encode the typemap and the typelist in the
-  // first type arguments in this macro, which we call on all types in the
-  // typelist.
+  // isn't up to the task. Here we encode a value type and its related sequence
+  // type in the first two arguments in this macro, which we then call on all
+  // types in the typelist.
 #define TRY_TYPE_ON_NODE(vtype, seq_val_t, node) \
   if (is_seq<vtype>(node)) { \
     std::vector<seq_val_t> vec(n); \

--- a/src/ekat/io/ekat_yaml.cpp
+++ b/src/ekat/io/ekat_yaml.cpp
@@ -156,6 +156,7 @@ void parse_node<YAML::NodeType::Sequence> (
   // types in the typelist.
 #define TRY_TYPE_ON_NODE(vtype, seq_val_t, node) \
   if (is_seq<vtype>(node)) { \
+    int n = node.size(); \
     std::vector<seq_val_t> vec(n); \
     for (int i=0; i<n; ++i) { \
       std::string str = node[i].as<std::string>(); \
@@ -164,7 +165,6 @@ void parse_node<YAML::NodeType::Sequence> (
     list.set(key,vec); \
     return; \
   }
-  int n = node.size();
   TRY_TYPE_ON_NODE(bool, char, node);
   TRY_TYPE_ON_NODE(int, int, node);
   TRY_TYPE_ON_NODE(double, double, node);


### PR DESCRIPTION
This commit implements `parse_node()` in a more primitive way to help out
the poor C++/CUDA compilers on our building-sized machines.

## Motivation

Currently, EKAT doesn't build on Summit with its out-of-the-box compilers. Perhaps this fix will help. @oksanaguba , can you try this branch of EKAT to see if it alleviates your troubles?

## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
