### PR TITLE
Add native support for WILL_FAIL in EkatCreateUnitTest

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -27,7 +27,7 @@ set(CUT_EXEC_MV_ARGS
 #       downstream test can check their results. With this options, we can have
 #       one individual downstream test for each rank/thread combination,
 #       allowing the user to debug possible errors with a test more quickly.
-set(CUT_TEST_OPTIONS SERIAL THREADS_SERIAL RANKS_SERIAL PRINT_OMP_AFFINITY)
+set(CUT_TEST_OPTIONS SERIAL THREADS_SERIAL RANKS_SERIAL PRINT_OMP_AFFINITY WILL_FAIL)
 set(CUT_TEST_MV_ARGS DEP EXE_ARGS MPI_RANKS THREADS LABELS PROPERTIES
     FIXTURES_SETUP FIXTURES_REQUIRED FIXTURES_CLEANUP
     FIXTURES_SETUP_INDIVIDUAL FIXTURES_REQUIRED_INDIVIDUAL FIXTURES_CLEANUP_INDIVIDUAL)
@@ -380,6 +380,10 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
         foreach(item IN LISTS ecutfe_FIXTURES_CLEANUP_INDIVIDUAL)
           set_property(TEST ${FULL_TEST_NAME} APPEND PROPERTY FIXTURES_CLEANUP "${item}${rank_thread_suffix}")
         endforeach()
+      endif()
+
+      if (eutfe_WILL_FAIL)
+        set_tests_properties(TEST ${FULL_TEST_NAME} PROPERTY WILL FAIL TRUE)
       endif()
 
       if (ecutfe_PROPERTIES)

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -382,8 +382,8 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
         endforeach()
       endif()
 
-      if (eutfe_WILL_FAIL)
-        set_tests_properties(TEST ${FULL_TEST_NAME} PROPERTY WILL FAIL TRUE)
+      if (ecutfe_WILL_FAIL)
+        set_property(TEST ${FULL_TEST_NAME} PROPERTY WILL_FAIL TRUE)
       endif()
 
       if (ecutfe_PROPERTIES)

--- a/tests/algorithm/CMakeLists.txt
+++ b/tests/algorithm/CMakeLists.txt
@@ -58,6 +58,6 @@ endif()
 
 EkatCreateUnitTestFromExec(tridiag_invalid_flags ${invalid_flags_exec}
   EXE_ARGS "--non-existent-flag"
-  PROPERTIES WILL_FAIL TRUE
   LABELS "MustFail"
+  WILL_FAIL
 )

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -45,14 +45,14 @@ EkatCreateUnitTest(math_util math_util_tests.cpp
 # of input is not parsed as test filter, by fwding a file
 EkatCreateUnitTest(regress_fail regress_fail.cpp
   LIBS ekat EXE_ARGS " < CTestTestfile.cmake"
-  PROPERTIES WILL_FAIL true
+  WILL_FAIL
   LABELS "MustFail"
 )
 
 # Test that Catch returns a failure if invalid flags are passed
 EkatCreateUnitTestFromExec(catch_main_invalid_flags regress_fail
   EXE_ARGS " --non-existent-flag"
-  PROPERTIES WILL_FAIL true
+  WILL_FAIL
   LABELS "MustFail"
 )
 
@@ -60,7 +60,7 @@ EkatCreateUnitTestFromExec(catch_main_invalid_flags regress_fail
 EkatCreateUnitTestExec (fpe_check "fpe_check.cpp")
 if (EKAT_ENABLE_FPE_DEFAULT_MASK)
   EkatCreateUnitTestFromExec (fpe_check fpe_check
-    PROPERTIES WILL_FAIL TRUE
+    WILL_FAIL
     LABELS "MustFail")
 else()
   EkatCreateUnitTestFromExec (fpe_check fpe_check)

--- a/tests/utils/regress_fail.cpp
+++ b/tests/utils/regress_fail.cpp
@@ -1,7 +1,5 @@
 #include <catch2/catch.hpp>
 
-#include "ekat/ekat_assert.hpp"
-
 namespace {
 
 TEST_CASE ("doomed") {


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
RIght now, when using `EkatCreateUnitTestFromExec/EkatCreateUnitTest`, in order to tell cmake that the test is expected to fail, we must pass the rather lengthy string `PROPERTIES WILL_FAIL TRUE`. That's b/c all options/properties that do not have an explicit name in the ECUT utilities must be captured via the "catch-all" PROPERTIES key.

This PR makes our cmake utility functions syntax a bit more lightweight, so users can simply pass `WILL_FAIL`. That is,

```
# Old syntax
EkatCreateUnitTest (my_test my_test.cpp
  LIBS my_libs
  LABELS A B C
  PROPERTIES WILL_FAIL TRUE
)

# New syntax
EkatCreateUnitTest (my_test my_test.cpp
  LIBS my_libs
  LABELS A B C
  WILL_FAIL
)
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Switched current ekat tests that have WILL_FAIL set, to use new syntax
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
