### PR TITLE
Add utility to join entries of iterable container into a string

### DIFF
--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -3,6 +3,7 @@
 
 #include <ekat/ekat_parameter_list.hpp>
 
+#include <sstream>
 #include <string>
 #include <vector>
 #include <list>
@@ -38,6 +39,27 @@ std::string strint (const std::string& s, const int i);
 
 // Conver the string to all upper case
 std::string upper_case (const std::string& s);
+
+// Join string-like version of iterable containers entries, using given separator.
+// E.g., if v is a vector of strings, out = v[0]+sep+v[1]+sep+...
+template<typename Iterable>
+std::string join (const Iterable& v, const std::string& sep) {
+  auto it = std::cbegin(v);
+  auto end = std::cend(v);
+  if (it==end) {
+    return "";
+  }
+
+  std::stringstream ss;
+  ss << *it;
+  ++it;
+  for (; it!=end; ++it) {
+    ss << sep;
+    ss << *it;
+  }
+
+  return ss.str();
+}
 
 // Split a string into tokens, according to any of the provided delimiters.
 // If atomic!="", substrings matching atomic will not be split with

--- a/tests/utils/string_utils_tests.cpp
+++ b/tests/utils/string_utils_tests.cpp
@@ -29,6 +29,15 @@ TEST_CASE("string","string") {
     REQUIRE (upper==upper_case(lower));
   }
 
+  SECTION ("join") {
+    std::vector<std::string> v = {"hello","world"};
+    std::list<std::string> l = {"hello","world"};
+    std::string a[4] = {"hello", " ", "world", "!"};
+    REQUIRE (join(v,",")=="hello,world");
+    REQUIRE (join(l,", o beautiful ")=="hello, o beautiful world");
+    REQUIRE (join(a,"")=="hello world!");
+  }
+
   SECTION ("case_insensitive_string") {
     CaseInsensitiveString cis1 = "field_1";
     CaseInsensitiveString cis2 = "fIeLd_1";

--- a/tests/utils/string_utils_tests.cpp
+++ b/tests/utils/string_utils_tests.cpp
@@ -36,6 +36,9 @@ TEST_CASE("string","string") {
     REQUIRE (join(v,",")=="hello,world");
     REQUIRE (join(l,", o beautiful ")=="hello, o beautiful world");
     REQUIRE (join(a,"")=="hello world!");
+
+    std::vector<int> i = {1,2,3};
+    REQUIRE (join(i,",")=="1,2,3");
   }
 
   SECTION ("case_insensitive_string") {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
I've wished several times that C++ had an equivalent to Python's `string.join(iterable)` method. This PR adds the closest thing we can get to that.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a test, with three different types of containers.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
