### PR TITLE
Quality-of-life overload in ekat::any

### DIFF
--- a/src/ekat/std_meta/ekat_std_any.hpp
+++ b/src/ekat/std_meta/ekat_std_any.hpp
@@ -92,6 +92,10 @@ class any {
 public:
 
   any () = default;
+  template<typename T>
+  any (const T& t) {
+    reset (t);
+  }
 
   template<typename T, typename... Args>
   void reset (Args... args) {

--- a/src/ekat/std_meta/ekat_std_any.hpp
+++ b/src/ekat/std_meta/ekat_std_any.hpp
@@ -98,6 +98,11 @@ public:
     m_content.reset( holder<T>::create(args...) );
   }
 
+  template<typename T>
+  void reset (const T& t) {
+    m_content.reset( holder<T>::create(t) );
+  }
+
   holder_base& content () const { 
     EKAT_REQUIRE_MSG (static_cast<bool>(m_content), "Error! Object not yet initialized.\n");
     return *m_content;

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -13,6 +13,10 @@ EkatCreateUnitTest (catch_main_tests catch_main_tests.cpp
 EkatCreateUnitTest(debug_tools debug_tools_tests.cpp
   LIBS ekat)
 
+# Test std_meta stuff
+EkatCreateUnitTest(std_meta std_meta.cpp
+  LIBS ekat)
+
 # Test meta utilities
 EkatCreateUnitTest(meta_utils meta_utils.cpp
   LIBS ekat)

--- a/tests/utils/std_meta.cpp
+++ b/tests/utils/std_meta.cpp
@@ -5,22 +5,21 @@
 #include <vector>
 
 TEST_CASE ("any") {
-  using namespace ekat;
 
-  any a,b;
+  ekat::any a,b;
 
   std::vector<int> u = {1,2};
 
   a.reset<std::vector<int>>(u);
   b.reset(u);
 
-  REQUIRE (any_cast<std::vector<int>>(a)==any_cast<std::vector<int>>(b));
-  REQUIRE (any_cast<std::vector<int>>(a)==u);
-  REQUIRE_THROWS (any_cast<std::vector<double>>(a));
+  REQUIRE (ekat::any_cast<std::vector<int>>(a)==ekat::any_cast<std::vector<int>>(b));
+  REQUIRE (ekat::any_cast<std::vector<int>>(a)==u);
+  REQUIRE_THROWS (ekat::any_cast<std::vector<double>>(a));
 
   REQUIRE (a.isType<std::vector<int>>());
   REQUIRE (not a.isType<int>());
 
-  any c (u);
-  REQUIRE (any_cast<std::vector<int>>(a)==any_cast<std::vector<int>>(c));
+  ekat::any c (u);
+  REQUIRE (ekat::any_cast<std::vector<int>>(a)==ekat::any_cast<std::vector<int>>(c));
 }

--- a/tests/utils/std_meta.cpp
+++ b/tests/utils/std_meta.cpp
@@ -1,0 +1,23 @@
+#include <catch2/catch.hpp>
+
+#include "ekat/std_meta/ekat_std_any.hpp"
+
+#include <vector>
+
+TEST_CASE ("any") {
+  using namespace ekat;
+
+  any a,b;
+
+  std::vector<int> u = {1,2};
+
+  a.reset<std::vector<int>>(u);
+  b.reset(u);
+
+  REQUIRE (any_cast<std::vector<int>>(a)==any_cast<std::vector<int>>(b));
+  REQUIRE (any_cast<std::vector<int>>(a)==u);
+  REQUIRE_THROWS (any_cast<std::vector<double>>(a));
+
+  REQUIRE (a.isType<std::vector<int>>());
+  REQUIRE (not a.isType<int>());
+}

--- a/tests/utils/std_meta.cpp
+++ b/tests/utils/std_meta.cpp
@@ -20,4 +20,7 @@ TEST_CASE ("any") {
 
   REQUIRE (a.isType<std::vector<int>>());
   REQUIRE (not a.isType<int>());
+
+  any c (u);
+  REQUIRE (any_cast<std::vector<int>>(a)==any_cast<std::vector<int>>(c));
 }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The method `any::reset` is cumbersome when we are passing the object to be stored. This PR makes the syntax simpler in this (common) case:

master:
```
std::vector<int> v =...
ekat::any a;
a.reset<std::vector<int>>(v);
```
pr:
```
std::vector<int> v =...
ekat::any a;
a.reset(v);

ekat::any b(v);
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added small unit test for ekat::any (which was never tested in ekat).
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
