### PR TITLE
Eliminating usage of Kokkos private headers.

### DIFF
--- a/src/ekat/ekat_pack_utils.hpp
+++ b/src/ekat/ekat_pack_utils.hpp
@@ -4,7 +4,7 @@
 #include "ekat/ekat_pack.hpp"
 #include "ekat/ekat_assert.hpp"
 
-#include "Kokkos_Pair.hpp"
+#include <Kokkos_Core.hpp>
 
 namespace ekat {
 

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -4,7 +4,7 @@
 #include "ekat/ekat_assert.hpp"
 #include "ekat/ekat_workspace.hpp"
 
-#include <Kokkos_Array.hpp>
+#include <Kokkos_Core.hpp>
 #include <map>
 
 namespace ekat {

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -11,7 +11,7 @@
 #include "ekat/ekat.hpp"
 #include "ekat/ekat_pack.hpp"
 
-#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
 
 #include <cassert>
 #include <cstring>

--- a/src/ekat/kokkos/ekat_kokkos_utils.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_utils.hpp
@@ -11,7 +11,7 @@
 #include "ekat/ekat.hpp"
 #include "ekat/ekat_pack.hpp"
 
-#include "Kokkos_Random.hpp"
+#include <Kokkos_Core.hpp>
 
 #include <cassert>
 #include <cstring>


### PR DESCRIPTION
This eliminates some pretty irritating compile warnings related to [the recent reorganization of public/private headers in Kokkos](https://github.com/kokkos/kokkos/issues/4856).