### PR TITLE
Support subiew_1 for rank2 views, returning a view with LayoutStride

### DIFF
--- a/src/ekat/kokkos/ekat_kokkos_types.hpp
+++ b/src/ekat/kokkos/ekat_kokkos_types.hpp
@@ -27,6 +27,9 @@ using HostDevice = Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::Def
 template<typename DT, typename... Props>
 using ViewLR = Kokkos::View<DT,Kokkos::LayoutRight,Props...>;
 
+template<typename DT, typename... Props>
+using ViewLS = Kokkos::View<DT,Kokkos::LayoutStride,Props...>;
+
 // Struct for getting useful Kokkos types based on the device
 template <typename DeviceType>
 struct KokkosTypes
@@ -49,6 +52,10 @@ struct KokkosTypes
   // left-layout views, may be useful for interacting with fortran
   template <typename DataType, typename MemoryTraits = Kokkos::MemoryManaged>
   using lview = Kokkos::View<DataType, Kokkos::LayoutLeft, Device, MemoryTraits>;
+
+  // strided-layout views, may be needed in certain subview operations
+  template <typename DataType, typename MemoryTraits = Kokkos::MemoryManaged>
+  using sview = Kokkos::View<DataType, Kokkos::LayoutStride, Device, MemoryTraits>;
 
   // A N-dim view given scalar type and N
   template<typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryManaged>

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -379,6 +379,7 @@ TEST_CASE("subviews") {
   const int i2 = 3;
   const int i3 = 2;
   const int i4 = 1;
+  const int i5 = 0;
 
   // Create input view
   kt::view_ND<Real,6> v6("v6",7,6,5,4,3,2);
@@ -468,6 +469,14 @@ TEST_CASE("subviews") {
     auto sv5 = ekat::subview_1(v5,i2);
     auto sv4 = ekat::subview_1(v4,i3);
     auto sv3 = ekat::subview_1(v3,i4);
+    auto sv2 = ekat::subview_1(v2,i5);
+
+    // First four should retain LaoutRight, last one has no other choice but getting LayoutStride
+    REQUIRE (std::is_same<typename decltype(sv6)::traits::array_layout,Kokkos::LayoutRight>::value);
+    REQUIRE (std::is_same<typename decltype(sv5)::traits::array_layout,Kokkos::LayoutRight>::value);
+    REQUIRE (std::is_same<typename decltype(sv4)::traits::array_layout,Kokkos::LayoutRight>::value);
+    REQUIRE (std::is_same<typename decltype(sv3)::traits::array_layout,Kokkos::LayoutRight>::value);
+    REQUIRE (std::is_same<typename decltype(sv2)::traits::array_layout,Kokkos::LayoutStride>::value);
 
     // Subview again the second slowest
     auto sv6_2 = ekat::subview_1(sv6,i2);
@@ -504,6 +513,9 @@ TEST_CASE("subviews") {
           if (sv3(k,m)!=v6(i0,i1,i2,k,i4,m)) ++ndiffs;
         }
 
+      for (int l=0; l<3; ++l) {
+        if (sv2(l)!=v6(i0,i1,i2,i3,l,i5)) ++ndiffs;
+      }
 
       for (int h=0; h<7; ++h)
         for (int k=0; k<4; ++k)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We implemented `subview_1` only for views with rank>2, pushed by the constraint that the return type should still have LayoutRight. However, this prevents us from doing something like
```
auto sv = ekat::subview_1(input_view);
```
in a generic function. While it's true that LayoutStride comes with a performance price, it is perfectly ok to use it in areas where the performance hit is negligible and the subview is treated in a way that doesn't care about layout type. For instance, we cannot use this if we need to store the subview in the class, since the class member type needs to be hardcoded; however, it's doable in small snippets of code.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in EAMxx.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a test that ensures output layout and values are the expected ones.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
