### PR TITLE
Refine use of memory_fence in get/release_workspace_idx for GPU.

### DIFF
--- a/tests/kokkos/workspace_tests.cpp
+++ b/tests/kokkos/workspace_tests.cpp
@@ -106,9 +106,15 @@ static void unittest_workspace_idx_lock()
     Kokkos::parallel_for(ttr, h);
     workspace.release(v);
   };
-  int err;
-  Kokkos::parallel_reduce(policy, f, err);
-  REQUIRE(err == 0);
+  for (int trial = 0; trial < 10; ++trial) {
+    // Failures in the buggy case (missing memory_fence in
+    // release_workspace_idx) are nondeterministic, so run this loop multiple
+    // times to increase the strength of the test. In the buggy case on a V100,
+    // I find that this test fails nearly 100% of the time.
+    int err;
+    Kokkos::parallel_reduce(policy, f, err);
+    REQUIRE(err == 0);
+  }
 }    
 
 static void unittest_workspace()


### PR DESCRIPTION
After thinking about read/write sequencing some more, I decided one memory_fence is not needed and the other should be placed earlier. I also strengthened the test. It now fails nearly 100% of the time in the buggy case, and multiple 100s of runs in the fixed case pass.

Edit: In fact, calling both memory_fences is best. But this PR still fixes placement of one, strengthens the test, and adds a bunch of comments.