### PR TITLE
Fix warnings due to TPLs includes

### DIFF
--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -102,7 +102,7 @@ macro (EkatDisableAllWarning targetName)
   target_compile_options (${targetName} PRIVATE
     $<$<COMPILE_LANGUAGE:C>:$<$<C_COMPILER_ID:GNU>:-w> $<$<C_COMPILER_ID:Intel>: -w>>)
   target_compile_options (${targetName} PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:GNU>:-w> $<$<CXX_COMPILER_ID:Intel>: -w>>)
+    $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:GNU>:-w -fcompare-debug-second> $<$<CXX_COMPILER_ID:Intel>: -w>>)
   if (${CMAKE_VERSION} VERSION_LESS "3.14.0")
     target_compile_options (${targetName} PRIVATE
       $<$<COMPILE_LANGUAGE:Fortran>:$<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","GNU">:-w> $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","Intel">: -w>>)

--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -111,6 +111,9 @@ macro (EkatDisableAllWarning targetName)
       $<$<COMPILE_LANGUAGE:Fortran>:$<$<Fortran_COMPILER_ID:GNU>:-w> $<$<Fortran_COMPILER_ID:Intel>: -w>>)
   endif()
 
+  get_target_property (tgt_include_dirs ${targetName} INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(${targetName} SYSTEM BEFORE PUBLIC ${tgt_include_dirs})
+
 endmacro (EkatDisableAllWarning)
 
 function(separate_cut_arguments prefix options oneValueArgs multiValueArgs return_varname)

--- a/src/ekat/ekat_session.cpp
+++ b/src/ekat/ekat_session.cpp
@@ -8,15 +8,14 @@
 
 namespace ekat_impl {
 
-static int get_default_fpes () {
 #ifdef EKAT_ENABLE_FPE_DEFAULT_MASK
+static int get_default_fpes () {
   return (FE_DIVBYZERO |
           FE_INVALID   |
           FE_OVERFLOW);
-#else
   return 0;
-#endif
 }
+#endif
 
 // If we initialize from inside a Fortran code, we don't have access to
 // char** args to pass to Kokkos::initialize. In this case we need to do


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The spdlog headers cause a lot of warnings when building on GPU. Albeit benign, these warnings pollute the compilation output log quite a bit. This PR ensures that, if `EKAT_DISABLE_TPL_WARNINGS=ON`, the include paths of TPLs are added with `-isystem` to the compile line, so that their warnings are silenced. This would not be necessary if `target_link_libraries` supported a `SYSTEM` option (much like `target_include_directories`).

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually verified that no warnings are generated when building on weaver with this PR (while there are several with master).
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
