### PR TITLE
EkatCreateUnitTest: Store shell command as a custom property of the test

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -314,7 +314,7 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
 
       # Set test properties
       math(EXPR CURR_CORES "${NRANKS}*${NTHREADS}")
-      set_tests_properties(${FULL_TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${NTHREADS} PROCESSORS ${CURR_CORES} PROCESSOR_AFFINITY True FULL_TEST_COMMAND ${FULL_TEST_CMD})
+      set_tests_properties(${FULL_TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${NTHREADS} PROCESSORS ${CURR_CORES} PROCESSOR_AFFINITY True FULL_TEST_COMMAND "${FULL_TEST_CMD}")
       if (ecutfe_DEP AND NOT ecutfe_DEP STREQUAL "${FULL_TEST_NAME}")
         set_tests_properties(${FULL_TEST_NAME} PROPERTIES DEPENDS ${ecutfe_DEP})
       endif()

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -305,15 +305,16 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
         if (EKAT_MPI_THREAD_FLAG)
           string(APPEND RANK_MAPPING " ${EKAT_MPI_THREAD_FLAG} ${NTHREADS}")
         endif()
-        add_test(NAME ${FULL_TEST_NAME}
-                 COMMAND sh -c "${EKAT_MPIRUN_EXE} ${RANK_MAPPING} ${EKAT_MPI_EXTRA_ARGS} ${invokeExecCurr}")
+        set(FULL_TEST_CMD "${EKAT_MPIRUN_EXE} ${RANK_MAPPING} ${EKAT_MPI_EXTRA_ARGS} ${invokeExecCurr}")
       else()
-        add_test(NAME ${FULL_TEST_NAME} COMMAND sh -c "${invokeExecCurr}")
+        set(FULL_TEST_CMD "${invokeExecCurr}")
       endif()
+
+      add_test(NAME ${FULL_TEST_NAME} COMMAND sh -c "${FULL_TEST_CMD}")
 
       # Set test properties
       math(EXPR CURR_CORES "${NRANKS}*${NTHREADS}")
-      set_tests_properties(${FULL_TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${NTHREADS} PROCESSORS ${CURR_CORES} PROCESSOR_AFFINITY True)
+      set_tests_properties(${FULL_TEST_NAME} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${NTHREADS} PROCESSORS ${CURR_CORES} PROCESSOR_AFFINITY True FULL_TEST_COMMAND ${FULL_TEST_CMD})
       if (ecutfe_DEP AND NOT ecutfe_DEP STREQUAL "${FULL_TEST_NAME}")
         set_tests_properties(${FULL_TEST_NAME} PROPERTIES DEPENDS ${ecutfe_DEP})
       endif()


### PR DESCRIPTION
Will allow users to easily create shell commands that follow the same convention as a unit test.

The usage on the scream side looks like this:
```
  CreateUnitTestFromExec(p3_baseline_f90_fake p3_run_and_cmp
    THREADS ${SCREAM_TEST_MAX_THREADS}
    EXE_ARGS "-f -g ${BASELINE_FILE_ARG}"
    PROPERTIES DISABLED True)

  get_test_property(p3_baseline_f90_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND P3_F90_GEN)
```

## Testing

Used this approach to change how baselines are generated for p3|shoc_run_and_cmp.
