### PR TITLE
Improve valgrind suppression file generation

### DIFF
--- a/valgrind_support/CMakeLists.txt
+++ b/valgrind_support/CMakeLists.txt
@@ -1,6 +1,9 @@
+include(EkatCreateUnitTest)
 
 add_executable(serial_hw serial_hw.cxx)
 add_executable(mpi_hw mpi_hw.cxx)
+
+EkatCreateUnitTest(mpi_valg_catch_test mpi_catch_test.cpp)
 
 add_custom_target(serial_sup ALL
   COMMAND valgrind --gen-suppressions=all ./serial_hw 2>&1 | ${CMAKE_CURRENT_SOURCE_DIR}/gen_sup.sh > ${CMAKE_BINARY_DIR}/serial.supp
@@ -11,6 +14,7 @@ add_custom_target(serial_sup ALL
 if (EKAT_ENABLE_MPI)
   add_custom_target(mpi_sup ALL
     COMMAND ${EKAT_MPIRUN_EXE} ${EKAT_MPI_NP_FLAG} 2 ${EKAT_MPI_EXTRA_ARGS} valgrind --gen-suppressions=all ./mpi_hw 2>&1 | ${CMAKE_CURRENT_SOURCE_DIR}/gen_sup.sh > ${CMAKE_BINARY_DIR}/mpi.supp
+    COMMAND ${EKAT_MPIRUN_EXE} ${EKAT_MPI_NP_FLAG} 2 ${EKAT_MPI_EXTRA_ARGS} valgrind --gen-suppressions=all ./mpi_valg_catch_test 2>&1 | ${CMAKE_CURRENT_SOURCE_DIR}/gen_sup.sh >> ${CMAKE_BINARY_DIR}/mpi.supp
     DEPENDS mpi_hw
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )

--- a/valgrind_support/mpi_catch_test.cpp
+++ b/valgrind_support/mpi_catch_test.cpp
@@ -1,0 +1,9 @@
+#include <catch2/catch.hpp>
+
+namespace {
+
+TEST_CASE("mpi_catch_fake_test", "[mpi_catch_fake_test]") {
+  REQUIRE (true);
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Include an executable that is linked the same way most catch exes are linked.

## Motivation
This will add some suppressions that will help to keep innocuous valgrind errors down.

## Testing
Scream ctests with valgrind enabled.