### PR TITLE
Some fixes that allow to build with raw compilers instead of mpi wrap…

### DIFF
--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -1,7 +1,6 @@
 # Detect the library that provides MPI
 set (EKAT_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 macro (GetMpiDistributionName DISTRO_NAME)
-  dump_cmake_variables(REGEX "^MPI")
   if (CMAKE_CXX_COMPILER AND MPI_CXX_FOUND)
     set (LINK_LIB MPI::MPI_CXX)
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.cxx)

--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -2,10 +2,10 @@
 set (EKAT_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 macro (GetMpiDistributionName DISTRO_NAME)
   if (MPI_CXX_COMPILER)
-    set (INCLUDE_DIRS ${MPI_CXX_INCLUDE_DIRS})
+    set (LINK_LIB MPI::MPI_CXX)
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.cxx)
   elseif (MPI_C_COMPILER)
-    set (INCLUDE_DIRS ${MPI_C_INCLUDE_DIRS})
+    set (LINK_LIB MPI::MPI_C)
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.c)
   else ()
     string (CONCAT MSG
@@ -20,9 +20,8 @@ macro (GetMpiDistributionName DISTRO_NAME)
     message (FATAL_ERROR "Aborting")
   endif()
   try_compile (RESULT
-               ${CMAKE_BINARY_DIR}/CMakeFiles
                SOURCES ${SOURCE_FILE}
-               CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${INCLUDE_DIRS}"
+               LINK_LIBRARIES ${LINK_LIB}
                OUTPUT_VARIABLE OUT_VAR)
 
   if (NOT RESULT)

--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -1,18 +1,19 @@
 # Detect the library that provides MPI
 set (EKAT_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 macro (GetMpiDistributionName DISTRO_NAME)
-  if (MPI_CXX_COMPILER)
+  dump_cmake_variables(REGEX "^MPI")
+  if (CMAKE_CXX_COMPILER AND MPI_CXX_FOUND)
     set (LINK_LIB MPI::MPI_CXX)
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.cxx)
-  elseif (MPI_C_COMPILER)
+  elseif (CMAKE_C_COMPILER AND MPI_C_FOUND)
     set (LINK_LIB MPI::MPI_C)
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.c)
   else ()
     string (CONCAT MSG
       "**************************************************************\n"
-      "  MPI_C_COMPILER and MPI_CXX_COMPILER are not set.\n"
       "  CMake logic to determine the distribution name\n"
-      "  requires a valid C or CXX mpi compiler.\n"
+      "  requires a valid C or CXX mpi compiler, with the corresponding\n"
+      "  MPI_<LANG>_FOUND=TRUE set (via previous call to find_package).\n"
       "  Please call find_package(MPI [REQUIRED] COMPONENTS [C|CXX])\n"
       "  *before* calling GetMpiDistributionName (in the same scope).\n"
       "**************************************************************\n")
@@ -59,6 +60,7 @@ function (DisableMpiCxxBindings)
 endfunction()
 
 # Set MPI runtime env vars for comm world rank/size, depending on mpi distribution
+# NOTE: this is needed by the test-launcher script you find in ${CMAKE_SOURCE_DIR}/bin
 macro (SetMpiRuntimeEnvVars)
   set (DISTRO_NAME)
   GetMpiDistributionName (DISTRO_NAME)

--- a/cmake/tpls/EkatTPLs.cmake
+++ b/cmake/tpls/EkatTPLs.cmake
@@ -8,7 +8,6 @@ option (EKAT_DISABLE_TPL_WARNINGS "Whether we should suppress warnings when comp
 
 # WARNING: you CANNOT do list(APPEND var item1 ... item2) if var is a CACHE variable!
 # Therefore, use an internal var during tpl parsing, then set a cache var ONCE at the end
-set (EKAT_TPL_LIBRARIES_INTERNAL)
 
 ###################################
 #         MPI (Optional)          #
@@ -17,7 +16,7 @@ set (EKAT_TPL_LIBRARIES_INTERNAL)
 # MPI is enabled by default, but not needed.
 option (EKAT_ENABLE_MPI "Whether EKAT requires MPI." ON)
 if (EKAT_ENABLE_MPI)
-  find_package(MPI REQUIRED COMPONENTS C)
+  find_package(MPI REQUIRED)
 
   # NOTE: may be an overkill, but depending on which FindMPI module is called,
   #       if _FIND_REQUIRED is not checked, we may not get a fatal error
@@ -35,7 +34,6 @@ if (EKAT_ENABLE_MPI)
   # MPI-related options
   option (EKAT_MPI_ERRORS_ARE_FATAL " Whether EKAT should crash when MPI errors happen." ON)
 
-  list (APPEND EKAT_TPL_LIBRARIES_INTERNAL MPI::MPI_C)
 endif()
 
 ###################################
@@ -47,7 +45,6 @@ include (EkatFindKokkos)
 if (NOT Kokkos_FOUND)
   include (EkatBuildKokkos)
 endif()
-list (APPEND EKAT_TPL_LIBRARIES_INTERNAL Kokkos::kokkos)
 
 # A shortcut var, to handle GPU-specific (but backend-agnostic) stuff
 set (EKAT_ENABLE_GPU False)
@@ -80,7 +77,6 @@ if (EKAT_ENABLE_YAML_PARSER)
     message (STATUS "Looking for yaml-cpp ... FOUND")
     message (STATUS "  yaml-cpp_DIR: ${yaml-cpp_DIR}")
   endif()
-  list (APPEND EKAT_TPL_LIBRARIES_INTERNAL yaml-cpp)
 endif()
 
 ###################################
@@ -97,7 +93,6 @@ else()
   message (STATUS "Looking for spdlog ... FOUND")
   message (STATUS "  spdlog_DIR: ${spdlog_DIR}")
 endif()
-list (APPEND EKAT_TPL_LIBRARIES_INTERNAL spdlog::spdlog)
 
 ###################################
 #   Boost stacktrace (Optional)   #
@@ -110,7 +105,6 @@ find_package(Boost 1.65.0
 )
 
 if (Boost_STACKTRACE_ADDR2LINE_FOUND)
-  list (APPEND EKAT_TPL_LIBRARIES_INTERNAL ${Boost_LIBRARIES})
   message (STATUS "Looking for boost::stacktrace ... Found")
   message ("    -> EKAT's assert macros will provide a stacktrace.")
   set (EKAT_HAS_STACKTRACE TRUE)
@@ -119,6 +113,5 @@ else()
   message ("    -> EKAT's assert macros will NOT provide a stacktrace.")
 endif()
 
-set (EKAT_TPL_LIBRARIES ${EKAT_TPL_LIBRARIES_INTERNAL} CACHE INTERNAL "List of EKAT's TPLs")
 
 message (STATUS " *** End processing EKAT's TPLs ***")

--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -42,6 +42,9 @@ target_link_libraries(ekat PUBLIC Kokkos::kokkos spdlog::spdlog)
 # target_link_libraries(ekat PUBLIC ${EKAT_TPL_LIBRARIES})
 
 # These libs are optional
+if (EKAT_ENABLE_MPI)
+  target_link_libraries(ekat PUBLIC MPI::MPI_C)
+endif()
 if (EKAT_ENABLE_YAML_PARSER)
   message ("linking yaml-cpp")
   target_link_libraries(ekat PRIVATE yaml-cpp)

--- a/src/ekat/CMakeLists.txt
+++ b/src/ekat/CMakeLists.txt
@@ -39,21 +39,19 @@ add_library(ekat ${EKAT_SOURCES})
 
 # These libs are for sure needed
 target_link_libraries(ekat PUBLIC Kokkos::kokkos spdlog::spdlog)
-# target_link_libraries(ekat PUBLIC ${EKAT_TPL_LIBRARIES})
 
 # These libs are optional
 if (EKAT_ENABLE_MPI)
   target_link_libraries(ekat PUBLIC MPI::MPI_C)
 endif()
 if (EKAT_ENABLE_YAML_PARSER)
-  message ("linking yaml-cpp")
   target_link_libraries(ekat PRIVATE yaml-cpp)
 endif()
-
 if (EKAT_HAS_STACKTRACE)
   message ("linking boost: ${Boost_LIBRARIES}")
   target_link_libraries(ekat PUBLIC ${Boost_LIBRARIES})
 endif()
+
 
 
 target_include_directories(ekat PUBLIC

--- a/valgrind_support/CMakeLists.txt
+++ b/valgrind_support/CMakeLists.txt
@@ -2,8 +2,11 @@ include(EkatCreateUnitTest)
 
 if (NOT EKAT_VALGRIND_SUPPRESSION_FILE)
   add_executable(serial_hw serial_hw.cxx)
-  add_executable(mpi_hw mpi_hw.cxx)
 
+  if (EKAT_ENABLE_MPI)
+    add_executable(mpi_hw mpi_hw.cxx)
+    target_link_libraries (mpi_hw PUBLIC MPI::MPI_C)
+  endif()
   EkatCreateUnitTestExec(mpi_valg_catch_test mpi_catch_test.cpp)
 
   # We know this var was not set so it's safe to FORCE set it.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In theory, one should be able to specify serial compilers for `CMAKE_<LANG>_COMPILER`, and simply "link" against the needed MPI targets (for Ekat, that's just `MPI::MPI_C`). However, that was not the case, as there were a few places where we were implicitly assuming the user provided mpi compiler wrappers as `CMAKE_<LANG>_COMPILER`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->