### PR TITLE
Add support for tags in YAML parsing

### DIFF
--- a/tests/io/input.yaml
+++ b/tests/io/input.yaml
@@ -1,5 +1,7 @@
 %YAML 1.1
 ---
+ints_as_strings: !string [1,2]
+empty_as_doubles: !double []
 Constants:
   One Double: 9.8
   Three Doubles: [1.024e3, .1 , -1.0E-2]

--- a/tests/io/yaml_parser.cpp
+++ b/tests/io/yaml_parser.cpp
@@ -12,7 +12,13 @@ TEST_CASE ("yaml_parser","") {
 
   std::string fname = "input.yaml";
   ParameterList params("parameters");
-  REQUIRE_NOTHROW ( parse_yaml_file(fname,params) );
+  parse_yaml_file(fname,params);
+
+  REQUIRE (params.isParameter ("ints_as_strings"));
+  REQUIRE (params.isType<std::vector<std::string>> ("ints_as_strings"));
+  REQUIRE (params.isParameter ("empty_as_doubles"));
+  REQUIRE (params.isType<std::vector<double>> ("empty_as_doubles"));
+  REQUIRE (params.get<std::vector<double>> ("empty_as_doubles").size()==0);
 
   // Check some of the loaded parameters.
   // NOTE: if you change input.yaml, you may have to


### PR DESCRIPTION
This allows the user to request the value to be stored with a specific type.

A big advantage is that we can have empty sequences stored with the correct type.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The main motivation for this is to be able to specify empty sequences of a specific type. So far, an entry of the form `foo: []` would be parsed as a sequence. But the parser deduces the inner type by trying to cast all the entries to, in order, `bool`, `int`, `double`, and `std::string`. Since an empty sequence has nothing to cast, the parser has nothing to check, and the first type (bool) was used.

With this PR, we can provide a tag to a node, to force the parser to use the desired type. The parser accepts `!bool`, `!int`, `!double`, and `!string`. Hence, a user can provide an empty list and force its inner type to be, say, `double` by using the syntax `foo: !double []`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
In the yaml file parsed in the unit tests I added the line `ints_as_strings: !string [1,2]`, and verified it gets stored as `std::vector<std::string>`. I also added an empty sequence with `!double` tag, and verified it is stored as `std::vector<double>`, and the stored size is 0.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
