### PR TITLE
Adding a flag to enable/disable EKAT's Fortran support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,14 @@ include(EkatBuildKokkos)
 include(EkatBuildYamlCpp)
 include(EkatBuildSpdlog)
 
-# EKAT has mostly C++, but some Fortran too
-project (EKAT C CXX Fortran)
+# EKAT has mostly C++, but (optionally) Fortran too
+option (EKAT_ENABLE_FORTRAN "Whether EKAT Fortran support is enabled." ON)
+enable_language(C)
+enable_language(CXX)
+if (EKAT_ENABLE_FORTRAN)
+  enable_language(Fortran)
+endif()
+project (EKAT)
 
 # MPI is enabled by default, but not needed.
 option (EKAT_ENABLE_MPI "Whether EKAT requires MPI." ON)

--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -2,10 +2,15 @@ include(GNUInstallDirs)
 include(EkatSetCompilerFlags)
 include (EkatUtils)
 
-# Generate configuration file
-EkatConfigFile (${CMAKE_CURRENT_SOURCE_DIR}/ekat_config.h.in
-                ${CMAKE_CURRENT_BINARY_DIR}/ekat_config.h
-                F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/ekat_config.f)
+# Generate configuration files
+if (EKAT_ENABLE_FORTRAN)
+  EkatConfigFile (${CMAKE_CURRENT_SOURCE_DIR}/ekat_config.h.in
+                  ${CMAKE_CURRENT_BINARY_DIR}/ekat_config.h
+                  F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/ekat_config.f)
+else()
+  EkatConfigFile (${CMAKE_CURRENT_SOURCE_DIR}/ekat_config.h.in
+                  ${CMAKE_CURRENT_BINARY_DIR}/ekat_config.h)
+endif()
 
 set(EKAT_SOURCES
   ekat_assert.cpp
@@ -13,11 +18,13 @@ set(EKAT_SOURCES
   ekat_session.cpp
   io/ekat_yaml.cpp
   io/ekat_array_io.cpp
-  io/ekat_array_io_mod.f90
   util/ekat_arch.cpp
   util/ekat_string_utils.cpp
   util/ekat_test_utils.cpp
 )
+if (EKAT_ENABLE_FORTRAN)
+  set(EKAT_SOURCES ${EKAT_SOURCES} io/ekat_array_io_mod.f90)
+endif()
 
 if (EKAT_ENABLE_MPI)
   set(EKAT_SOURCES ${EKAT_SOURCES} mpi/ekat_comm.cpp)
@@ -43,10 +50,13 @@ endif()
 target_include_directories(ekat PUBLIC
   $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${EKAT_BINARY_DIR}/src>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/ekat_f90_modules>
   $<BUILD_INTERFACE:${EKAT_SOURCE_DIR}/extern/Catch2/single_include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ekat_f90_modules>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+if (EKAT_ENABLE_FORTRAN)
+  target_include_directories(ekat PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/ekat_f90_modules>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ekat_f90_modules>)
+endif()
 
 # TODO: The current version of kokkos we are using in e3sm has a nvcc_wrapper
 #       which breaks the cmake toolchain features detection mechanisms.
@@ -63,8 +73,10 @@ if (EKAT_HAVE_FEENABLEEXCEPT)
 endif()
 
 target_link_libraries(ekat PUBLIC ${EKAT_TPL_LIBRARIES})
-set_target_properties(ekat PROPERTIES
-    Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ekat_f90_modules)
+if (EKAT_ENABLE_FORTRAN)
+  set_target_properties(ekat PROPERTIES
+      Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ekat_f90_modules)
+endif()
 
 install (TARGETS ekat
          EXPORT EkatTargets
@@ -83,8 +95,10 @@ install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/ekat_config.h
                ${CMAKE_CURRENT_BINARY_DIR}/ekat_config.f
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ekat)
-install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ekat_f90_modules
-         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if (EKAT_ENABLE_FORTRAN)
+  install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ekat_f90_modules
+           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 ###########################################
 ###       Testing micro-libraries       ###

--- a/tests/algorithm/CMakeLists.txt
+++ b/tests/algorithm/CMakeLists.txt
@@ -6,8 +6,10 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/ekat_config.f.in
 # Test lin interp processes
 set (LIN_INTERP_SRCS
   lin_interp_test.cpp
-  lin_interp_ref.F90
 )
+if (EKAT_ENABLE_FORTRAN)
+  set (LIN_INTERP_SRCS ${LIN_INTERP_SRCS} lin_interp_ref.F90)
+endif()
 
 if (EKAT_TEST_DOUBLE_PRECISION)
   EkatCreateUnitTest(lin_interp${DP_POSTFIX} "${LIN_INTERP_SRCS}"
@@ -28,8 +30,10 @@ set (TRIDIAG_SRCS
   tridiag_bfb.cpp
   tridiag_tests_correctness.cpp
   tridiag_tests_performance.cpp
-  tridiag_bfb_mod.F90
 )
+if (EKAT_ENABLE_FORTRAN)
+  set (TRIDIAG_SRCS ${TRIDIAG_SRCS} tridiag_bfb_mod.F90)
+endif()
 if (EKAT_TEST_DOUBLE_PRECISION)
   EkatCreateUnitTest(tridiag${DP_POSTFIX} "${TRIDIAG_SRCS}"
     LIBS ekat

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -9,12 +9,14 @@
 #include <vector>
 #include <algorithm>
 
+#ifdef EKAT_ENABLE_FORTRAN
 extern "C" {
 
 // This will link to the fortran reference implementation
 void linear_interp_c(const Real* x1, const Real* x2, const Real* y1, Real* y2, int km1, int km2, int ncol);
 
 }
+#endif
 
 namespace {
 
@@ -64,6 +66,7 @@ auto get_col (const ViewT& packed_view, int i) ->
     return ekat::scalarize(ekat::subview(packed_view,i));
 };
 
+#ifdef EKAT_ENABLE_FORTRAN
 TEST_CASE("lin_interp_soak", "lin_interp") {
 
   std::default_random_engine generator;
@@ -278,6 +281,7 @@ TEST_CASE("lin_interp_soak", "lin_interp") {
     }
   }
 }
+#endif // EKAT_ENABLE_FORTRAN
 
 TEST_CASE("lin_interp_api", "lin_interp")
 {

--- a/tests/ekat_test_config.h.in
+++ b/tests/ekat_test_config.h.in
@@ -14,6 +14,9 @@ using Real = double;
 using Real = float;
 #endif
 
+// Whether Fortran is enabled
+#cmakedefine EKAT_ENABLE_FORTRAN
+
 // The number of scalars in a default pack::Pack and Mask.
 #cmakedefine EKAT_TEST_PACK_SIZE ${EKAT_TEST_PACK_SIZE}
 


### PR DESCRIPTION
## Motivation

In order to make EKAT easier to use for a wider range of E3SM developers, I think it would be good not to require a Fortran compiler in those environments in which it's not needed. This probably isn't very interesting to a lot of projects just yet, but the MAM4 C++ port doesn't actually have any Fortran in it, and we're interested in providing a development environment with only the essentials for our task. This PR adds an optional called `EKAT_ENABLE_FORTRAN` that allows you to choose whether you want to build EKAT's Fortran support and run the Fortran-related BFB tests.

"Why not just live with the Fortran code and make you you have a working Fortran compiler on your system?" I hear you ask. Good question. In a perfect world, everyone would use a Linux development environment, in which all these things are *usually* easy. In practice, many people have Macs on which they like to develop, and many others have Linux machines that are maintained by their IT departments, which creates all kinds of edge cases that make every additional thing a support issue. Also, as you can see in this PR, there are really only a few spots where EKAT makes use of Fortran, at least so far, and it wasn't very difficult to find them and put guards around them.

This is just a suggestion (with solution attached), so if we don't want to go in this direction, that's also fine. By default, EKAT's Fortran support is enabled, so we shouldn't see any difference in the testing output (unless I've messed up somewhere).

## Testing

We are planning to build EKAT with `-DEKAT_ENABLE_FORTRAN=OFF` in our Haero/mam4xx test configurations for EAGLES, so this feature (like `EKAT_ENABLE_MPI`) is tested in our environment.
