### PR TITLE
Allow to extract a rank0 subview of a rank1 view

### DIFF
--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -11,6 +11,18 @@ namespace ekat {
 // Note: we template on scalar type ST to allow both builtin and Packs,
 //       as well as to allow const/non-const versions.
 
+// --- Rank1 --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLR<ST,Props...>>
+subview(const ViewLR<ST*,Props...>& v,
+        const int i0) {
+  assert(v.data() != nullptr);
+  assert(i0>=0 && i0 < v.extent_int(0));
+  return Unmanaged<ViewLR<ST,Props...>>(
+      &v.impl_map().reference(i0, 0));
+}
+
 // --- Rank2 --- //
 template <typename ST, typename... Props>
 KOKKOS_INLINE_FUNCTION

--- a/src/ekat/std_meta/ekat_std_type_traits.hpp
+++ b/src/ekat/std_meta/ekat_std_type_traits.hpp
@@ -46,8 +46,8 @@ struct DataND {
   using type = typename DataND<T,N-1>::type*;
 };
 template<typename T>
-struct DataND<T,1> {
-  using type = T*;
+struct DataND<T,0> {
+  using type = T;
 };
 
 } // namespace ekat

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -446,6 +446,10 @@ TEST_CASE("subviews") {
         if (v4_1(m)!=v6(i0,i1,i2,i3,i4,m)) ++ndiffs;
         if (v3_1(m)!=v6(i0,i1,i2,i3,i4,m)) ++ndiffs;
         if (v2_1(m)!=v6(i0,i1,i2,i3,i4,m)) ++ndiffs;
+
+        // Check rank0 subview
+        auto v0 = ekat::subview(v1,m);
+        if (v0()!=v1(m)) ++ndiffs;
       }
 
       // Make sure that our diffs counting strategy works


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In doing some work in EAMxx, I found myself in need of being able to extract a rank0 subview from a rank1 view. Since kokkos _does_ support rank0 views, this should be supported in EKAT, so I added it.

Note: I only added the possibility to subview a rank1 view with 1 index. It would be possible to add equivalent for subviewing a rankN view with N indices, but I don't know if that's necessary. If you think I should, I can add it.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in some EAMxx work.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a test in the kokkos subview tests.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
