### PR TITLE
Make Units usabe inside constant expressions

### DIFF
--- a/src/ekat/util/ekat_rational_constant.hpp
+++ b/src/ekat/util/ekat_rational_constant.hpp
@@ -120,7 +120,7 @@ constexpr RationalConstant operator/ (const RationalConstant& lhs, const Rationa
 
 // WARNING! If exp>>1, this generates a huge recursion. Use carefully!!
 template<typename IntType>
-inline constexpr
+constexpr
 typename std::enable_if<std::is_integral<IntType>::value,RationalConstant>::type
 pow (const RationalConstant& x, const IntType p) {
   // Three main cases:

--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -5,6 +5,8 @@
 #include "ekat/util/ekat_scaling_factor.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
 
+#include <array>
+
 namespace ekat
 {
 
@@ -69,10 +71,11 @@ public:
          const RationalConstant& currentExp,
          const RationalConstant& amountExp,
          const RationalConstant& luminousIntensityExp,
-         const ScalingFactor& scalingFactor = RationalConstant::one())
+         const ScalingFactor& scalingFactor = ScalingFactor::one(),
+         const char* name = nullptr)
    : m_scaling {scalingFactor}
    , m_units {lengthExp,timeExp,massExp,temperatureExp,currentExp,amountExp,luminousIntensityExp}
-   , m_name {nullptr}
+   , m_name {name}
   {
     // Nothing to do here
   }
@@ -98,7 +101,7 @@ public:
     m_name = s.c_str();
   }
 
-  bool is_dimensionless () const {
+  constexpr bool is_dimensionless () const {
     return m_units[0].num==0 &&
            m_units[1].num==0 &&
            m_units[2].num==0 &&
@@ -123,8 +126,8 @@ private:
 
   friend std::string to_string(const Units&);
 
-  const ScalingFactor     m_scaling;
-  const RationalConstant  m_units[7];
+  const ScalingFactor                   m_scaling;
+  const std::array<RationalConstant,7>  m_units;
 
   const char*             m_name;
 };
@@ -286,13 +289,13 @@ inline std::ostream& operator<< (std::ostream& out, const Units& x) {
 
 // Note: no need to pass a string for these, since the default
 //       string construction would return the same thing.
-const Units m   = Units(1,0,0,0,0,0,0);
-const Units s   = Units(0,1,0,0,0,0,0);
-const Units kg  = Units(0,0,1,0,0,0,0);
-const Units K   = Units(0,0,0,1,0,0,0);
-const Units A   = Units(0,0,0,0,1,0,0);
-const Units mol = Units(0,0,0,0,0,1,0);
-const Units cd  = Units(0,0,0,0,0,0,1);
+const Units m   = Units(1,0,0,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[0]);
+const Units s   = Units(0,1,0,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[1]);
+const Units kg  = Units(0,0,1,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[2]);
+const Units K   = Units(0,0,0,1,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[3]);
+const Units A   = Units(0,0,0,0,1,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[4]);
+const Units mol = Units(0,0,0,0,0,1,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[5]);
+const Units cd  = Units(0,0,0,0,0,0,1,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[6]);
 
 // === DERIVED === //
 

--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -89,16 +89,18 @@ public:
 
   constexpr Units (const Units&) = default;
 
+  constexpr Units& operator= (const Units&) = default;
+
   static Units nondimensional () {
-    return Units(RationalConstant::one());
+    return Units(ScalingFactor::one());
+  }
+
+  void set_string (const char* name) {
+    m_name = name;
   }
 
   std::string get_string () const {
     return m_name==nullptr ? to_string(*this) : m_name;
-  }
-
-  void set_string (const std::string& s) {
-    m_name = s.c_str();
   }
 
   constexpr bool is_dimensionless () const {
@@ -129,7 +131,7 @@ private:
   const ScalingFactor                   m_scaling;
   const std::array<RationalConstant,7>  m_units;
 
-  const char*             m_name;
+  const char*                           m_name;
 };
 
 // === Operators/functions overload === //
@@ -140,7 +142,7 @@ private:
 
 // --- Comparison --- //
 
-constexpr inline bool operator==(const Units& lhs, const Units& rhs) {
+constexpr bool operator==(const Units& lhs, const Units& rhs) {
   // Do not compare names, since N == kg*m/(s*s)
   return lhs.m_scaling==rhs.m_scaling &&
          lhs.m_units[0]==rhs.m_units[0] &&
@@ -152,12 +154,12 @@ constexpr inline bool operator==(const Units& lhs, const Units& rhs) {
          lhs.m_units[6]==rhs.m_units[6];
 }
 
-constexpr inline bool operator!=(const Units& lhs, const Units& rhs) {
+constexpr bool operator!=(const Units& lhs, const Units& rhs) {
   return !(lhs==rhs);
 }
 
 // --- Multiplicaiton --- //
-constexpr inline Units operator*(const Units& lhs, const Units& rhs) {
+constexpr Units operator*(const Units& lhs, const Units& rhs) {
   return Units(lhs.m_units[0]+rhs.m_units[0],
                lhs.m_units[1]+rhs.m_units[1],
                lhs.m_units[2]+rhs.m_units[2],
@@ -167,7 +169,7 @@ constexpr inline Units operator*(const Units& lhs, const Units& rhs) {
                lhs.m_units[6]+rhs.m_units[6],
                lhs.m_scaling*rhs.m_scaling);
 }
-constexpr inline Units operator*(const ScalingFactor& lhs, const Units& rhs) {
+constexpr Units operator*(const ScalingFactor& lhs, const Units& rhs) {
   return Units(rhs.m_units[0],
                rhs.m_units[1],
                rhs.m_units[2],
@@ -177,18 +179,18 @@ constexpr inline Units operator*(const ScalingFactor& lhs, const Units& rhs) {
                rhs.m_units[6],
                lhs*rhs.m_scaling);
 }
-constexpr inline Units operator*(const Units& lhs, const ScalingFactor& rhs) {
+constexpr Units operator*(const Units& lhs, const ScalingFactor& rhs) {
   return rhs*lhs;
 }
-constexpr inline Units operator*(const RationalConstant& lhs, const Units& rhs) {
+constexpr Units operator*(const RationalConstant& lhs, const Units& rhs) {
   return ScalingFactor(lhs)*rhs;
 }
-constexpr inline Units operator*(const Units& lhs, const RationalConstant& rhs) {
+constexpr Units operator*(const Units& lhs, const RationalConstant& rhs) {
   return lhs*ScalingFactor(rhs);
 }
 
 // --- Division --- //
-constexpr inline Units operator/(const Units& lhs, const Units& rhs) {
+constexpr Units operator/(const Units& lhs, const Units& rhs) {
   return Units(lhs.m_units[0]-rhs.m_units[0],
                lhs.m_units[1]-rhs.m_units[1],
                lhs.m_units[2]-rhs.m_units[2],
@@ -198,7 +200,7 @@ constexpr inline Units operator/(const Units& lhs, const Units& rhs) {
                lhs.m_units[6]-rhs.m_units[6],
                lhs.m_scaling/rhs.m_scaling);
 }
-constexpr inline Units operator/(const Units& lhs, const ScalingFactor& rhs) {
+constexpr Units operator/(const Units& lhs, const ScalingFactor& rhs) {
   return Units(lhs.m_units[0],
                lhs.m_units[1],
                lhs.m_units[2],
@@ -208,7 +210,7 @@ constexpr inline Units operator/(const Units& lhs, const ScalingFactor& rhs) {
                lhs.m_units[6],
                lhs.m_scaling/rhs);
 }
-constexpr inline Units operator/(const ScalingFactor& lhs, const Units& rhs) {
+constexpr Units operator/(const ScalingFactor& lhs, const Units& rhs) {
   return Units(-rhs.m_units[0],
                -rhs.m_units[1],
                -rhs.m_units[2],
@@ -218,16 +220,16 @@ constexpr inline Units operator/(const ScalingFactor& lhs, const Units& rhs) {
                -rhs.m_units[6],
                lhs/rhs.m_scaling);
 }
-constexpr inline Units operator/(const RationalConstant& lhs, const Units& rhs) {
+constexpr Units operator/(const RationalConstant& lhs, const Units& rhs) {
   return ScalingFactor(lhs)/rhs;
 }
-constexpr inline Units operator/(const Units& lhs, const RationalConstant& rhs) {
+constexpr Units operator/(const Units& lhs, const RationalConstant& rhs) {
   return lhs/ScalingFactor(rhs);
 }
 
 // --- Powers and roots --- //
 
-constexpr inline Units pow(const Units& x, const RationalConstant& p) {
+constexpr Units pow(const Units& x, const RationalConstant& p) {
   return Units(x.m_units[0]*p,
                x.m_units[1]*p,
                x.m_units[2]*p,
@@ -238,7 +240,7 @@ constexpr inline Units pow(const Units& x, const RationalConstant& p) {
                pow(x.m_scaling,p));
 }
 
-constexpr inline Units sqrt(const Units& x) {
+constexpr Units sqrt(const Units& x) {
   return Units(x.m_units[0] / 2,
                x.m_units[1] / 2,
                x.m_units[2] / 2,
@@ -289,38 +291,38 @@ inline std::ostream& operator<< (std::ostream& out, const Units& x) {
 
 // Note: no need to pass a string for these, since the default
 //       string construction would return the same thing.
-const Units m   = Units(1,0,0,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[0]);
-const Units s   = Units(0,1,0,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[1]);
-const Units kg  = Units(0,0,1,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[2]);
-const Units K   = Units(0,0,0,1,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[3]);
-const Units A   = Units(0,0,0,0,1,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[4]);
-const Units mol = Units(0,0,0,0,0,1,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[5]);
-const Units cd  = Units(0,0,0,0,0,0,1,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[6]);
+constexpr Units m   = Units(1,0,0,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[0]);
+constexpr Units s   = Units(0,1,0,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[1]);
+constexpr Units kg  = Units(0,0,1,0,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[2]);
+constexpr Units K   = Units(0,0,0,1,0,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[3]);
+constexpr Units A   = Units(0,0,0,0,1,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[4]);
+constexpr Units mol = Units(0,0,0,0,0,1,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[5]);
+constexpr Units cd  = Units(0,0,0,0,0,0,1,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[6]);
 
 // === DERIVED === //
 
 // Thermomechanics
-const Units day  = 86400*s;                   // day          (time)
-const Units year = 365*day;                   // year         (time)
-const Units g    = Units(kg/1000,"g");        // gram         (mass)
-const Units N    = Units(kg*m/(s*s),"N");     // newton       (force)
-const Units dyn  = N/(10000);                 // dyne         (force)
-const Units Pa   = Units(N/(m*m),"Pa");       // pascal       (pressure)
-const Units bar  = Units(100000*Pa,"bar");    // bar          (pressure)
-const Units atm  = Units(101325*Pa,"atm");    // atmosphere   (pressure)
-const Units J    = Units(N*m,"J");            // joule        (energy)
-const Units W    = Units(J/s,"W");            // watt         (power)
+constexpr Units day  = 86400*s;                   // day          (time)
+constexpr Units year = 365*day;                   // year         (time)
+constexpr Units g    = Units(kg/1000,"g");        // gram         (mass)
+constexpr Units N    = Units(kg*m/(s*s),"N");     // newton       (force)
+constexpr Units dyn  = N/(10000);                 // dyne         (force)
+constexpr Units Pa   = Units(N/(m*m),"Pa");       // pascal       (pressure)
+constexpr Units bar  = Units(100000*Pa,"bar");    // bar          (pressure)
+constexpr Units atm  = Units(101325*Pa,"atm");    // atmosphere   (pressure)
+constexpr Units J    = Units(N*m,"J");            // joule        (energy)
+constexpr Units W    = Units(J/s,"W");            // watt         (power)
 
 // Electro-magnetism
-const Units C    = Units(A*s,"C");            // coulomb      (charge)
-const Units V    = Units(J/C,"V");            // volt         (voltage)
-const Units T    = Units(N/(A*m),"T");        // tesla        (magnetic field)
-const Units F    = Units(C/V,"F");            // farad        (capacitance)
-const Units Wb   = Units(V*s,"Wb");           // weber        (magnetic flux)
-const Units H    = Units(Wb/A,"H");           // henri        (inductance)
-const Units Sv   = Units(J/kg,"Sv");          // sievert      (radiation dose)
-const Units rem  = Units(Sv/100,"rem");       // rem          (radiation dose)
-const Units Hz   = Units(1/s,"Hz");           // hertz        (frequency)
+constexpr Units C    = Units(A*s,"C");            // coulomb      (charge)
+constexpr Units V    = Units(J/C,"V");            // volt         (voltage)
+constexpr Units T    = Units(N/(A*m),"T");        // tesla        (magnetic field)
+constexpr Units F    = Units(C/V,"F");            // farad        (capacitance)
+constexpr Units Wb   = Units(V*s,"Wb");           // weber        (magnetic flux)
+constexpr Units H    = Units(Wb/A,"H");           // henri        (inductance)
+constexpr Units Sv   = Units(J/kg,"Sv");          // sievert      (radiation dose)
+constexpr Units rem  = Units(Sv/100,"rem");       // rem          (radiation dose)
+constexpr Units Hz   = Units(1/s,"Hz");           // hertz        (frequency)
 
 } // namespace units
 

--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -94,6 +94,10 @@ public:
     return m_name==nullptr ? to_string(*this) : m_name;
   }
 
+  void set_string (const std::string& s) {
+    m_name = s.c_str();
+  }
+
   bool is_dimensionless () const {
     return m_units[0].num==0 &&
            m_units[1].num==0 &&

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -75,6 +75,11 @@ TEST_CASE("units_framework", "") {
     REQUIRE (mix_ratio==nondim);
     REQUIRE (to_string(mix_ratio)=="1");
     REQUIRE (mix_ratio.get_string()=="kg/kg");
+
+    Units my_J = N*m;
+    my_J.set_string("J");
+    REQUIRE (my_J.get_string()==std::string("J"));
+
   }
 
   SECTION ("issue-52") {

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -58,10 +58,9 @@ TEST_CASE("units_framework", "") {
     const auto km = kilo*m;
     const auto kPa = kilo*Pa;
 
-    Units nondim (ScalingFactor(1));
-    Units milliJ = milli*N*m;
-    Units mix_ratio = kg/kg;
-    mix_ratio.set_string("kg/kg");
+    constexpr Units nondim (ScalingFactor(1));
+    constexpr Units milliJ = milli*N*m;
+    constexpr Units mix_ratio (kg/kg,"kg/kg");
 
     // Verify operations
     REQUIRE (milliJ == kPa*pow(m,3)/mega);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Units were not constexpr constructible b/c of the runtime string stored. It occurred to me that we can still use `const char*`, by requiring that the unit name is passed in at construction time, which is definitely not a restriction. This would open the door to compile-time checks on units, by templating stuff on units.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## E3SM Stakeholder Feedback
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Turned some vars in the units testing to constexpr vars.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
