### PR TITLE
Fix strlen for HIP. Adjust some EKAT_DEFAULT_BFB behavior.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ if (EKAT_ENABLE_COVERAGE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   message(FATAL_ERROR "Code coverage will only work with Debug build type")
 endif()
 
+if (EKAT_DEFAULT_BFB AND NOT EKAT_IS_DEBUG_BUILD)
+  message("WARNING: Setting EKAT_DEFAULT_BFB in an optimized build may invalidate BFBness.")
+endif()
+
 ############################################
 ###  COMPILER/OS-SPECIFIC CONFIG OPTIONS ###
 ############################################

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -618,7 +618,7 @@ class TeamUtils<ValueType,EkatGpuSpace> : public TeamUtilsCommonBase<ValueType,E
 
 namespace impl {
 
-#ifdef KOKKOS_ENABLE_CUDA
+#ifdef EKAT_ENABLE_GPU
 // Replacements for namespace std functions that don't run on the GPU.
 KOKKOS_INLINE_FUNCTION
 size_t strlen(const char* str)
@@ -633,7 +633,7 @@ KOKKOS_INLINE_FUNCTION
 void strcpy(char* dst, const char* src)
 {
   EKAT_KERNEL_ASSERT(dst != NULL && src != NULL);
-  while(*dst++ = *src++);
+  while((*dst++ = *src++));
 }
 KOKKOS_INLINE_FUNCTION
 int strcmp(const char* first, const char* second)


### PR DESCRIPTION
* Fix a missing EKAT_ENABLE_GPU case. Fixes strlen issue in HIP debug build.
* Provide a warning about EKAT_DEFAULT_BFB in optimized builds and adjust the tridiag test accordingly.

Tested on crusher.