### PR TITLE
Fix CMake error in EkatDisableAllWarning

### DIFF
--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -112,7 +112,9 @@ macro (EkatDisableAllWarning targetName)
   endif()
 
   get_target_property (tgt_include_dirs ${targetName} INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories(${targetName} SYSTEM BEFORE PUBLIC ${tgt_include_dirs})
+  if (tgt_include_dirs)
+    target_include_directories(${targetName} SYSTEM BEFORE PUBLIC ${tgt_include_dirs})
+  endif()
 
 endmacro (EkatDisableAllWarning)
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The utility was _assuming_ that the target had the `INTERFACE_INCLUDE_DIRECTORIES` property defined, but that's not necessarily the case. Therefore, before using the result of `get_target_property`, we need to check that the property was found.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
The fix is needed in order to build scream.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Verified this fix works building scream.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
