### PR TITLE
Use TeamVectorRange when possible

### DIFF
--- a/scripts/jenkins/jenkins.sh
+++ b/scripts/jenkins/jenkins.sh
@@ -17,6 +17,7 @@ export SCREAM_SCRIPTS=${WORK_DIR}/scream/components/eamxx/scripts
 export JENKINS_SCRIPT_DIR=${SCREAM_SCRIPTS}/jenkins # some scream env setups depend on this
 source ${SCREAM_SCRIPTS}/jenkins/${NODE_NAME}_setup
 source ${SCREAM_SCRIPTS}/source_to_load_scream_env.sh
+export SCREAM_MACHINE
 
 BATCHP=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE batch)
 

--- a/scripts/jenkins/jenkins.sh
+++ b/scripts/jenkins/jenkins.sh
@@ -9,10 +9,10 @@ fi
 
 cd $WORKSPACE/${BUILD_ID}/
 
-WORK_DIR=$(pwd)
+export WORK_DIR=$(pwd)
 
 # setup env, use SCREAM env
-SCREAM_SCRIPTS=${WORK_DIR}/scream/components/eamxx/scripts
+export SCREAM_SCRIPTS=${WORK_DIR}/scream/components/eamxx/scripts
 source ${SCREAM_SCRIPTS}/jenkins/${NODE_NAME}_setup
 source ${SCREAM_SCRIPTS}/source_to_load_scream_env.sh
 

--- a/scripts/jenkins/jenkins.sh
+++ b/scripts/jenkins/jenkins.sh
@@ -3,5 +3,20 @@
 export JENKINS_SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
 
+if [ -z "$WORKSPACE" ]; then
+    echo "Must run from Jenkins job"
+fi
+
+cd $WORKSPACE/${BUILD_ID}/
+
+WORK_DIR=$(pwd)
+
+# setup env, use SCREAM env
+SCREAM_SCRIPTS=${WORK_DIR}/scream/components/eamxx/scripts
+source ${SCREAM_SCRIPTS}/jenkins/${NODE_NAME}_setup
+source ${SCREAM_SCRIPTS}/source_to_load_scream_env.sh
+
+BATCHP=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE batch)
+
 set -o pipefail
-$JENKINS_SCRIPT_DIR/jenkins_impl.sh 2>&1 | tee JENKINS_$DATE_STAMP
+$BATCHP $JENKINS_SCRIPT_DIR/jenkins_impl.sh 2>&1 | tee JENKINS_$DATE_STAMP

--- a/scripts/jenkins/jenkins.sh
+++ b/scripts/jenkins/jenkins.sh
@@ -1,22 +1,24 @@
 #! /bin/bash -xe
 
-export JENKINS_SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+EKAT_JENKINS_SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
 
 if [ -z "$WORKSPACE" ]; then
     echo "Must run from Jenkins job"
+    exit 1
 fi
 
-cd $WORKSPACE/${BUILD_ID}/
+cd $WORKSPACE/${BUILD_ID}
 
 export WORK_DIR=$(pwd)
 
 # setup env, use SCREAM env
 export SCREAM_SCRIPTS=${WORK_DIR}/scream/components/eamxx/scripts
+export JENKINS_SCRIPT_DIR=${SCREAM_SCRIPTS}/jenkins # some scream env setups depend on this
 source ${SCREAM_SCRIPTS}/jenkins/${NODE_NAME}_setup
 source ${SCREAM_SCRIPTS}/source_to_load_scream_env.sh
 
 BATCHP=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE batch)
 
 set -o pipefail
-$BATCHP $JENKINS_SCRIPT_DIR/jenkins_impl.sh 2>&1 | tee JENKINS_$DATE_STAMP
+$BATCHP $EKAT_JENKINS_SCRIPT_DIR/jenkins_impl.sh 2>&1 | tee JENKINS_$DATE_STAMP

--- a/scripts/jenkins/jenkins_impl.sh
+++ b/scripts/jenkins/jenkins_impl.sh
@@ -38,7 +38,7 @@ if [[ "$ISCUDA" == "False" ]]; then
     EKAT_THREAD_SETTINGS="-DEKAT_TEST_THREAD_INC=2 -DEKAT_TEST_MAX_THREADS=14"
 fi
 
-# Build and test double precision
+# Build and test single precision
 mkdir -p ekat-build/ekat-sp && cd ekat-build/ekat-sp && rm -rf *
 
 cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
@@ -80,7 +80,7 @@ else
 fi
 cd ${WORK_DIR}
 
-# Build and test single precision
+# Build and test double precision
 mkdir -p ekat-build/ekat-dp && cd ekat-build/ekat-dp && rm -rf *
 
 cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \

--- a/scripts/jenkins/jenkins_impl.sh
+++ b/scripts/jenkins/jenkins_impl.sh
@@ -55,7 +55,7 @@ fi
 # Build and test double precision
 mkdir -p ekat-build/ekat-sp && cd ekat-build/ekat-sp && rm -rf *
 
-cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
     -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-sp    \
     -DCMAKE_BUILD_TYPE=DEBUG                                   \
     -DCMAKE_C_COMPILER=${MPICC}                                \
@@ -97,7 +97,7 @@ cd ${WORK_DIR}
 # Build and test single precision
 mkdir -p ekat-build/ekat-dp && cd ekat-build/ekat-dp && rm -rf *
 
-cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
     -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-dp    \
     -DCMAKE_BUILD_TYPE=DEBUG                                   \
     -DCMAKE_C_COMPILER=${MPICC}                                \
@@ -140,7 +140,7 @@ if [[ "$ISCUDA" == "False" ]]; then
   # Build and test double precision with FPE on, and packsize=1
   mkdir -p ekat-build/ekat-fpe && cd ekat-build/ekat-fpe && rm -rf *
 
-  cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+  ${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
       -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-fpe   \
       -DCMAKE_BUILD_TYPE=DEBUG                                   \
       -DCMAKE_C_COMPILER=${MPICC}                                \
@@ -185,7 +185,7 @@ if [[ "$ISCUDA" == "True" ]]; then
   # Build and test Cuda UVM
   mkdir -p ekat-build/ekat-uvm && cd ekat-build/ekat-uvm && rm -rf *
 
-  cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+  ${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
       -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-uvm   \
       -DCMAKE_BUILD_TYPE=DEBUG                                   \
       -DCMAKE_C_COMPILER=${MPICC}                                \

--- a/scripts/jenkins/jenkins_impl.sh
+++ b/scripts/jenkins/jenkins_impl.sh
@@ -1,19 +1,6 @@
 #! /bin/bash -x
 
-if [ -z "$WORKSPACE" ]; then
-    echo "Must run from Jenkins job"
-fi
-
-cd $WORKSPACE/${BUILD_ID}/
-
-WORK_DIR=$(pwd)
-
 rm -rf ekat-build ekat-install
-
-# setup env, use SCREAM env
-SCREAM_SCRIPTS=${WORK_DIR}/scream/components/eamxx/scripts
-source ${SCREAM_SCRIPTS}/jenkins/${NODE_NAME}_setup
-source ${SCREAM_SCRIPTS}/source_to_load_scream_env.sh
 
 # Merge origin master, to make sure we're up to date. If merge fails, exit.
 cd ${WORK_DIR}/ekat-src;
@@ -28,7 +15,6 @@ fi
 MPICXX=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE cxx_compiler)
 MPICC=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE c_compiler)
 MPIF90=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE f90_compiler)
-BATCHP=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE batch)
 COMP_J=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE comp_j)
 TEST_J=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE test_j)
 ISCUDA=$(${SCREAM_SCRIPTS}/query-scream $SCREAM_MACHINE cuda)
@@ -55,7 +41,7 @@ fi
 # Build and test double precision
 mkdir -p ekat-build/ekat-sp && cd ekat-build/ekat-sp && rm -rf *
 
-${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
     -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-sp    \
     -DCMAKE_BUILD_TYPE=DEBUG                                   \
     -DCMAKE_C_COMPILER=${MPICC}                                \
@@ -73,12 +59,12 @@ if [ $? -ne 0 ]; then
     echo "Something went wrong while configuring the SP case."
     RET_SP=1
 else
-    ${BATCHP} make -j ${COMP_J}
+    make -j ${COMP_J}
     if [ $? -ne 0 ]; then
         echo "Something went wrong while building the SP case."
         RET_SP=1
     else
-        ${BATCHP} ctest --output-on-failure
+        ctest --output-on-failure
         if [ $? -ne 0 ]; then
             echo "Something went wrong while testing the SP case."
             RET_SP=1
@@ -97,7 +83,7 @@ cd ${WORK_DIR}
 # Build and test single precision
 mkdir -p ekat-build/ekat-dp && cd ekat-build/ekat-dp && rm -rf *
 
-${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
     -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-dp    \
     -DCMAKE_BUILD_TYPE=DEBUG                                   \
     -DCMAKE_C_COMPILER=${MPICC}                                \
@@ -115,12 +101,12 @@ if [ $? -ne 0 ]; then
     echo "Something went wrong while configuring the DP case."
     RET_DP=1
 else
-    ${BATCHP} make -j ${COMP_J}
+    make -j ${COMP_J}
     if [ $? -ne 0 ]; then
         echo "Something went wrong while building the DP case."
         RET_DP=1
     else
-        ${BATCHP} ctest --output-on-failure
+        ctest --output-on-failure
         if [ $? -ne 0 ]; then
             echo "Something went wrong while testing the DP case."
             RET_DP=1
@@ -140,7 +126,7 @@ if [[ "$ISCUDA" == "False" ]]; then
   # Build and test double precision with FPE on, and packsize=1
   mkdir -p ekat-build/ekat-fpe && cd ekat-build/ekat-fpe && rm -rf *
 
-  ${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+  cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
       -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-fpe   \
       -DCMAKE_BUILD_TYPE=DEBUG                                   \
       -DCMAKE_C_COMPILER=${MPICC}                                \
@@ -159,12 +145,12 @@ if [[ "$ISCUDA" == "False" ]]; then
       echo "Something went wrong while configuring the FPE case."
       RET_FPE=1
   else
-      ${BATCHP} make -j ${COMP_J}
+      make -j ${COMP_J}
       if [ $? -ne 0 ]; then
           echo "Something went wrong while building the FPE case."
           RET_FPE=1
       else
-          ${BATCHP} ctest --output-on-failure
+          ctest --output-on-failure
           if [ $? -ne 0 ]; then
               echo "Something went wrong while testing the FPE case."
               RET_FPE=1
@@ -185,7 +171,7 @@ if [[ "$ISCUDA" == "True" ]]; then
   # Build and test Cuda UVM
   mkdir -p ekat-build/ekat-uvm && cd ekat-build/ekat-uvm && rm -rf *
 
-  ${BATCHP} cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
+  cmake -C ${WORK_DIR}/ekat-src/cmake/machine-files/${NODE_NAME}.cmake \
       -DCMAKE_INSTALL_PREFIX=${WORK_DIR}/ekat-install/ekat-uvm   \
       -DCMAKE_BUILD_TYPE=DEBUG                                   \
       -DCMAKE_C_COMPILER=${MPICC}                                \
@@ -203,12 +189,12 @@ if [[ "$ISCUDA" == "True" ]]; then
       echo "Something went wrong while configuring the UVM case."
       RET_UVM=1
   else
-      ${BATCHP} make -j ${COMP_J}
+      make -j ${COMP_J}
       if [ $? -ne 0 ]; then
           echo "Something went wrong while building the UVM case."
           RET_UVM=1
       else
-          ${BATCHP} ctest --output-on-failure
+          ctest --output-on-failure
           if [ $? -ne 0 ]; then
               echo "Something went wrong while testing the UVM case."
               RET_UVM=1

--- a/src/ekat/ekat_workspace_impl.hpp
+++ b/src/ekat/ekat_workspace_impl.hpp
@@ -199,7 +199,7 @@ KOKKOS_INLINE_FUNCTION
 void WorkspaceManager<T, D>::operator() (const MemberType& team) const
 {
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, m_max_used), [&] (int i) {
+    Kokkos::TeamVectorRange(team, m_max_used), [&] (int i) {
       init_slot_metadata(team.league_rank(), i);
   });
 }
@@ -439,7 +439,7 @@ void WorkspaceManager<T, D>::Workspace::take_many_and_reset(
 
   // We only need to reset the metadata for spaces that are being left free
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(m_team, m_parent.m_max_used - N), [&] (int i) {
+    Kokkos::TeamVectorRange(m_team, m_parent.m_max_used - N), [&] (int i) {
       m_parent.init_slot_metadata(m_ws_idx, i+N);
     });
 
@@ -474,7 +474,7 @@ void WorkspaceManager<T, D>::Workspace::reset() const
 #endif
   m_next_slot = 0;
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(m_team, m_parent.m_max_used), [&] (int i) {
+    Kokkos::TeamVectorRange(m_team, m_parent.m_max_used), [&] (int i) {
       m_parent.init_slot_metadata(m_ws_idx, i);
     });
 
@@ -653,7 +653,7 @@ void WorkspaceManager<T, D>::Workspace::release_macro_block(
   // Reset metadata
   m_team.team_barrier();
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(m_team, n_sub_blocks), [&] (int i) {
+    Kokkos::TeamVectorRange(m_team, n_sub_blocks), [&] (int i) {
       m_parent.init_slot_metadata(m_ws_idx, i+m_next_slot);
   });
 

--- a/src/ekat/util/ekat_lin_interp.hpp
+++ b/src/ekat/util/ekat_lin_interp.hpp
@@ -78,7 +78,7 @@ struct LinInterp
   const TeamPolicy& policy() const { return m_policy; }
 
   // Setup the index map. This must be called before lin_interp. By default, will launch a
-  // TeamThreadRange kernel. By default, the column idx will be team.league_rank(); this can be
+  // TeamVectorRange kernel. By default, the column idx will be team.league_rank(); this can be
   // overridden by the col argument.
   template<typename V1, typename V2>
   KOKKOS_INLINE_FUNCTION
@@ -100,7 +100,7 @@ struct LinInterp
     const Int col=-1) const;
 
   // Linearly interpolate y(x1) onto coordinates x2. By default, will launch a
-  // TeamThreadRange kernel. The x1 and x2 should match what was given to setup.
+  // TeamVectorRange kernel. The x1 and x2 should match what was given to setup.
   // By default, the column idx will be team.league_rank(); this can be
   // overridden by the col argument.
   template <typename V1, typename V2, typename V3, typename V4>

--- a/src/ekat/util/ekat_lin_interp_impl.hpp
+++ b/src/ekat/util/ekat_lin_interp_impl.hpp
@@ -25,7 +25,7 @@ void LinInterp<ScalarT, PackSize, DeviceT>::setup(
   const V2& x2,
   const Int col) const
 {
-  setup_impl(team, Kokkos::TeamThreadRange(team, m_km2_pack),
+  setup_impl(team, Kokkos::TeamVectorRange(team, m_km2_pack),
              ekat::repack<Pack::n>(x1), ekat::repack<Pack::n>(x2), col);
 }
 
@@ -55,7 +55,7 @@ void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp(
   const Int col) const
 {
   lin_interp_impl(team,
-                  Kokkos::TeamThreadRange(team, m_km2_pack),
+                  Kokkos::TeamVectorRange(team, m_km2_pack),
                   ekat::repack<Pack::n>(x1),
                   ekat::repack<Pack::n>(x2),
                   ekat::repack<Pack::n>(y1),

--- a/src/ekat/util/ekat_tridiag.hpp
+++ b/src/ekat/util/ekat_tridiag.hpp
@@ -645,7 +645,7 @@ void bfb (const TeamMember& team,
   const auto f = [&] (const int& j) {
     impl::bfb_thomas_solve(dl, d, du, Kokkos::subview(X , Kokkos::ALL(), j));
   };
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nrhs), f);
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nrhs), f);
 }
 
 template <typename TeamMember, typename TridiagDiag, typename DataArray>
@@ -675,7 +675,7 @@ void bfb (const TeamMember& team,
                            subview(du, ALL(), j),
                            subview(X , ALL(), j));
   };
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nrhs), f);
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nrhs), f);
 }
 
 } // namespace tridiag

--- a/tests/kokkos/kernel_on_host.cpp
+++ b/tests/kokkos/kernel_on_host.cpp
@@ -24,7 +24,7 @@ void run (const Policy& p,
   int value = std::is_same<typename Policy::traits::execution_space,Kokkos::Serial>::value ? ValueHost : ValueDev;
   Kokkos::parallel_for(p,KOKKOS_LAMBDA(const typename Policy::member_type& team_member) {
     const int i = team_member.league_rank();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member,nk),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team_member,nk),
                          [&](const int k) {
       a(i,k) = value;
     });

--- a/tests/kokkos/workspace_tests.cpp
+++ b/tests/kokkos/workspace_tests.cpp
@@ -97,13 +97,13 @@ static void unittest_workspace_idx_lock()
     const auto i = team.league_rank();
     auto workspace = wsm.get_workspace(team);
     auto v = workspace.take("v");
-    const auto ttr = Kokkos::TeamThreadRange(team, 0, nk);
+    const auto tevr = Kokkos::TeamVectorRange(team, 0, nk);
     const auto g = [&] (const int k) { v(k) = i; };
-    Kokkos::parallel_for(ttr, g);
+    Kokkos::parallel_for(tevr, g);
     team.team_barrier();
     // Write race, but doesn't matter. Any err > 0 is an error.
     const auto h = [&] (const int k) { if (v(k) != i) ++err; };
-    Kokkos::parallel_for(ttr, h);
+    Kokkos::parallel_for(tevr, h);
     workspace.release(v);
   };
   for (int trial = 0; trial < 10; ++trial) {
@@ -115,7 +115,7 @@ static void unittest_workspace_idx_lock()
     Kokkos::parallel_reduce(policy, f, err);
     REQUIRE(err == 0);
   }
-}    
+}
 
 static void unittest_workspace()
 {
@@ -325,7 +325,7 @@ static void unittest_workspace()
         }
 
         for (int w = 0; w < n_slots_per_team; ++w) {
-          Kokkos::parallel_for(Kokkos::TeamThreadRange(team, slot_length), [&] (Int i) {
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team, slot_length), [&] (Int i) {
             if (r % 5 == 1) {
               wsmacro2d(w,i) = i * w;
             } else {
@@ -403,7 +403,7 @@ static void unittest_workspace()
             team.team_barrier();
 
             for (int w = 0; w < n_slots_per_team; ++w) {
-              Kokkos::parallel_for(Kokkos::TeamThreadRange(team, slot_length), [&] (Int i) {
+              Kokkos::parallel_for(Kokkos::TeamVectorRange(team, slot_length), [&] (Int i) {
                   wssub[w](i) = i * w;
                 });
             }
@@ -467,7 +467,7 @@ static void unittest_workspace()
 
             for (int w = 0; w < n_slots_per_team; ++w) {
               if (exp_active[w]) {
-                Kokkos::parallel_for(Kokkos::TeamThreadRange(team, slot_length), [&] (Int i) {
+                Kokkos::parallel_for(Kokkos::TeamVectorRange(team, slot_length), [&] (Int i) {
                     wssub[w](i) = i * w;
                   });
               }

--- a/tests/pack/pack_kokkos_tests.cpp
+++ b/tests/pack/pack_kokkos_tests.cpp
@@ -237,7 +237,7 @@ TEST_CASE("kokkos_packs", "ekat::pack") {
 
     int nerrs_local = 0;
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, num_bigs), [&] (int i) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_bigs), [&] (int i) {
       test_k_array(i) = i;
     });
 
@@ -245,7 +245,7 @@ TEST_CASE("kokkos_packs", "ekat::pack") {
     if (small.extent_int(0) != 4 * num_bigs) ++nerrs_local;
 
     team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, num_bigs*4), [&] (int i) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_bigs*4), [&] (int i) {
       for (int p = 0; p < 4; ++p) {
         if (small(i)[p] != i / 4) ++nerrs_local;
       }
@@ -254,13 +254,13 @@ TEST_CASE("kokkos_packs", "ekat::pack") {
     auto big = repack<16>(small);
     if (big.extent_int(0) != num_bigs) ++nerrs_local;
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, num_bigs*4), [&] (int i) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_bigs*4), [&] (int i) {
       for (int p = 0; p < 4; ++p) {
         small(i)[p] = p * i;
       }
     });
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, num_bigs*4), [&] (int i) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_bigs*4), [&] (int i) {
       auto mask = small(i) >= (2 * i);
       for (int p = 0; p < 4; ++p) {
         if (i == 0) {


### PR DESCRIPTION
Use `TeamVectorRange` when no further parallelism is needed.

## Motivation
Avoids meaningless computation when vector dim > 1. 

## Related Issues

Part of https://github.com/E3SM-Project/scream/issues/2070
