### PR TITLE
Allow ADL to kick in in ekat::join

### DIFF
--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -44,8 +44,8 @@ std::string upper_case (const std::string& s);
 // E.g., if v is a vector of strings, out = v[0]+sep+v[1]+sep+...
 template<typename Iterable>
 std::string join (const Iterable& v, const std::string& sep) {
-  auto it = std::cbegin(v);
-  auto end = std::cend(v);
+  auto it = cbegin(v);
+  auto end = cend(v);
   if (it==end) {
     return "";
   }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The utility `join`, that allows to print entries of an iterable separated by given string, was using `std::cbegin` and `std::cend` to get begin/end of iterable. However, the explicit usage of `std::` prevents Argument-Dependent Lookup (ADL) to kick in. For instance, defining `begin/end` at global space for a Kokkos view was now working. Removing the namespace fixes that.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Manually tested in scream. Current tests still verify correctness on std containers.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
