### PR TITLE
If available, use boost::stacktrace in assert macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,21 @@ list (APPEND EKAT_TPL_LIBRARIES_INTERNAL ${YAMLCPP_LIBRARIES})
 BuildSpdlog()
 list (APPEND EKAT_TPL_LIBRARIES_INTERNAL ${SPDLOG_LIBRARIES})
 
+# Try to find Boost>=1.6
+message (STATUS "Looking for boost::stacktrace ...")
+find_package(Boost 1.65.0
+  COMPONENTS stacktrace_addr2line
+)
+
+if (Boost_STACKTRACE_ADDR2LINE_FOUND)
+  list (APPEND EKAT_TPL_LIBRARIES_INTERNAL ${Boost_LIBRARIES})
+  message (STATUS "Looking for boost::stacktrace ... Found")
+  message ("    -> EKAT's assert macros will provide a stacktrace.")
+else()
+  message (STATUS "Looking for boost::stacktrace ... NOT Found")
+  message ("    -> EKAT's assert macros will NOT provide a stacktrace.")
+endif()
+
 set (EKAT_TPL_LIBRARIES ${EKAT_TPL_LIBRARIES_INTERNAL} CACHE INTERNAL "List of EKAT's TPLs")
 
 ##################################

--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -33,6 +33,13 @@ if (EKAT_ENABLE_MPI)
   target_link_libraries (ekat PUBLIC MPI::MPI_C)
 endif()
 
+if (Boost_STACKTRACE_ADDR2LINE_FOUND)
+  target_link_libraries (ekat PUBLIC
+    Boost::stacktrace_addr2line dl)
+  target_compile_definitions (ekat PUBLIC
+    EKAT_HAS_STACKTRACE BOOST_STACKTRACE_USE_ADDR2LINE)
+endif()
+
 target_include_directories(ekat PUBLIC
   $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${EKAT_BINARY_DIR}/src>

--- a/src/ekat/ekat_assert.hpp
+++ b/src/ekat/ekat_assert.hpp
@@ -18,15 +18,23 @@
  * For _msg checks, the msg argument can contain '<<' if not a kernel check.
  */
 
+#ifdef EKAT_HAS_STACKTRACE
+#include <boost/stacktrace.hpp>
+#define EKAT_BACKTRACE boost::stacktrace::stacktrace()
+#else
+#define EKAT_BACKTRACE __FILE__ << ":" << __LINE__
+#endif
+
 // Internal do not call directly
-#define IMPL_THROW(condition, msg, exception_type)                      \
-  do {                                                                  \
-    if ( ! (condition) ) {                                              \
-      std::stringstream _ss_;                                           \
-      _ss_ << __FILE__ << ":" << __LINE__ << ": FAIL:\n" << #condition; \
-      _ss_ << "\n" << msg;                                              \
-      throw exception_type(_ss_.str());                                 \
-    }                                                                   \
+#define IMPL_THROW(condition, msg, exception_type)    \
+  do {                                                \
+    if ( ! (condition) ) {                            \
+      std::stringstream _ss_;                         \
+      _ss_ << "\n FAIL:\n" << #condition;             \
+      _ss_ << EKAT_BACKTRACE;                         \
+      _ss_ << "\n" << msg;                            \
+      throw exception_type(_ss_.str());               \
+    }                                                 \
   } while(0)
 
 // SYCL cannot printf like the other backends quite yet

--- a/src/ekat/ekat_assert.hpp
+++ b/src/ekat/ekat_assert.hpp
@@ -30,7 +30,7 @@
   do {                                                \
     if ( ! (condition) ) {                            \
       std::stringstream _ss_;                         \
-      _ss_ << "\n FAIL:\n" << #condition;             \
+      _ss_ << "\n FAIL:\n" << #condition  << "\n";   \
       _ss_ << EKAT_BACKTRACE;                         \
       _ss_ << "\n" << msg;                            \
       throw exception_type(_ss_.str());               \


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Currently, our assert macros only print the filename and linenumber where the macro was invoked. For asserts inside widely used functions, this adds little context. A backtrace of the error would allow for faster debugging, even from production runs. Boost offers an easy choice, so if the library is available, we can take advantage of it.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:


* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
## Related Issues
* Closes #294 

## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Might help debugging some EAMxx failures without having to re-run inside a debugger.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually verified that this PR enriches the output:

If boost stacktrace lib is not found, we resort to the old implementation:
```
/home/lbertag/workdir/libs/ekat/ekat-src/master/tests/utils/std_meta.cpp:18: FAILED:
  {Unknown expression after the reported line}
due to unexpected exception with message:
  
 FAIL:
  src.isType<ConcreteType>()/home/lbertag/workdir/libs/ekat/ekat-src/master/
  src/ekat/std_meta/ekat_std_any.hpp:144
  Error! Invalid cast requested.
     - actual type:    St6vectorIiSaIiEE
     - requested type: St6vectorIdSaIdEE'.
```
If the boost lib is available _AND_ debug symbols are present, we get
```
due to unexpected exception with message:
  
 FAIL:
  src.isType<ConcreteType>() 0# std::vector<double, std::allocator<double> >&
  ekat::any_cast<std::vector<double, std::allocator<double> > >(ekat::any&) at
  /home/lbertag/workdir/libs/ekat/ekat-src/master/src/ekat/std_meta/
  ekat_std_any.hpp:141
   1# C_A_T_C_H_T_E_S_T_0() at /home/lbertag/workdir/libs/ekat/ekat-src/master/
  tests/utils/std_meta.cpp:21
   2# Catch::TestInvokerAsFunction::invoke() const at /home/lbertag/workdir/
  libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.hpp:14329
   3# Catch::TestCase::invoke() const at /home/lbertag/workdir/libs/ekat/ekat-
  src/master/extern/Catch2/single_include/catch2/catch.hpp:14168
   4# Catch::RunContext::invokeActiveTestCase() at /home/lbertag/workdir/libs/
  ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.hpp:13026
   5# Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::
  char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char,
  std::char_traits<char>, std::allocator<char> >&) at /home/lbertag/workdir/
  libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.hpp:13002
   6# Catch::RunContext::runTest(Catch::TestCase const&) at /home/lbertag/
  workdir/libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.
  hpp:12762
   7# Catch::(anonymous namespace)::TestGroup::execute() at /home/lbertag/
  workdir/libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.
  hpp:13354
   8# Catch::Session::runInternal() at /home/lbertag/workdir/libs/ekat/ekat-
  src/master/extern/Catch2/single_include/catch2/catch.hpp:13562
   9# Catch::Session::run() at /home/lbertag/workdir/libs/ekat/ekat-src/master/
  extern/Catch2/single_include/catch2/catch.hpp:13516
  10# main at /home/lbertag/workdir/libs/ekat/ekat-src/master/src/ekat/util/
  ekat_catch_main.cpp:117
  11# __libc_start_main in /lib64/libc.so.6
  12# _start in ./std_meta
  
Error! Invalid cast requested.
     - actual type:    St6vectorIiSaIiEE
     - requested type: St6vectorIdSaIdEE'.
```
If the lib is available _BUT_ debug symbols are not present, we still get a stack, albeit without line numbers:
```
due to unexpected exception with message:
  
 FAIL:
  src.isType<ConcreteType>() 0# std::vector<double, std::allocator<double> >&
  ekat::any_cast<std::vector<double, std::allocator<double> > >(ekat::any&) in
  ./std_meta
   1# C_A_T_C_H_T_E_S_T_0() at std_meta.cpp:?
   2# Catch::TestInvokerAsFunction::invoke() const in ./std_meta
   3# Catch::TestCase::invoke() const in ./std_meta
   4# Catch::RunContext::invokeActiveTestCase() in ./std_meta
   5# Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::
  char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char,
  std::char_traits<char>, std::allocator<char> >&) in ./std_meta
   6# Catch::RunContext::runTest(Catch::TestCase const&) in ./std_meta
   7# Catch::(anonymous namespace)::TestGroup::execute() at ekat_catch_main.
  cpp:?
   8# Catch::Session::runInternal() in ./std_meta
   9# Catch::Session::run() in ./std_meta
  10# main in ./std_meta
  11# __libc_start_main in /lib64/libc.so.6
  12# _start in ./std_meta
  
Error! Invalid cast requested.
     - actual type:    St6vectorIiSaIiEE
     - requested type: St6vectorIdSaIdEE'.
```
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
