### PR TITLE
Fix bug in TeamUtils get/release_workspace_idx for GPU.

### DIFF
--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -573,31 +573,23 @@ class TeamUtils<ValueType,EkatGpuSpace> : public TeamUtilsCommonBase<ValueType,E
   KOKKOS_INLINE_FUNCTION
   int get_workspace_idx(const MemberType& team_member) const
   {
-    EKAT_KERNEL_ASSERT_MSG (this->_num_teams>0, "Error! TeamUtils not yet inited.\n");
+    EKAT_KERNEL_ASSERT_MSG (this->_num_teams > 0, "Error! TeamUtils not yet inited.\n");
 
-    if (!_need_ws_sharing) {
+    if ( ! _need_ws_sharing) {
       return team_member.league_rank();
-    }
-    else {
-      int ws_idx = 0;
-      Kokkos::single(Kokkos::PerTeam(team_member), [&] () {
+    } else {
+      int ws_idx_broadcast;
+      Kokkos::single(Kokkos::PerTeam(team_member), [&] (int& ws_idx) {
         ws_idx = team_member.league_rank() % _num_ws_slots;
-        if (!Kokkos::atomic_compare_exchange_strong(&_open_ws_slots(ws_idx), (flag_type) 0, (flag_type)1)) {
+        if ( ! Kokkos::atomic_compare_exchange_strong(&_open_ws_slots(ws_idx), (flag_type) 0, (flag_type) 1)) {
           rnd_type rand_gen = _rand_pool.get_state(team_member.league_rank());
           ws_idx = Kokkos::rand<rnd_type, int>::draw(rand_gen) % _num_ws_slots;
-          while (!Kokkos::atomic_compare_exchange_strong(&_open_ws_slots(ws_idx), (flag_type) 0, (flag_type)1)) {
+          while ( ! Kokkos::atomic_compare_exchange_strong(&_open_ws_slots(ws_idx), (flag_type) 0, (flag_type) 1))
             ws_idx = Kokkos::rand<rnd_type, int>::draw(rand_gen) % _num_ws_slots;
-          }
+          Kokkos::memory_fence();
         }
-      });
-
-      // broadcast the idx to the team with a simple reduce
-      int ws_idx_max_reduce;
-      Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, 1), [&] (int, int& ws_idx_max) {
-        ws_idx_max = ws_idx;
-      }, Kokkos::Max<int>(ws_idx_max_reduce));
-      team_member.team_barrier();
-      return ws_idx_max_reduce;
+      }, ws_idx_broadcast);
+      return ws_idx_broadcast;
     }
   }
 
@@ -609,7 +601,8 @@ class TeamUtils<ValueType,EkatGpuSpace> : public TeamUtilsCommonBase<ValueType,E
       team_member.team_barrier();
       Kokkos::single(Kokkos::PerTeam(team_member), [&] () {
         flag_type volatile* const e = &_open_ws_slots(ws_idx);
-        *e = (flag_type)0;
+        *e = (flag_type) 0;
+        Kokkos::memory_fence();
       });
     }
   }


### PR DESCRIPTION
We need a memory_fence so that read/writes to work slots are sequenced properly w.r.t. the lock on the workspace slots.

Add a test that fails in ~2 out of 5 trials with the buggy code. Passes 100 times in a row with the fix.

Use Kokkos::single's broadcast instead of a separate reduction.