### PR TITLE
In ParameterList::get method, print more info in case of wrong type

### DIFF
--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -103,8 +103,15 @@ inline T& ParameterList::get (const std::string& name) {
   // Check entry exists
   EKAT_REQUIRE_MSG ( isParameter(name),
       "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
+  auto p = m_params[name];
+  EKAT_REQUIRE_MSG ( p.isType<T>(),
+      "Error! Attempting to access parameter using the wrong type.\n"
+      "   - list name : " + m_name + "\n"
+      "   - param name: " + name + "\n"
+      "   - param type: " + std::string(p.content().type().name()) + "\n"
+      "   - input type: " + std::string(typeid(T).name()) + "'.\n");
 
-  return any_cast<T>(m_params[name]);
+  return any_cast<T>(p);
 }
 
 template<typename T>
@@ -112,7 +119,15 @@ inline const T& ParameterList::get (const std::string& name) const {
   EKAT_REQUIRE_MSG ( isParameter(name),
       "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
 
-  return any_cast<T>(m_params.at(name));
+  auto p = m_params.at(name);
+  EKAT_REQUIRE_MSG ( p.isType<T>(),
+      "Error! Attempting to access parameter using the wrong type.\n"
+      "   - list name : " + m_name + "\n"
+      "   - param name: " + name + "\n"
+      "   - param type: " + std::string(p.content().type().name()) + "\n"
+      "   - input type: " + std::string(typeid(T).name()) + ".\n");
+
+  return any_cast<T>(p);
 }
 
 template<typename T>

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -96,6 +96,25 @@ TEST_CASE("parameter_list", "") {
   src.set<int>("j",10);
   src.sublist("sl").set<double>("d",1.0);
 
+  bool thrown = false;
+  try {
+    double d = src.get<double>("i");
+  } catch (std::exception& e) {
+    std::stringstream exp_err;
+    exp_err << "\n FAIL:\n"
+            << "p.isType<T>()\n"
+            << "/home/lbertag/workdir/libs/ekat/ekat-src/branch/src/ekat/ekat_parameter_list.hpp:107\n"
+            << "Error! Attempting to access parameter using the wrong type.\n"
+            << "   - list name : src\n"
+            << "   - param name: i\n"
+            << "   - param type: i\n"
+            << "   - input type: d'.\n";
+    REQUIRE (e.what()==exp_err.str());
+    thrown = true;
+  }
+  // Check that an exception was thrown, so that the previous check was excercised
+  REQUIRE (thrown);
+
   ParameterList dst("dst");
   dst.set<int>("i",10);
 

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -4,6 +4,7 @@
 #include "ekat/kokkos/ekat_kokkos_meta.hpp"
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_type_traits.hpp"
+#include "ekat/util/ekat_string_utils.hpp"
 
 #include "ekat_test_config.h"
 
@@ -98,18 +99,22 @@ TEST_CASE("parameter_list", "") {
 
   bool thrown = false;
   try {
-    double d = src.get<double>("i");
+    printf("d = %f\n",src.get<double>("i"));
   } catch (std::exception& e) {
-    std::stringstream exp_err;
-    exp_err << "\n FAIL:\n"
-            << "p.isType<T>()\n"
-            << "/home/lbertag/workdir/libs/ekat/ekat-src/branch/src/ekat/ekat_parameter_list.hpp:107\n"
-            << "Error! Attempting to access parameter using the wrong type.\n"
-            << "   - list name : src\n"
-            << "   - param name: i\n"
-            << "   - param type: i\n"
-            << "   - input type: d'.\n";
-    REQUIRE (e.what()==exp_err.str());
+    auto lines = ekat::split(e.what(),"\n");
+    std::vector<std::string> expected = {
+      "Error! Attempting to access parameter using the wrong type.",
+      "   - list name : src",
+      "   - param name: i",
+      "   - param type: i",
+      "   - input type: d'.",
+      ""
+    };
+    auto it = lines.end()-6;
+    for (const auto& s : expected) {
+      REQUIRE (s==*it);
+      ++it;
+    }
     thrown = true;
   }
   // Check that an exception was thrown, so that the previous check was excercised


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Currently, if the provided template type does not match the parameter real type, an exception is thrown inside the `any_cast` function, which however has no knowledge about the fact that this `ekat::any` instance comes from a parameter list, let alone the name of the parameter. This makes it complicated for the user to realize which parameter was accessed with the wrong type (or even that this error comes from a `ParameterList::get` call)

This PR adds a check on the template type (the same that `any_cast` would do) before attempting the cast. If the cast fails, it prints the name of the parameter, as well as the name of the enclosing parameter list.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added small test to verify exception is thrown, and expected error message is printed.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
