### PR TITLE
Change tag names used in YAML parser

### DIFF
--- a/src/ekat/io/ekat_yaml.cpp
+++ b/src/ekat/io/ekat_yaml.cpp
@@ -121,23 +121,23 @@ void parse_node<YAML::NodeType::Scalar> (
     });
   } else {
     // YAY, the user is telling us how to interpret the values
-    if (tag=="!bool") {
+    if (tag=="!!bool" or tag=="tag:yaml.org,2002:bool") {
       EKAT_REQUIRE_MSG (is_type<bool>(str),
           "Error! Tag " + tag + " not compatible with the stored value '" + str + "'\n");
       list.set(key,str2type<bool>(str));
-    } else if (tag=="!int") {
+    } else if (tag=="!!int" or tag=="tag:yaml.org,2002:int") {
       EKAT_REQUIRE_MSG (is_type<int>(str),
           "Error! Tag " + tag + " not compatible with the stored value '" + str + "'\n");
       list.set(key,str2type<int>(str));
-    } else if (tag=="!double") {
+    } else if (tag=="!!float" or tag=="tag:yaml.org,2002:float") {
       EKAT_REQUIRE_MSG (is_type<double>(str),
           "Error! Tag " + tag + " not compatible with the stored value '" + str + "'\n");
       list.set(key,str2type<double>(str));
-    } else if (tag=="!string") {
+    } else if (tag=="!!str" or tag=="tag:yaml.org,2002:str") {
       list.set(key,str);
     } else {
       EKAT_ERROR_MSG ("Error! Unrecognized/unsupported node tag: " + tag + "\n"
-          "  Supported tags: !int, !bool, !double, !string");
+          "  Supported tags: !!int, !!bool, !!float, !!str");
     }
   }
 }
@@ -200,18 +200,18 @@ void parse_node<YAML::NodeType::Sequence> (
     TRY_TYPE_ON_NODE(std::string, std::string, node);
   } else {
     // YAY, the user is telling us how to interpret the values
-    if (tag=="!bool") {
+    if (tag=="!bools") {
       TRY_TYPE_ON_NODE(bool,char,node);
-    } else if (tag=="!int") {
+    } else if (tag=="!ints") {
       TRY_TYPE_ON_NODE(int,int,node);
-    } else if (tag=="!double") {
+    } else if (tag=="!floats") {
       TRY_TYPE_ON_NODE(double,double,node);
-    } else if (tag=="!string") {
+    } else if (tag=="!strings") {
       TRY_TYPE_ON_NODE(std::string,std::string,node);
     } else {
       EKAT_ERROR_MSG ("Error! Unrecognized/unsupported node tag.\n"
           "  tag: " + tag + "\n"
-          "  supported tags: !int, !bool, !double, !string");
+          "  supported tags: !ints, !bools, !floats, !strings");
     }
     EKAT_ERROR_MSG ("Error! Tag '" + tag + "' was not compatible with the stored values.\n");
   }

--- a/tests/io/input.yaml
+++ b/tests/io/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-ints_as_strings: !string [1,2]
-empty_as_doubles: !double []
+ints_as_strings: !strings [1,2]
+empty_as_doubles: !floats []
 Constants:
   One Double: 9.8
   Three Doubles: [1.024e3, .1 , -1.0E-2]
@@ -12,6 +12,6 @@ Constants:
 Options:
   My Bool: FALSE
   My Int: -2
-  My String: string
+  My String: !!str 1
   My Real: -1.0
 ...


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
YAML already supports special tags for built-in types. This PR avoid confusion (and enhances interoperability with existing codes) by using native tags `!!bool`, `!!int`, `!!float`, and `!!str` for boolean, integer, floating point, and string parameters. Notice the double !! for the YAML built-in tags; `!!blah` actually is a short for `tag:yaml.org,2002:blah`. For arrays of parameters, we changed the tag names to be plural, for clarity and to minimize bugs.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Modified (and improved) the tests accordingly.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
