### PR TITLE
Removed pointless const, which prevented assignment

### DIFF
--- a/src/ekat/util/ekat_rational_constant.hpp
+++ b/src/ekat/util/ekat_rational_constant.hpp
@@ -36,8 +36,8 @@ struct RationalConstant {
 
   using iType = long long;
 
-  const iType num;
-  const iType den;
+  iType num;
+  iType den;
 
   // No default
   RationalConstant () = delete;
@@ -65,6 +65,7 @@ struct RationalConstant {
     // Nothing to do here
   }
   constexpr RationalConstant (const RationalConstant&) = default;
+  constexpr RationalConstant& operator= (const RationalConstant&) = default;
 
   constexpr RationalConstant operator- () const {
     return RationalConstant(-num,den);

--- a/src/ekat/util/ekat_scaling_factor.hpp
+++ b/src/ekat/util/ekat_scaling_factor.hpp
@@ -10,8 +10,8 @@ namespace ekat
 {
 
 struct ScalingFactor {
-  const RationalConstant base;
-  const RationalConstant exp;
+  RationalConstant base;
+  RationalConstant exp;
 
   ScalingFactor () = delete;
   constexpr ScalingFactor (const RationalConstant& s)
@@ -28,6 +28,8 @@ struct ScalingFactor {
   }
 
   constexpr ScalingFactor (const ScalingFactor&) = default;
+
+  constexpr ScalingFactor& operator= (const ScalingFactor&) = default;
 
   static constexpr ScalingFactor one () { return ScalingFactor(1); }
   static constexpr ScalingFactor zero () { return ScalingFactor(0); }

--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -133,10 +133,10 @@ private:
 
   friend std::string to_string(const Units&);
 
-  const ScalingFactor                   m_scaling;
-  const std::array<RationalConstant,7>  m_units;
+  ScalingFactor                   m_scaling;
+  std::array<RationalConstant,7>  m_units;
 
-  const char*                           m_name;
+  const char*                     m_name;
 };
 
 // === Operators/functions overload === //


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The units classes (`Units`, `ScalingFactor`, `RationalConstant`) do not offer a way to alter the class content anyways. And constexpr object will still be fine. Without const, we can now use these classes also at runtime.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in scream, to allow passing units objects inside parameter lists.