### PR TITLE
Fix reduction utilities, part 2

### DIFF
--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -147,9 +147,9 @@ auto view_reduction (const TeamMember& team,
   if (has_garbage_begin) {
     const auto temp_input = input(pack_loop_begin-1);
     const int first_indx = begin % N;
-    Kokkos::single(Kokkos::PerThread(team),[&] (ValueType& result) {
+    Kokkos::single(Kokkos::PerThread(team),[&] (ValueType& r) {
       for (int j=first_indx; j<N; ++j) {
-        result += temp_input[j];
+        r += temp_input[j];
       }
     },result);
   }
@@ -182,9 +182,9 @@ auto view_reduction (const TeamMember& team,
     // The following is basically a const var, but there are issues with
     // gnu and std=c++14. The macro ConstExceptGnu is defined in ekat_kokkos_types.hpp.
     ConstExceptGnu int last_indx = end % N;
-    Kokkos::single(Kokkos::PerThread(team),[&] (ValueType& result) {
+    Kokkos::single(Kokkos::PerThread(team),[&] (ValueType& r) {
       for (int j=0; j<last_indx; ++j) {
-        result += temp_input[j];
+        r += temp_input[j];
       }
     },result);
   }

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -108,7 +108,7 @@ ValueType parallel_reduce (const TeamMember& team,
  * NOTE: for simd-type usage, the simd-type must a) have a specialization of ekat::ScalarTraits
  *       that sets is_simd=true, b) support operator[](int), and c) have a compile-time size
  *       equal to the length of the simd array times the size of the individual element type.
- *       Furtermore, a specialization of Kokkos::reduction_identity<T> must be available for
+ *       Furthermore, a specialization of Kokkos::reduction_identity<T> must be available for
  *       the simd type T.
  * NOTE: we do not provide an overload with Serialized defaulted, since this fcn is an impl
  *       detail, and, normally, should not be used by customer apps

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -399,7 +399,7 @@ struct ExeSpaceUtils<EkatGpuSpace> {
                              const int& end,
                              const Lambda& lambda)
   {
-    return parallel_reduce<Serialize,ValueType>(team, begin, end, lambda, result);
+    return parallel_reduce<Serialize,ValueType>(team, begin, end, lambda);
   }
 
   // Requires user to specify whether to serialize or not


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We want to make sure that the bug we had related to reduction utilities never shows up again. Therefore, we force using a version of reduction utilities that returns the value, rather than update an input var. We still _do_ have one utility that takes the result as a ref, namely one overload of `impl::parallel_reduce`. We need that in order to perform Serialized reductions in `impl::view_reduction`. The user could technically still get the bug by using that overload improperly (e.g., passing a view entry as result). My hope is that, being the method in the `impl` namespace, and putting a big WARNING in the inline documentation, the risk of this happening is very minimal.

~~Bonus: fix the TPL include paths, so that they are treated as SYSTEM paths (if `EKAT_DISABLE_TPL_WARNINGS=ON`). This should fix  all the warnings from spdlog we get on GPU builds.~~ The commit(s) that did this got lost. I will issue a separate PR.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
