### PR TITLE
Fix bug in YAML parser

### DIFF
--- a/src/ekat/io/ekat_yaml.cpp
+++ b/src/ekat/io/ekat_yaml.cpp
@@ -133,10 +133,10 @@ void parse_node<YAML::NodeType::Scalar> (
       EKAT_REQUIRE_MSG (is_type<double>(str),
           "Error! Tag " + tag + " not compatible with the stored value '" + str + "'\n");
       list.set(key,str2type<double>(str));
-    } else if (tag=="!!str" or tag=="tag:yaml.org,2002:str") {
+    } else if (tag=="!" or tag=="!!str" or tag=="tag:yaml.org,2002:str") {
       list.set(key,str);
     } else {
-      EKAT_ERROR_MSG ("Error! Unrecognized/unsupported node tag: " + tag + "\n"
+      EKAT_ERROR_MSG ("Error! Unrecognized/unsupported node tag '" + tag + "' for scalar node '" + key + "'.\n"
           "  Supported tags: !!int, !!bool, !!float, !!str");
     }
   }

--- a/tests/io/input.yaml
+++ b/tests/io/input.yaml
@@ -10,8 +10,8 @@ Constants:
   Nested Sublist:
     The Answer: 42
 Options:
-  My Bool: FALSE
+  My Bool: !!bool "false"
   My Int: -2
-  My String: !!str 1
+  My String: "blah"
   My Real: -1.0
 ...


### PR DESCRIPTION
Non-specific tag uses a single exlamation mark, not a question mark

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Testing in EAMxx revealed that explicitly quoted strings do get the tag `!` (a single exlamation mark). Since quotes were explicitly used, such entries should be parsed as strings.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Modified the yaml parser unit test to exercise this use case.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
