### PR TITLE
Fix cmake utility EkatDisableAllWarning

### DIFF
--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -110,12 +110,6 @@ macro (EkatDisableAllWarning targetName)
     target_compile_options (${targetName} PRIVATE
       $<$<COMPILE_LANGUAGE:Fortran>:$<$<Fortran_COMPILER_ID:GNU>:-w> $<$<Fortran_COMPILER_ID:Intel>: -w>>)
   endif()
-
-  get_target_property (tgt_include_dirs ${targetName} INTERFACE_INCLUDE_DIRECTORIES)
-  if (tgt_include_dirs)
-    target_include_directories(${targetName} SYSTEM BEFORE PUBLIC ${tgt_include_dirs})
-  endif()
-
 endmacro (EkatDisableAllWarning)
 
 function(separate_cut_arguments prefix options oneValueArgs multiValueArgs return_varname)


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The current impl was changing the order of the include directories, by grabbing all interface dirs, and re-adding them as include dirs with SYSTEM specifier. Instead, the correct thing to do is to set the [INTERFACE_SYSTEM_INCLUDE_DIRECTORIES](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_SYSTEM_INCLUDE_DIRECTORIES.html) to contain all the include directories. However, this still doesn't fix failures we were observing in SCREAM. There seem to be no way to get the feature to work, so I'm going to roll it back.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Current impl was causing nonsensical failures in SCREAM on blake.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I verified that, with this mod, SCREAM tests pass on blake.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
