### PR TITLE
Fix Intel Broadwell mach file

### DIFF
--- a/cmake/machine-files/kokkos/intel-bdw.cmake
+++ b/cmake/machine-files/kokkos/intel-bdw.cmake
@@ -1,4 +1,4 @@
 include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
 
 # Enable Broadwell arch in kokkos
-set(KOKKOS_ARCH BDW CACHE STRING "")
+option(Kokkos_ARCH_BDW "" ON)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Intel BDW mach file used an obsolete format for kokkos arch, which caused an error. Recent refactor of SCREAM mach files specs exposed this bug, as the file was not used previously.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed by SCREAM. See E3SM-Project/scream#2192
