### PR TITLE
Fix GetMpiDistributionName

### DIFF
--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -1,20 +1,19 @@
 # Detect the library that provides MPI
 set (EKAT_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 macro (GetMpiDistributionName DISTRO_NAME)
-  if (CMAKE_CXX_COMPILER AND MPI_CXX_FOUND)
+  if (CMAKE_CXX_COMPILER)
+    find_package (MPI REQUIRED COMPONENTS CXX)
     set (LINK_LIB MPI::MPI_CXX)
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.cxx)
-  elseif (CMAKE_C_COMPILER AND MPI_C_FOUND)
+  elseif (CMAKE_C_COMPILER)
+    find_package (MPI REQUIRED COMPONENTS C)
     set (LINK_LIB MPI::MPI_C)
     set (SOURCE_FILE ${EKAT_CMAKE_DIR}/TryCompileMPI.c)
   else ()
     string (CONCAT MSG
       "**************************************************************\n"
       "  CMake logic to determine the distribution name\n"
-      "  requires a valid C or CXX mpi compiler, with the corresponding\n"
-      "  MPI_<LANG>_FOUND=TRUE set (via previous call to find_package).\n"
-      "  Please call find_package(MPI [REQUIRED] COMPONENTS [C|CXX])\n"
-      "  *before* calling GetMpiDistributionName (in the same scope).\n"
+      "  requires a valid C or CXX mpi compiler.\n"
       "**************************************************************\n")
     message ("${MSG}")
     message (FATAL_ERROR "Aborting")


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The error message in the function was already hinting at the issue, which was going to bite us at some point: one had to call `find_pacakge(MPI ...)` _within a scope visible from the scope where `GetMpiDistributionName` was called_. That's because the function checked which CMake var `MPI_<LANG>_FOUND` is `TRUE` to establish which source file to use with `try_compile`, but this vars, set by `find_package` are not cached, so they disappear as soon as we exit the scope where `find_package` was called.
In EAMxx, we let Ekat find the MPI package, so when control comes back to eamxx, we are out of scope, and those vars above are undefined when we call `DisableMpiCxxBindings` (which calls `GetMpiDistributionName`. Sure, we could add a call to `find_package(MPI)` in EAMxx's main `CMakeLists.txt` file, right before `DisableMpiCxxBindings`, but that seems to make things more complicated.

The solution is simple: we don't need to check if `MPI_<LANG_FOUND` is true. Instead, we simply call `find_package(MPI REQUIRED COMPONENTS <LANG>)` once we detect that `CMAKE_<LANG>_COMPILER` is set. Recall that `find_package` caches all the important stuff (libs, lib dirs, targets, include dirs,...), so subsequent calls are no ops anyways. So if MPI was already found, it doesn't cost anything to call this again.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Required by EAMxx
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Manually verified that EAMxx builds with this mod (well, it goes past the error, other things need to be adjusted in EAMxx to use current EKAT's master).
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
