### PR TITLE
Turn SetWarningFlags to a macro (or else has no effect)

### DIFF
--- a/cmake/EkatSetCompilerFlags.cmake
+++ b/cmake/EkatSetCompilerFlags.cmake
@@ -119,21 +119,21 @@ endmacro ()
 #############################
 # Warnings
 #############################
-function (SetWarningFlags)
+macro (SetWarningFlags)
   # enable all warning but disable Intel vectorization remarks like
   #    "remark: simd loop has only one iteration"
   # since we would get hit with 1000's of those anytime we use Packs with packsize=1.
 
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-    set (FFLAGS "-warn all -diag-disable=remark -fpscomp logicals")
-    set (CXXFLAGS "-Wall -diag-disable=remark")
+    set (SWF_FFLAGS "-warn all -diag-disable=remark -fpscomp logicals")
+    set (SWF_CXXFLAGS "-Wall -diag-disable=remark")
   else()
-    set (FFLAGS -Wall)
-    set (CXXFLAGS -Wall)
+    set (SWF_FFLAGS -Wall)
+    set (SWF_CXXFLAGS -Wall)
   endif()
 
-  SetFlags(FFLAGS ${FFLAGS} CFLAGS -Wall CXXFLAGS ${CXXFLAGS})
-endfunction()
+  SetFlags(FFLAGS ${SWF_FFLAGS} CFLAGS -Wall CXXFLAGS ${SWF_CXXFLAGS})
+endmacro()
 
 #############################
 # Profiling/coverage flags


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The previous PR for fixing SetWarningFlags was wrong. I did have the correct fix on my laptop, but did not push it, and left the original version on the PR. I triple checked that this _does_ 1) modify `CMAKE_<LANG>_FLAGS` while 2) leave `CXXFLAGS`/`FFLAGS`/`CFLAGS` untouched.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

