### PR TITLE
Fix misspelling of some CMake vars in cmake utilities

### DIFF
--- a/cmake/pkg_build/EkatBuildSpdlog.cmake
+++ b/cmake/pkg_build/EkatBuildSpdlog.cmake
@@ -36,7 +36,7 @@ endmacro()
 
 # Process the spdlog subdirectory
 macro (BuildSpdlog)
-  if (NOT IS_SPDLOG_ALREADY_BUILT)
+  if (NOT IS_EKAT_SPDLOG_BUILT)
 
     # Make sure SPDLOG_SOURCE_DIR is set
     EkatSetSpdlogSourceDir()

--- a/cmake/pkg_build/EkatBuildYamlCpp.cmake
+++ b/cmake/pkg_build/EkatBuildYamlCpp.cmake
@@ -36,7 +36,7 @@ endmacro()
 
 # Process the libyaml subdirectory
 macro (BuildYamlcpp)
-  if (NOT IS_YAMLCPP_ALREADY_BUILT)
+  if (NOT IS_EKAT_YAMLCPP_BUILT)
 
     # Make sure YAMLCPP_SOURCE_DIR is set
     EkatSetYamlcppSourceDir()


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The CMake var checked inside `EkatBuildSpdlog.cmake` and `EkatBuildYamlCpp.cmake` were misspelled. This would cause the guard against double config of the package to fail.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
