### PR TITLE
Allow EKAT to be built without MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,21 +21,29 @@ include(EkatBuildSpdlog)
 # EKAT has mostly C++, but some Fortran too
 project (EKAT C CXX Fortran)
 
-# EKAT requires MPI.
-find_package(MPI REQUIRED COMPONENTS C)
+# Here's an option for disabling MPI (because no, not everyone needs it
+# all the time).
+option (EKAT_ENABLE_MPI "Whether EKAT requires MPI." ON)
 
-# NOTE: may be an overkill, but depending on which FindMPI module is called,
-#       if _FIND_REQUIRED is not checked, we may not get a fatal error
-#       if the required components are not found. So check the _FOUND var.
-if (NOT MPI_C_FOUND)
-  message (FATAL_ERROR "EKAT *requires* the C component of MPI to be found")
+if (EKAT_ENABLE_MPI)
+  find_package(MPI REQUIRED COMPONENTS C)
+
+  # NOTE: may be an overkill, but depending on which FindMPI module is called,
+  #       if _FIND_REQUIRED is not checked, we may not get a fatal error
+  #       if the required components are not found. So check the _FOUND var.
+  if (NOT MPI_C_FOUND)
+    message (FATAL_ERROR "EKAT *requires* the C component of MPI to be found")
+  endif()
+
+  # We should avoid cxx bindings in mpi; they are already deprecated,
+  # and can cause headaches at link time, cause they require -lmpi_cxx
+  # (for openpmi; -lmpicxx for mpich) flag.
+  include(EkatMpiUtils)
+  DisableMpiCxxBindings()
+
+  # MPI-related options
+  option (EKAT_MPI_ERRORS_ARE_FATAL " Whether EKAT should crash when MPI errors happen." ON)
 endif()
-
-# We should avoid cxx bindings in mpi; they are already deprecated,
-# and can cause headaches at link time, cause they require -lmpi_cxx
-# (for openpmi; -lmpicxx for mpich) flag.
-include(EkatMpiUtils)
-DisableMpiCxxBindings()
 
 include(EkatUtils)
 IsDebugBuild(EKAT_IS_DEBUG_BUILD)
@@ -51,7 +59,6 @@ message(STATUS "Installation prefix: ${CMAKE_INSTALL_PREFIX}")
 ###  EKAT CONFIG OPTIONS ###
 ############################
 
-option (EKAT_MPI_ERRORS_ARE_FATAL " Whether EKAT should crash when MPI errors happen." ON)
 option (EKAT_DEFAULT_BFB "Whether EKAT should default to BFB behavior whenever possible/appropriate." ${EKAT_IS_DEBUG_BUILD})
 option (EKAT_ENABLE_FPE "Whether to enable support for floating point exceptions" ON)
 if (EKAT_ENABLE_FPE)
@@ -142,7 +149,9 @@ add_subdirectory(src/ekat)
 ############################
 
 # Set some vars needed to configure test-launcher
-SetMpiRuntimeEnvVars()
+if (EKAT_ENABLE_MPI)
+  SetMpiRuntimeEnvVars()
+endif()
 if (EKAT_ENABLE_GPU)
   set (TEST_LAUNCHER_ON_GPU True)
 else()

--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -14,17 +14,22 @@ set(EKAT_SOURCES
   io/ekat_yaml.cpp
   io/ekat_array_io.cpp
   io/ekat_array_io_mod.f90
-  mpi/ekat_comm.cpp
   util/ekat_arch.cpp
   util/ekat_string_utils.cpp
   util/ekat_test_utils.cpp
 )
 
+if (EKAT_ENABLE_MPI)
+  set(EKAT_SOURCES ${EKAT_SOURCES} mpi/ekat_comm.cpp)
+endif()
+
 # Create the library, and set all its properties
 add_library(ekat ${EKAT_SOURCES})
 
-# Link MPI
-target_link_libraries (ekat PUBLIC MPI::MPI_C)
+if (EKAT_ENABLE_MPI)
+  # Link MPI
+  target_link_libraries (ekat PUBLIC MPI::MPI_C)
+endif()
 
 target_include_directories(ekat PUBLIC
   $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>

--- a/src/ekat/ekat_assert.cpp
+++ b/src/ekat/ekat_assert.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 
+#include "ekat_assert.hpp"
+#include "ekat_session.hpp"
+
 #ifdef EKAT_ENABLE_MPI
 #include <mpi.h>
 #endif
-
-#include "ekat_assert.hpp"
-#include "ekat_session.hpp"
 
 #ifdef EKAT_ENABLE_FPE
 #include "util/ekat_feutils.hpp"

--- a/src/ekat/ekat_assert.cpp
+++ b/src/ekat/ekat_assert.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 
+#ifdef EKAT_ENABLE_MPI
 #include <mpi.h>
+#endif
 
 #include "ekat_assert.hpp"
 #include "ekat_session.hpp"
@@ -24,6 +26,7 @@ void runtime_abort(const std::string& message, int code) {
   // Finalize ekat (e.g., finalize kokkos);
   finalize_ekat_session();
 
+#ifdef EKAT_ENABLE_MPI
   // Check if mpi is active. If so, use MPI_Abort, otherwise, simply std::abort
   int flag;
   MPI_Initialized(&flag);
@@ -32,6 +35,9 @@ void runtime_abort(const std::string& message, int code) {
   } else {
     std::abort();
   }
+#else
+  std::abort();
+#endif
 }
 
 } // namespace ekat

--- a/src/ekat/ekat_config.h.in
+++ b/src/ekat/ekat_config.h.in
@@ -1,8 +1,13 @@
 #ifndef EKAT_CONFIG_H
 #define EKAT_CONFIG_H
 
+// Whether MPI is enabled
+#cmakedefine EKAT_ENABLE_MPI
+
+#ifdef EKAT_ENABLE_MPI
 // Whether MPI errors should abort
 #cmakedefine EKAT_MPI_ERRORS_ARE_FATAL
+#endif
 
 // Whether we allow use of CONSTEXPR_ASSERT macro
 #cmakedefine EKAT_CONSTEXPR_ASSERT

--- a/src/ekat/mpi/ekat_comm.hpp
+++ b/src/ekat/mpi/ekat_comm.hpp
@@ -1,6 +1,10 @@
 #ifndef EKAT_COMM_HPP
 #define EKAT_COMM_HPP
 
+#include <ekat_config.h>
+
+#ifdef EKAT_ENABLE_MPI
+
 #include <type_traits>
 
 #include <mpi.h>
@@ -143,5 +147,7 @@ void Comm::all_gather (T* inout_vals, const int count) const
 }
 
 } // namespace ekat
+
+#endif // EKAT_ENABLE_MPI
 
 #endif // EKAT_COMM_HPP

--- a/src/ekat/mpi/ekat_comm.hpp
+++ b/src/ekat/mpi/ekat_comm.hpp
@@ -1,7 +1,7 @@
 #ifndef EKAT_COMM_HPP
 #define EKAT_COMM_HPP
 
-#include <ekat_config.h>
+#include <ekat/ekat_config.h>
 
 #ifdef EKAT_ENABLE_MPI
 

--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -2,12 +2,16 @@
 
 #include "catch2/catch.hpp"
 
+#include "ekat/ekat_config.h"
+
 #include "ekat/mpi/ekat_comm.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include "ekat/ekat_session.hpp"
 #include "ekat/ekat_assert.hpp"
 
+#ifdef EKAT_ENABLE_MPI
 #include <mpi.h>
+#endif
 
 void ekat_initialize_test_session (int argc, char** argv, const bool print_config);
 void ekat_finalize_test_session ();

--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -113,8 +113,10 @@ int main (int argc, char **argv) {
   // to not use it, and provide one instead.
   ekat_finalize_test_session ();
 
+#ifdef EKAT_ENABLE_MPI
   // Finalize MPI
   MPI_Finalize();
+#endif
 
   // Return test result
   return num_failed != 0 ? 1 : 0;

--- a/src/ekat/util/ekat_catch_main.cpp
+++ b/src/ekat/util/ekat_catch_main.cpp
@@ -98,10 +98,10 @@ int main (int argc, char **argv) {
 #ifndef NDEBUG
 #ifdef EKAT_ENABLE_MPI
   MPI_Barrier(comm.mpi_comm());
-#endif
   std::cout << "Starting catch session on rank " << comm.rank() << " out of " << comm.size() << "\n";
-#ifdef EKAT_ENABLE_MPI
   MPI_Barrier(comm.mpi_comm());
+#else
+  std::cout << "Starting catch session\n";
 #endif
 #endif
 


### PR DESCRIPTION
This PR makes it possible to use EKAT/Kokkos without MPI. I know many people don't care about this option and/or view it as counterproductive, but there are actually several interesting cases where (a) MPI is not needed at all (like column physics) and (b) it complicates development environments and workflows. One ignores these circumstances at the cost of a large productivity hit.

These changes illustrate the type of effort needed to enable a no-MPI build. I'm happy to maintain the "no-MPI-ness" in the near term, because the EAGLES aerosol work is column physics and does not need MPI in its standalone mode. If there's anything I can do to make it less distracting to support this option, let's talk!
