### PR TITLE
Fix warning related to poinless comparison of unsigned int

### DIFF
--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -124,7 +124,7 @@ bool valid_nested_list_format (const std::string& str)
   // We verified the string starts with '['.
   size_t start = 1;
   char last_match = open;
-  size_t num_open = 1;
+  int num_open = 1;
   size_t pos = str.find_first_of(separators,start);
 
   while (pos!=npos) {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes a buggy comparison in `valid_nested_list_format`, which pointed to the need of an `int` instead of a `size_t`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Closes #226 


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Verified that the warning disappears with this fix.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
