### PR TITLE
Make sure the name of the log file is available on all ranks

### DIFF
--- a/src/ekat/logging/ekat_logger.hpp
+++ b/src/ekat/logging/ekat_logger.hpp
@@ -142,8 +142,15 @@ public:
   {
     // make the console sink; default console level = log level
     csink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    if (MpiOutputPolicy::should_log(comm)) {
+
+    // Retrieve log file name (if a file is generated at all) even if
+    // this rank should not log, since we might still need to know the
+    // name of the generated file.
+    if (not std::is_same<LogFilePolicy,LogNoFile>::value) {
       logfile_name = (MpiOutputPolicy::get_log_name(log_name, comm) + suffix);
+    }
+
+    if (MpiOutputPolicy::should_log(comm)) {
       fsink = LogFilePolicy::get_file_sink(logfile_name);
     } else {
       fsink = LogNoFile::get_file_sink(logfile_name);


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
If a file is generated at all (i.e., LogFilePolicy!=LofNoFile), we want all ranks to know the name of the file, since they might need it, even if they don't log anything. E.g., they might need to create a second log file based on the name of the first. This is indeed what has to happen in scream, where homme's log file is called `homme_$atmlogfilename.log`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->


<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
