### PR TITLE
Add possibility to pass bool flags to catch main

### DIFF
--- a/src/ekat/util/ekat_test_utils.hpp
+++ b/src/ekat/util/ekat_test_utils.hpp
@@ -14,6 +14,7 @@ struct TestSession {
   }
 
   std::map<std::string,std::string> params;
+  std::map<std::string,bool>        flags;
 private:
   TestSession() = default;
 };

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,5 +1,14 @@
 include(EkatCreateUnitTest)
 
+# Test catch main options
+
+# Note: the trick to match multiple lines of output follows solution
+#       found at https://stackoverflow.com/a/38173182/1093346
+#       This only works for *consecutive* lines
+EkatCreateUnitTest (catch_main_tests catch_main_tests.cpp
+  EXE_ARGS "--ekat-test-params 'a=1,b=2' --flags verbose,debug,skip"
+  PROPERTIES PASS_REGULAR_EXPRESSION "flags: debug skip verbose[\r\n]*params: a=1 b=2 kokkos-device-id=-1")
+
 # Test debug tools
 EkatCreateUnitTest(debug_tools debug_tools_tests.cpp
   LIBS ekat)

--- a/tests/utils/catch_main_tests.cpp
+++ b/tests/utils/catch_main_tests.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch.hpp>
+
+#include "ekat/util/ekat_test_utils.hpp"
+
+namespace {
+
+TEST_CASE ("flags_and_params") {
+  auto& ts = ekat::TestSession::get();
+
+  const auto& f = ts.flags;
+  std::cout << "flags:";
+  for (const auto& it : f) {
+    std::cout << " " << it.first;
+    // All flags added should be added as true
+    REQUIRE (it.second);
+  }
+  std::cout << "\n";
+
+  const auto& p = ts.params;
+  std::cout << "params:";
+  for (const auto& it : p) {
+    std::cout << " " << it.first << "=" << it.second;
+  }
+  std::cout << "\n";
+}
+
+}


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The only way we had to pass arbitrary parameters to a test was via `--ekat-test-params key=val`. For simple bool flags, this syntax is heavy. So I added a shorthand version: `--flags a,b,c` will populate the `flags` member of `TestSession` (an std::map) with bool entries with those names, setting their value to true. This should allow making development easier. E.g., one could have very little output to its test, but if `--flags verbose` is used, print more output:
```
auto verb = ekat::TestSession::get().flags["verbose"];
if (verb) {
  // print extra stuff
}
```
Before, one would have had to pass `--ekat-test-params verbose=true`, and in the test, do
```
auto verb = ekat::TestSession::get().params["verbose"];
if (verb=="true" || verb=="yes") {
  // print extra stuff
}
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added testing for params and flags.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
