### PR TITLE
Allow to pass a lambda to ekat::join

### DIFF
--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -80,6 +80,58 @@ std::string join (const Iterable& v, const Lambda& f, const std::string& sep) {
   return ss.str();
 }
 
+template<typename Iterable, typename Selector>
+std::string join_if (const Iterable& v, const Selector& check, const std::string& sep) {
+  auto it = cbegin(v);
+  auto end = cend(v);
+  if (it==end) {
+    return "";
+  }
+
+  // It is complicated to figure out if/when to add sep, since we don't
+  // know a priori if the following items will satisfy the check.
+  // Hence, build short list of ptrs beforehand
+  using elem_t = typename std::remove_reference<decltype(*it)>::type;
+  std::list<elem_t*> ptrs;
+
+  for (const auto& elem : v) {
+    if (check(elem)) {
+      ptrs.push_back(&elem);
+    }
+  }
+  auto deref = [](const auto& p) {
+    return *p;
+  };
+  return ekat::join(ptrs,deref,sep);
+}
+
+// Combo of prebious two
+template<typename Iterable, typename Selector, typename Lambda>
+std::string join_if (const Iterable& v, const Selector& check,
+                     const Lambda& f, const std::string& sep) {
+  auto it = cbegin(v);
+  auto end = cend(v);
+  if (it==end) {
+    return "";
+  }
+
+  // It is complicated to figure out if/when to add sep, since we don't
+  // know a priori if the following items will satisfy the check.
+  // Hence, build short list of ptrs beforehand
+  using elem_t = typename std::remove_reference<decltype(*it)>::type;
+  std::list<elem_t*> ptrs;
+
+  for (const auto& elem : v) {
+    if (check(elem)) {
+      ptrs.push_back(&elem);
+    }
+  }
+  auto apply_f = [&](const auto& p) {
+    return f(*p);
+  };
+  return ekat::join(ptrs,apply_f,sep);
+}
+
 // Split a string into tokens, according to any of the provided delimiters.
 // If atomic!="", substrings matching atomic will not be split with
 // any of the delimiters.

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -61,6 +61,25 @@ std::string join (const Iterable& v, const std::string& sep) {
   return ss.str();
 }
 
+template<typename Iterable, typename Lambda>
+std::string join (const Iterable& v, const Lambda& f, const std::string& sep) {
+  auto it = cbegin(v);
+  auto end = cend(v);
+  if (it==end) {
+    return "";
+  }
+
+  std::stringstream ss;
+  ss << f(*it);
+  ++it;
+  for (; it!=end; ++it) {
+    ss << sep;
+    ss << f(*it);
+  }
+
+  return ss.str();
+}
+
 // Split a string into tokens, according to any of the provided delimiters.
 // If atomic!="", substrings matching atomic will not be split with
 // any of the delimiters.

--- a/tests/utils/string_utils_tests.cpp
+++ b/tests/utils/string_utils_tests.cpp
@@ -41,6 +41,14 @@ TEST_CASE("string","string") {
     REQUIRE (join(i,",")=="1,2,3");
   }
 
+  SECTION ("join with lambda") {
+    std::list<std::string> l = {"hello","world"};
+    auto f = [](const std::string& s)->std::string {
+      return upper_case(s);
+    };
+    REQUIRE (join(f,l," ")=="HELLO WORLD");
+  }
+
   SECTION ("case_insensitive_string") {
     CaseInsensitiveString cis1 = "field_1";
     CaseInsensitiveString cis2 = "fIeLd_1";

--- a/tests/utils/string_utils_tests.cpp
+++ b/tests/utils/string_utils_tests.cpp
@@ -41,12 +41,31 @@ TEST_CASE("string","string") {
     REQUIRE (join(i,",")=="1,2,3");
   }
 
-  SECTION ("join with lambda") {
+  SECTION ("join_apply") {
     std::list<std::string> l = {"hello","world"};
     auto f = [](const std::string& s)->std::string {
       return upper_case(s);
     };
-    REQUIRE (join(f,l," ")=="HELLO WORLD");
+    REQUIRE (join(l,f," ")=="HELLO WORLD");
+  }
+
+  SECTION ("join_if") {
+    std::list<std::string> l = {"hello","SKIP","world","SKIP"};
+    auto f = [](const std::string& s) {
+      return s!="SKIP";
+    };
+    REQUIRE (join_if(l,f," ")=="hello world");
+  }
+
+  SECTION ("join_apply_if") {
+    std::list<std::string> l = {"hello","SKIP","world","SKIP"};
+    auto f = [](const std::string& s)->std::string {
+      return upper_case(s);
+    };
+    auto cond = [](const std::string& s) {
+      return s!="SKIP";
+    };
+    REQUIRE (join_if(l,cond,f," ")=="HELLO WORLD");
   }
 
   SECTION ("case_insensitive_string") {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The `join` util is mimicking the one in python. In python, you can use list comprehension to make things even niftier, but C++ can't do that. The closest we can do is pass a lambda to `join`, which will perform additional ops on its elements, and/or a selector, i.e., a lambda that returns true if the element is to be included in the output.

E.g., given a list of integers (be that a vector, list, or any iterable), the string of the squares of all even integers separated by a comma can be built as
```
auto even = [](const int i) { return i%2==0; };
auto pow2 = [] (const int) { return i*i; };
std::list<int> ints = {....};
auto squares = ekat::join_if (ints, even, pow2, ",")
``` 

This is not much less code than a manual for, but a) the join function hides all the logic regarding not adding separator at the end, and b) it might make the code cleaner (lambdas can have a meaningful name).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added tests for selector version (`join_if`) as well as the version taking an "apply" function.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
