### PR TITLE
Replacing --kokkos-num-devices with --kokkos-map-device-id-by=mpi_rank.

### DIFF
--- a/src/ekat/ekat_session.cpp
+++ b/src/ekat/ekat_session.cpp
@@ -55,9 +55,12 @@ void initialize_kokkos () {
     // It isn't a big deal if we can't get the device count.
     nd = 1;
   }
+#endif
 
   auto const settings = Kokkos::InitializationSettings()
-    .map_device_id_by("mpi_rank")
+#ifdef EKAT_ENABLE_MPI
+    .set_map_device_id_by("mpi_rank")
+#endif
     .set_num_devices(nd)
     .set_disable_warnings(true);
   Kokkos::initialize(settings);

--- a/src/ekat/ekat_session.cpp
+++ b/src/ekat/ekat_session.cpp
@@ -28,8 +28,8 @@ void initialize_kokkos () {
   //   If for some reason we're running on a GPU platform, have Cuda enabled,
   // but are using a different execution space, this initialization is still
   // OK. The rank gets a GPU assigned and simply will ignore it.
+  int nd = 1;
 #ifdef EKAT_ENABLE_GPU
-  int nd;
 # if defined KOKKOS_ENABLE_CUDA
   const auto ret = cudaGetDeviceCount(&nd);
   const bool ok = ret == cudaSuccess;

--- a/src/ekat/ekat_session.cpp
+++ b/src/ekat/ekat_session.cpp
@@ -20,8 +20,8 @@ static int get_default_fpes () {
 // If we initialize from inside a Fortran code, we don't have access to
 // char** args to pass to Kokkos::initialize. In this case we need to do
 // some work on our own. As a side benefit, we'll end up running on GPU
-// platforms optimally without having to specify --kokkos-num-devices on
-// the command line.
+// platforms optimally without having to specify
+// --kokkos-map-device-id-by=mpi_rank on the command line.
 // We also will use this function to generate kokkos args if the user
 // specified none.
 void initialize_kokkos () {
@@ -57,13 +57,13 @@ void initialize_kokkos () {
   const bool ok = true;
 # else
   error "No valid GPU space, yet EKAT_ENABLE_GPU is defined."
-# endif  
+# endif
   if (not ok) {
     // It isn't a big deal if we can't get the device count.
     nd = 1;
   }
   std::stringstream ss;
-  ss << "--kokkos-num-devices=" << nd;
+  ss << "--kokkos-map-device-id-by=mpi_rank" << nd;
   const auto key = ss.str();
   std::vector<char> str(key.size()+1);
   std::copy(key.begin(), key.end(), str.begin());

--- a/src/ekat/ekat_session.cpp
+++ b/src/ekat/ekat_session.cpp
@@ -20,8 +20,45 @@ static int get_default_fpes () {
 // This function provides a simple and correct way to initialize Kokkos from
 // any context with the correct settings.
 void initialize_kokkos () {
+  // Count up our devices.
+  // This is the only way to get the round-robin rank assignment Kokkos
+  // provides, as that algorithm is hardcoded in Kokkos::initialize(int& narg,
+  // char* arg[]). Once the behavior is exposed in the InitArguments version of
+  // initialize, we can remove this string code.
+  //   If for some reason we're running on a GPU platform, have Cuda enabled,
+  // but are using a different execution space, this initialization is still
+  // OK. The rank gets a GPU assigned and simply will ignore it.
+#ifdef EKAT_ENABLE_GPU
+  int nd;
+# if defined KOKKOS_ENABLE_CUDA
+  const auto ret = cudaGetDeviceCount(&nd);
+  const bool ok = ret == cudaSuccess;
+# elif defined KOKKOS_ENABLE_HIP
+  const auto ret = hipGetDeviceCount(&nd);
+  const bool ok = ret == hipSuccess;
+# elif defined KOKKOS_ENABLE_SYCL
+  nd = 0;
+  auto gpu_devs = sycl::device::get_devices(sycl::info::device_type::gpu);
+  for (auto &dev : gpu_devs) {
+    if (dev.get_info<sycl::info::device::partition_max_sub_devices>() > 0) {
+      auto subDevs = dev.create_sub_devices<sycl::info::partition_property::partition_by_affinity_domain>(sycl::info::partition_affinity_domain::numa);
+      nd += subDevs.size();
+    } else {
+      nd++;
+    }
+  }
+  const bool ok = true;
+# else
+  error "No valid GPU space, yet EKAT_ENABLE_GPU is defined."
+# endif
+  if (not ok) {
+    // It isn't a big deal if we can't get the device count.
+    nd = 1;
+  }
+
   auto const settings = Kokkos::InitializationSettings()
     .map_device_id_by("mpi_rank")
+    .set_num_devices(nd)
     .set_disable_warnings(true);
   Kokkos::initialize(settings);
 }


### PR DESCRIPTION
This PR replaces a deprecated compiler flag as described in [SCREAM issue 2026](https://github.com/E3SM-Project/scream/issues/2026).