### PR TITLE
Error out if the found kokkos installation is not compatible with the requested options

### DIFF
--- a/cmake/tpls/EkatFindKokkos.cmake
+++ b/cmake/tpls/EkatFindKokkos.cmake
@@ -44,7 +44,15 @@ endforeach()
 
 # Try to find the package
 message (STATUS "Looking for a Kokkos installation ...")
-find_package(Kokkos QUIET)
+find_package(Kokkos QUIET
+  # Skip all cmake defaults paths, except for env/cmake vars Kokkos_ROOT (if any)
+  NO_CMAKE_PATH
+  NO_CMAKE_ENVIRONMENT_PATH
+  NO_SYSTEM_ENVIRONMENT_PATH
+  NO_CMAKE_PACKAGE_REGISTRY
+  NO_CMAKE_SYSTEM_PATH
+  NO_CMAKE_INSTALL_PREFIX
+  NO_CMAKE_SYSTEM_PACKAGE_REGISTRY)
 
 if (Kokkos_FOUND)
   # Check if the requested devices/archs/options are enabled in the installation
@@ -69,12 +77,9 @@ if (Kokkos_FOUND)
       set (Kokkos_FOUND FALSE)
     endif()
   endforeach()
-endif()
 
-# If not found, download it and add subirectory
-if (NOT Kokkos_FOUND)
-  message (STATUS "Looking for a Kokkos installation ... NOT FOUND")
   if (MISSING_DEVICES OR MISSING_ARCHS OR MISSING_OPTIONS)
+    message (STATUS "Looking for a Kokkos installation ... NOT FOUND")
     message (STATUS "  -> An installation was found at ${Kokkos_DIR}, but was not accepted, because:")
 
     if (MISSING_DEVICES)
@@ -86,8 +91,15 @@ if (NOT Kokkos_FOUND)
     if (MISSING_OPTIONS)
       message (STATUS "   - Requested options ${MISSING_OPTIONS} not found in the installation")
     endif()
+
+    string (CONCAT msg
+          "Please, provide a Kokkos_ROOT env/CMake variable pointing to a correct installation.\n"
+          "You can also provide no such env/CMake variable, and we will build/install Kokkos locally")
+    message ("${msg}")
+    message (FATAL_ERROR "Aborting...")
   endif()
-else()
   message (STATUS "Looking for a Kokkos installation ... FOUND")
   message (STATUS "  Kokkos_DIR: ${Kokkos_DIR}")
+else ()
+  message (STATUS "Looking for a Kokkos installation ... NOT FOUND")
 endif()


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When `find_package` succeeds, it imports all the defined targets. In `EkatFindKokkos.cmake` we "reject" the installation if it does not have the correct Kokkos settings (e.g., it's an OpenMP build, but this build needs a Serial backend). However, since the target "kokkos" has been defined by the import, we can no longer build kokkos locally, since we would hit an error of the form

```
CMake Error at /home/lbertag/workdir/scream/scream-src/branch/externals/ekat/extern/kokkos/CMakeLists.txt:290 (ADD_LIBRARY):
  ADD_LIBRARY cannot create target "kokkos" because an imported target with
  the same name already exists.
```

Therefore, we must error out if the installation we find is not the suitable one.

Furthermore,  the default behavior of CMake when it comes to `find_package` is to use a bunch of default search paths. @AaronDonahue as well as @jgfouca and myself, run into an odd behavior where CMake would find some long forgotten Kokkos install in some random folder, which, being very old, were rejected by our cmake logic. After some digging, I found out these were found inside the CMake package registry. To avoid surprises, I decided to not allow any default path, _except_ for what is provided via the env/CMake var `Kokkos_ROOT`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
