### PR TITLE
Allow to pass option to SetCudaFlag

### DIFF
--- a/cmake/EkatSetCompilerFlags.cmake
+++ b/cmake/EkatSetCompilerFlags.cmake
@@ -355,7 +355,7 @@ macro (SetCudaFlags targetName)
       message (FATAL_ERROR "Error! Unable to find CUDA.")
     endif()
 
-    set(options)
+    set(options CUDA_LANG)
     set(args1v)
     set(argsMv FLAGS)
     cmake_parse_arguments(SCF "${options}" "${args1v}" "${argsMv}" ${ARGN})
@@ -374,8 +374,15 @@ macro (SetCudaFlags targetName)
     endif()
 
     # Set the flags on the target
-    target_compile_options (${targetName} PUBLIC
-      "$<$<COMPILE_LANGUAGE:CXX>:${FLAGS}>")
+    if (SCF_CUDA_LANG)
+      # User is setting the src files language to CUDA
+      target_compile_options (${targetName} PUBLIC
+        "$<$<COMPILE_LANGUAGE:CUDA>:${FLAGS}>")
+    else()
+      # We assume the user is setting the src files lang to CXX
+      target_compile_options (${targetName} PUBLIC
+        "$<$<COMPILE_LANGUAGE:CXX>:${FLAGS}>")
+    endif()
   endif()
 endmacro()
 


### PR DESCRIPTION
So that the desired flags are set for sources with CUDA language (in case the user changes the LANGUAGE property for its source files)

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We want to use this macro to set project-wide cuda flags to all targets. But some targets may decide to set the compiler language of its C++ source files to CUDA. In that case, in order for this macro to be effective, the user must be able to inform it that flags must be set for COMPILE_LANGUAGE=CUDA.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in EAMxx