### PR TITLE
EKAT: Disable test-launcher resource management by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ option (EKAT_ENABLE_VALGRIND "Whether to run tests with valgrind" OFF)
 option (EKAT_ENABLE_CUDA_MEMCHECK "Whether to run tests with cuda-memcheck" OFF)
 option (EKAT_ENABLE_COVERAGE "Whether to enable code coverage" OFF)
 option (EKAT_TEST_LAUNCHER_BUFFER "Whether test-launcher should buffer all out and print all at once. Useful for avoiding interleaving output when multiple tests are running concurrently" OFF)
+option (EKAT_TEST_LAUNCHER_MANAGE_RESOURCES "Whether test-launcher should try to manage thread distribution. Requires a ctest resource file to be effective." OFF)
 set (EKAT_PROFILING_TOOL "NONE" CACHE STRING "Profiling tool to be used")
 
 if (EKAT_ENABLE_COVERAGE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -151,10 +152,20 @@ add_subdirectory(src/ekat)
 if (EKAT_ENABLE_MPI)
   SetMpiRuntimeEnvVars()
 endif()
+
+#
+# These need to be set to python boolean values
+#
 if (EKAT_ENABLE_GPU)
   set (TEST_LAUNCHER_ON_GPU True)
 else()
   set (TEST_LAUNCHER_ON_GPU False)
+endif()
+
+if (EKAT_TEST_LAUNCHER_MANAGE_RESOURCES)
+  set (TEST_LAUNCHER_MANAGE_RESOURCES True)
+else()
+  set (TEST_LAUNCHER_MANAGE_RESOURCES False)
 endif()
 
 # Configure/install test-launcher to build/install folder

--- a/bin/test-launcher
+++ b/bin/test-launcher
@@ -118,53 +118,57 @@ def run_test(buffer_output,print_omp_affinity,exec_args):
     cmd = " ".join(omp_env)
 
     # If run with --resource-spec-file, we will have some special env var set
-    if "CTEST_RESOURCE_GROUP_COUNT" in env:
-        print ("HAS RESOURCE SPECS")
-        # Total number of resources for this test (for all ranks/threads)
-        res_count = int(env["CTEST_RESOURCE_GROUP_COUNT"])
-        my_res_id = myrank % res_count
+    if ${TEST_LAUNCHER_MANAGE_RESOURCES}:
+        if "CTEST_RESOURCE_GROUP_COUNT" in env:
+            print ("HAS RESOURCE SPECS")
+            # Total number of resources for this test (for all ranks/threads)
+            res_count = int(env["CTEST_RESOURCE_GROUP_COUNT"])
+            my_res_id = myrank % res_count
 
-        # Get the list of devices ids in my resource group
-        key = "CTEST_RESOURCE_GROUP_" + str(my_res_id)
-        expect(key in env, "Error! CTEST_RESOURCE_GROUP_COUNT found in the env, but can't find {}".format(key))
-        my_res_name = env[key]
-        expect (my_res_name=="devices", "Error! My ctest resource group should be 'devices'.")
-        key += "_DEVICES"
-        expect(key in env, "Error! CTEST_RESOURCE_GROUP_{} found in the env, but can't find {}".format(my_res_id,key))
-        my_res_str = env[key]
+            # Get the list of devices ids in my resource group
+            key = "CTEST_RESOURCE_GROUP_" + str(my_res_id)
+            expect(key in env, "Error! CTEST_RESOURCE_GROUP_COUNT found in the env, but can't find {}".format(key))
+            my_res_name = env[key]
+            expect (my_res_name=="devices", "Error! My ctest resource group should be 'devices'.")
+            key += "_DEVICES"
+            expect(key in env, "Error! CTEST_RESOURCE_GROUP_{} found in the env, but can't find {}".format(my_res_id,key))
+            my_res_str = env[key]
 
-        # Split the CTEST_RESOURCE_GROUP_[N]_DEVICE string into tokens, and get the slots ids
-        my_res = my_res_str.split(';')
-        ids = []
-        for res in my_res:
-            id_slots_tokens = res.split(',')
-            id_tokens = id_slots_tokens[0].split(':')
-            ids.append(int(id_tokens[1]))
+            # Split the CTEST_RESOURCE_GROUP_[N]_DEVICE string into tokens, and get the slots ids
+            my_res = my_res_str.split(';')
+            ids = []
+            for res in my_res:
+                id_slots_tokens = res.split(',')
+                id_tokens = id_slots_tokens[0].split(':')
+                ids.append(int(id_tokens[1]))
 
-        # CTest should already present these in lexicographic order, which should match
-        # numeric order thanks to our recent change to prepend leading 0's to fill empty
-        # digits. This sort shouldn't be necessary but it can't hurt.
-        ids.sort()
+            # CTest should already present these in lexicographic order, which should match
+            # numeric order thanks to our recent change to prepend leading 0's to fill empty
+            # digits. This sort shouldn't be necessary but it can't hurt.
+            ids.sort()
 
-        # Convert back to str so ids can be used in shell commands
-        ids = [str(item) for item in ids]
+            # Convert back to str so ids can be used in shell commands
+            ids = [str(item) for item in ids]
 
-        # Now get the chunk of ids that belongs to this rank
-        expect (len(ids) % nranks == 0, "Error! Number of ranks does not divide the number of resources.")
-        ids_per_rank = int(len(ids) / nranks)
-        my_ids = ids[myrank*ids_per_rank : (myrank+1)*ids_per_rank]
+            # Now get the chunk of ids that belongs to this rank
+            expect (len(ids) % nranks == 0, "Error! Number of ranks does not divide the number of resources.")
+            ids_per_rank = int(len(ids) / nranks)
+            my_ids = ids[myrank*ids_per_rank : (myrank+1)*ids_per_rank]
 
-        # This file is to be run through cmake's configure_file, which will expand the
-        # variable TEST_LAUNCHER_ON_GPU to either True or False
-        if ${TEST_LAUNCHER_ON_GPU}:
-            expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
-            exec_args.append(" --ekat-kokkos-device {}".format(ids[0]))
+            # This file is to be run through cmake's configure_file, which will expand the
+            # variable TEST_LAUNCHER_ON_GPU to either True or False
+            if ${TEST_LAUNCHER_ON_GPU}:
+                expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
+                exec_args.append(" --ekat-kokkos-device {}".format(ids[0]))
+            else:
+                # Start placing on the correct cpu set
+                cmd += " taskset -c " + ",".join(my_ids)
+
         else:
-            # Start placing on the correct cpu set
-            cmd += " taskset -c " + ",".join(my_ids)
+            print ("WARNING: NO RESOUCE SPECS. EKAT was configured to manage resources, but no --resource-spec-file option was provided.")
 
     else:
-        print ("NO RESOURCE SPECS")
+        print ("EKAT is not managing resources.")
 
     cmd += " {}".format(" ".join(exec_args[1:]))
 


### PR DESCRIPTION
Most of the machines we run on have resources managers (batch systems) and we should rely on those over test-launcher to manage resources. Users can enable test-launcher resource management via EKAT_TEST_LAUNCHER_MANAGE_RESOURCES.

This PR is best viewed with whitespace changes off.

## Motivation

We do not want test-launcher to try to manage resources when there's already a resource manager trying to do that. srun + test_launcher w/ resource mgmt showed a significant performance loss for our test suites.

A future PR will bring this change into SCREAM.

## Testing

Testing by-hand on mappy.