### PR TITLE
Avoid creating a modules folder for unit tests if no fortran files are to be compiled

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -70,8 +70,17 @@ function(EkatCreateUnitTestExec exec_name exec_srcs)
     ${ecute_INCLUDE_DIRS}
     )
 
-  # F90 output dir
-  set_target_properties(${target_name} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}_modules)
+  # Check if we need a Fortran modules folder
+  foreach (file ${exec_srcs})
+    get_filename_component(ext ${file} EXT)
+    string(REGEX REPLACE "^\\." "" ext ${ext})
+
+    if (ext IN_LIST CMAKE_Fortran_SOURCE_FILE_EXTENSIONS)
+      set_target_properties(${target_name} PROPERTIES
+        Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}_modules)
+      break()
+    endif()
+  endforeach()
 
   # Link flags/libs
   if (NOT ecute_EXCLUDE_MAIN_CPP)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
It's quite annoying to have a folder full of folders that are not needed, especially when it can impact tab completion. Take, for instance, ekat's `tests/util` folder (in the build tree):

current master:
```
$ ls
catch_main_modules        debug_tools_modules  math_util_modules     string_utils
catch_main_tests          factory              meta_utils            string_utils_modules
catch_main_tests_modules  factory_modules      meta_utils_modules    Testing
CMakeFiles                fpe_check            regress_fail          upper_bound
cmake_install.cmake       fpe_check_modules    regress_fail_modules  upper_bound_modules
CTestTestfile.cmake       Makefile             std_meta              util_cxx
debug_tools               math_util            std_meta_modules      util_cxx_modules
```
with this PR:
```
$ ls
catch_main_tests     CTestTestfile.cmake  fpe_check  meta_utils    string_utils
CMakeFiles           debug_tools          Makefile   regress_fail  upper_bound
cmake_install.cmake  factory              math_util  std_meta      util_cxx
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
None needed.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
