### PR TITLE
[SYCL] Fix failed tests for PVC

### DIFF
--- a/cmake/machine-files/jlse-xehp.cmake
+++ b/cmake/machine-files/jlse-xehp.cmake
@@ -1,2 +1,0 @@
-# Load XEHP arch with SYCL backend for kokkos
-include (${CMAKE_CURRENT_LIST_DIR}/kokkos/intel-xehp.cmake)

--- a/cmake/machine-files/kokkos/intel-pvc.cmake
+++ b/cmake/machine-files/kokkos/intel-pvc.cmake
@@ -1,0 +1,5 @@
+include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
+
+option(Kokkos_ARCH_INTEL_PVC "" ON)
+set(Kokkos_ENABLE_SYCL TRUE CACHE BOOL "")
+set(Kokkos_ENABLE_DEPRECATED_CODE_3 FALSE CACHE BOOL "")

--- a/cmake/machine-files/kokkos/intel-xehp.cmake
+++ b/cmake/machine-files/kokkos/intel-xehp.cmake
@@ -1,5 +1,0 @@
-include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
-
-option(Kokkos_ARCH_INTEL_XEHP "" ON)
-set(Kokkos_ENABLE_SYCL TRUE CACHE BOOL "")
-set(Kokkos_ENABLE_DEPRECATED_CODE_3 FALSE CACHE BOOL "")

--- a/cmake/machine-files/sunspot-xehp.cmake
+++ b/cmake/machine-files/sunspot-xehp.cmake
@@ -1,0 +1,2 @@
+# Load PVC arch with SYCL backend for kokkos
+include (${CMAKE_CURRENT_LIST_DIR}/kokkos/intel-pvc.cmake)

--- a/src/ekat/util/ekat_math_utils.hpp
+++ b/src/ekat/util/ekat_math_utils.hpp
@@ -54,6 +54,8 @@ KOKKOS_INLINE_FUNCTION
 bool is_nan (const RealT& a) {
 #ifdef __CUDA_ARCH__
   return isnan(a);
+#elif defined(__SYCL_DEVICE_ONLY__)
+  return sycl::isnan(a);
 #else
   return std::isnan(a);
 #endif

--- a/src/ekat/util/ekat_tridiag.hpp
+++ b/src/ekat/util/ekat_tridiag.hpp
@@ -115,7 +115,7 @@ int get_team_nthr (const TeamMember& team) {
   return team.team_size();
 }
 
-// Impl details for Nvidia and AMD GPUs.
+// Impl details for Nvidia, AMD and Intel GPUs.
 
 template <typename TeamMember> KOKKOS_FORCEINLINE_FUNCTION
 int get_thread_id_within_team_gpu (const TeamMember& team) {


### PR DESCRIPTION
- Address SYCL failing tests on PVC
- Add Sunspot (ANL) machine config for Kokkos/PVC
- Removed XEHP (ATS) redundant hardware config