### PR TITLE
add power9 kokkos arch support

### DIFF
--- a/cmake/machine-files/kokkos/p9.cmake
+++ b/cmake/machine-files/kokkos/p9.cmake
@@ -1,0 +1,4 @@
+include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
+  
+# Enable Power9 arch in kokkos
+option(Kokkos_ARCH_POWER9 "" ON)


### PR DESCRIPTION
Add p9.cmake machine-file to support POWER9 cpu build on Summit.

## Motivation
<!--- 
This option is required for SCREAM to be able to run on Summit Power9 cpu.
-->

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
