### PR TITLE
Mild upgrades to string utils

### DIFF
--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -32,6 +32,10 @@ std::vector<std::string> split(const std::string& str, const std::string& delim)
   return tokens;
 }
 
+bool starts_with (const std::string& s, const std::string& start) {
+  return s.substr(0,start.size())==start;
+}
+
 std::string trim (const std::string& s, const char c) {
   if (s=="") {
     return s;

--- a/src/ekat/util/ekat_string_utils.cpp
+++ b/src/ekat/util/ekat_string_utils.cpp
@@ -16,20 +16,20 @@ void strip (std::string& str, const char c) {
   str.erase(new_end,str.end());
 }
 
-std::vector<std::string> split(const std::string& str, const char del) {
-  std::vector<std::string> blocks;
+std::vector<std::string> split(const std::string& str, const std::string& delim) {
+  std::vector<std::string> tokens;
 
   auto start = 0;
-  auto pos = str.find(del);
+  auto pos = str.find(delim);
   while (pos!=std::string::npos) {
-    blocks.push_back(str.substr(start,pos-start));
-    start = pos + 1;
-    pos = str.find(del,start);
+    tokens.push_back(str.substr(start,pos-start));
+    start = pos + delim.size();
+    pos = str.find(delim,start);
   }
 
-  // Don't forget to add the substring from the last occurrence of 'del' (if any) to the end of str
-  blocks.push_back(str.substr(start));
-  return blocks;
+  // Don't forget to add the substring from the last occurrence of 'delim' (if any) to the end of str
+  tokens.push_back(str.substr(start));
+  return tokens;
 }
 
 std::string trim (const std::string& s, const char c) {

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -28,8 +28,12 @@ namespace ekat {
 // Strip character c from input string
 void strip (std::string& str, const char c);
 
-// Split a string at every occurrence of given delimiter char
-std::vector<std::string> split(const std::string& str, const char del);
+// Split a string at every occurrence of given delimiter string
+std::vector<std::string> split(const std::string& str, const std::string& delim);
+
+inline std::vector<std::string> split(const std::string& str, const char delim) {
+  return split(str,std::string(1,delim));
+}
 
 // Trim leading/trailing characters matching given one (default: whitespace).
 std::string trim (const std::string& s, const char c = ' ');

--- a/src/ekat/util/ekat_string_utils.hpp
+++ b/src/ekat/util/ekat_string_utils.hpp
@@ -35,6 +35,9 @@ inline std::vector<std::string> split(const std::string& str, const char delim) 
   return split(str,std::string(1,delim));
 }
 
+// Checks if string begins with given substring
+bool starts_with (const std::string& s, const std::string& start);
+
 // Trim leading/trailing characters matching given one (default: whitespace).
 std::string trim (const std::string& s, const char c = ' ');
 

--- a/tests/utils/string_utils_tests.cpp
+++ b/tests/utils/string_utils_tests.cpp
@@ -20,6 +20,11 @@ TEST_CASE("string","string") {
     REQUIRE(items[1]=="item2");
     REQUIRE(items[2]=="item3");
 
+    auto items2 = split(my_list,";item2;");
+    REQUIRE(items2.size()==2);
+    REQUIRE(items2[0]=="item1");
+    REQUIRE(items2[1]=="item3");
+
     std::string padded   = "*****my**string**";
     std::string unpadded = "my**string";
     REQUIRE (trim(padded,'*')==unpadded);
@@ -27,6 +32,12 @@ TEST_CASE("string","string") {
     std::string lower = "my_lower case string!";
     std::string upper = "MY_LOWER CASE STRING!";
     REQUIRE (upper==upper_case(lower));
+  }
+
+  SECTION ("starts_with") {
+    std::string s = "hello world";
+    REQUIRE (starts_with(s,"hello"));
+    REQUIRE (not starts_with(s,"world"));
   }
 
   SECTION ("join") {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The `split` utility did not allow to specify a string (rather than a char) as a delimiter. This PR allows that. I also added the `starts_with` util (C++20 introduces it as a method of basic_string, so it will be obsolete one day). Although the code reduction is very limited, it makes for a clearer intent when reading the code.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in EAMxx.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added tests for new features in `tests/utils/string_utils`.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
