### PR TITLE
HIP: Omit aggressive vectorization flag

### DIFF
--- a/cmake/machine-files/kokkos/hip.cmake
+++ b/cmake/machine-files/kokkos/hip.cmake
@@ -1,5 +1,3 @@
 # Settings used when HIP is the Kokkos backend
 
-#is this needed?
-set(Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION FALSE CACHE BOOL "")
 set(Kokkos_ENABLE_HIP TRUE CACHE BOOL "")


### PR DESCRIPTION
While auditing all machine configuration options on Frontier, encountered this flag.
Evidently, this is not used by the GPU backends. Removed to avoid confusion.

Per Slack conversation,
> @ambrad : The vec flag triggers ivdep on CPU on ThreadVectorRange loops. I don't think any of the GPU backends do anything with it.

