### PR TITLE
Prevent SetWarningFlags from overwriting existing CFLAGS/FFLAGS/CXXFLAGS

### DIFF
--- a/cmake/EkatSetCompilerFlags.cmake
+++ b/cmake/EkatSetCompilerFlags.cmake
@@ -119,7 +119,7 @@ endmacro ()
 #############################
 # Warnings
 #############################
-macro (SetWarningFlags)
+function (SetWarningFlags)
   # enable all warning but disable Intel vectorization remarks like
   #    "remark: simd loop has only one iteration"
   # since we would get hit with 1000's of those anytime we use Packs with packsize=1.
@@ -133,7 +133,7 @@ macro (SetWarningFlags)
   endif()
 
   SetFlags(FFLAGS ${FFLAGS} CFLAGS -Wall CXXFLAGS ${CXXFLAGS})
-endmacro()
+endfunction()
 
 #############################
 # Profiling/coverage flags


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The macro `SetWarningFlags` used very common names for the f/c/cxx flags vars. Being a macro, it overwrote any homonymus var already in scope (if any).

## Related Issues
Fixes #242 

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in SCREAM.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I verified in scream that doing `set(CXXFLAGS "hello world")` at the top of the main CMakeLists.txt, and printing its value at the bottom will print 
- `-Wall` in master
- `hello world` with this branch.

That is, upon returning from the macro, the original value of the var CXXFLAGS is recovered.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
