### PR TITLE
Change default constructor of Pack to init to 0

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -176,7 +176,7 @@ struct Pack {
   KOKKOS_FORCEINLINE_FUNCTION
   Pack () {
     vector_simd for (int i = 0; i < n; ++i) {
-      d[i] = ScalarTraits<scalar>::invalid();
+      d[i] = scalar(0);
     }
   }
 

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -175,15 +175,13 @@ struct Pack {
 
   KOKKOS_FORCEINLINE_FUNCTION
   Pack () {
-    vector_simd for (int i = 0; i < n; ++i) {
-      d[i] = scalar(0);
-    }
+    *this = scalar(0);
   }
 
   // Init all slots to scalar v.
   KOKKOS_FORCEINLINE_FUNCTION
   Pack (const scalar& v) {
-    vector_simd for (int i = 0; i < n; ++i) d[i] = v;
+    *this = v;
   }
 
   // Init this Pack from another one.
@@ -205,14 +203,11 @@ struct Pack {
     vector_simd for (int i = 0; i < n; ++i) d[i] = src.d[i];
   }
 
-  // Init this Pack from a scalar, but only where Mask is true; otherwise
-  // init to default value.
+  // Init this Pack from a scalar, but only where Mask is true
   template <typename T>
   KOKKOS_FORCEINLINE_FUNCTION
   explicit Pack (const Mask<n>& m, const T p) {
-    vector_simd for (int i = 0; i < n; ++i) {
-      d[i] = m[i] ? p : ScalarTraits<scalar>::invalid();
-    }
+    set (m,p);
   }
 
   // Init this Pack from two scalars, according to a given mask:
@@ -220,10 +215,7 @@ struct Pack {
   template <typename T, typename S>
   KOKKOS_FORCEINLINE_FUNCTION
   explicit Pack (const Mask<n>& m, const T v_true, const S v_false) {
-    vector_simd
-    for (int i = 0; i < n; ++i) {
-      d[i] = m[i] ? v_true : v_false;
-    }
+    set (m,v_true,v_false);
   }
 
   // Init this Pack from a scalar, but only where Mask is true; otherwise
@@ -231,9 +223,7 @@ struct Pack {
   template <typename T>
   KOKKOS_FORCEINLINE_FUNCTION
   explicit Pack (const Mask<n>& m, const Pack<T,n>& p) {
-    vector_simd for (int i = 0; i < n; ++i) {
-      d[i] = m[i] ? p[i] : ScalarTraits<scalar>::invalid();
-    }
+    set (m,p);
   }
 
   // Init this Pack from two other packs, according to a given mask:
@@ -241,10 +231,7 @@ struct Pack {
   template <typename T, typename S>
   KOKKOS_FORCEINLINE_FUNCTION
   explicit Pack (const Mask<n>& m, const Pack<T,n>& p_true, const Pack<S,n>& p_false) {
-    vector_simd
-    for (int i = 0; i < n; ++i) {
-      d[i] = m[i] ? p_true[i] : p_false[i];
-    }
+    set (m,p_true,p_false);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION const scalar& operator[] (const int& i) const { return d[i]; }

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -174,40 +174,44 @@ struct Pack {
   typedef typename std::remove_const<ScalarType>::type scalar;
 
   KOKKOS_FORCEINLINE_FUNCTION
-  Pack () {
-    *this = scalar(0);
+  constexpr Pack ()
+   : Pack (scalar(0))
+  {
+    // Nothing to do here
   }
 
   // Init all slots to scalar v.
   KOKKOS_FORCEINLINE_FUNCTION
-  Pack (const scalar& v) {
+  constexpr Pack (const scalar& v) {
     *this = v;
   }
 
   // Init this Pack from another one.
   template <typename T>
   KOKKOS_FORCEINLINE_FUNCTION explicit
-  Pack (const Pack<T,n>& v) {
+  constexpr Pack (const Pack<T,n>& v) {
     vector_simd for (int i = 0; i < n; ++i) d[i] = v[i];
   }
 
   // Init this Pack from another one.
   KOKKOS_FORCEINLINE_FUNCTION
-  Pack (const Pack& src) {
+  constexpr Pack (const Pack& src) {
     vector_simd for (int i = 0; i < n; ++i) d[i] = src[i];
   }
 
   // Init this Pack from another one.
   KOKKOS_FORCEINLINE_FUNCTION
-  Pack (const volatile Pack& src) {
+  constexpr Pack (const volatile Pack& src) {
     vector_simd for (int i = 0; i < n; ++i) d[i] = src.d[i];
   }
 
   // Init this Pack from a scalar, but only where Mask is true
   template <typename T>
   KOKKOS_FORCEINLINE_FUNCTION
-  explicit Pack (const Mask<n>& m, const T p) {
-    set (m,p);
+  explicit Pack (const Mask<n>& m, const T p)
+   : Pack (m,p,T(0))
+  {
+    // Nothing to do here
   }
 
   // Init this Pack from two scalars, according to a given mask:
@@ -223,7 +227,7 @@ struct Pack {
   template <typename T>
   KOKKOS_FORCEINLINE_FUNCTION
   explicit Pack (const Mask<n>& m, const Pack<T,n>& p) {
-    set (m,p);
+    set (m,p,Pack());
   }
 
   // Init this Pack from two other packs, according to a given mask:

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -588,9 +588,9 @@ TEST_CASE("lin_interp_monotone", "lin_interp") {
 
   // Generic lambda, to get min-max of a scalarized subview
   // Must use with rank-1 scalar views only
-  auto minmax = [](const auto& v) -> std::pair<Real,Real> {
+  auto minmax = [](const auto& v, const int sz) -> std::pair<Real,Real> {
     std::pair<Real,Real> minmax {v[0],v[0]};
-    for (int i=1; i<v.extent_int(0); ++i) {
+    for (int i=1; i<sz; ++i) {
       minmax.first = std::min(minmax.first,v[i]);
       minmax.second = std::max(minmax.second,v[i]);
     }
@@ -623,7 +623,7 @@ TEST_CASE("lin_interp_monotone", "lin_interp") {
       populate_array (km1,get_col(y1_h,i).data(),generator,y_dist,false);
 
       // Generate x2 in a way that guarantees its range is contained in that of x1
-      auto mm1 = minmax(get_col(x1_h,i));
+      auto mm1 = minmax(get_col(x1_h,i),km1);
       auto delta = mm1.second-mm1.first;
       real_pdf x2_dist(mm1.first+delta/1000,mm1.second-delta/1000);
       populate_array (km2,get_col(x2_h,i).data(),generator,x2_dist,true);
@@ -653,8 +653,8 @@ TEST_CASE("lin_interp_monotone", "lin_interp") {
     auto y2_h_s = ekat::scalarize(y2_h);
     auto y1_h_s = ekat::scalarize(y1_h);
     for (int i = 0; i < ncol; ++i) {
-      auto mm1 = minmax(ekat::subview(y1_h_s,i));
-      auto mm2 = minmax(ekat::subview(y2_h_s,i));
+      auto mm1 = minmax(ekat::subview(y1_h_s,i),km1);
+      auto mm2 = minmax(ekat::subview(y2_h_s,i),km2);
       REQUIRE ( (mm2.first>=mm1.first && mm2.second<=mm1.second) );
     }
   }

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -479,8 +479,8 @@ TEST_CASE("isnan", "ekat::pack") {
   mvt mzero("",1), mnan("",1);
   Kokkos::parallel_for(Kokkos::RangePolicy<>(0,1),
                        KOKKOS_LAMBDA(int) {
-    zero(0) = pt(0);  // Ctor inits pack to 0
-    nan(0)  = pt();   // Ctor inits pack to nan
+    zero(0) = pt();  // Ctor inits pack to 0
+    nan(0)  = ScalarTraits<Real>::invalid();
 
     const pt& z = zero(0);
     const pt& n = nan(0);

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -176,7 +176,7 @@ struct TestPack {
       REQUIRE(p2[i] == p_ref[i]);
     }
 
-    // Masked ctor to create a pack with [3 invalid 3 invalid ...]
+    // Masked ctor to create a pack with [3 0 3 0 ...]
     // We can do this with scalars or packs
     Pack p3(m,3);
     Pack p4(m,three);
@@ -187,8 +187,9 @@ struct TestPack {
         REQUIRE(p3[i] == p_ref[i]);
         REQUIRE(p4[i] == p_ref[i]);
       } else {
-        REQUIRE(ekat::is_invalid(p3[i]));
-        REQUIRE(ekat::is_invalid(p4[i]));
+        // Non-masked values should keep the default ctor value (which is 0)
+        REQUIRE(p3[i]==0);
+        REQUIRE(p4[i]==0);
       }
     }
   }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
While leaving entries to be invalid seems like a nice idea (allows to track uninited values better), it plays badly with Kokkos parallel_scan, where the accumulation variable is initialized as `ValueType accum = ValueType();`, which _assumes_ that the value initialization inits to 0 (or, to be precise, to the identity value for the sum operation). It would be nice if Kokkos did
```
  ValueType accum = reduction_identity<ValueType>::sum();
```
but this may break existing code (e.g., code that uses some `ValueType` for which there is no specialization of `reduction_identity`). I still think they _could_ use some SFINAE magic to use `reduction_identity` if the right specialization exists, and resort to `ValueType()` otherwise. Alas, I am not a kokkos dev.

So the solution is to make our default constructor init to 0.

I threw in also the change of a few ctor, to call the corresponding `set` method, to avoid duplication of code.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
The PR in E3SM that updates to Kokkos 4.2 has exposed this issue. In the version of Kokkos in current master, the accum var is inited as `value_type accum = 0`, which works correctly. But updating to Kokkos 4.2 will require this change.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I tested EAMxx with the Kokkos 4.2 branch on chrysalis. Without this change, I get NaN's from scan operation, while with this change I get correct numbers.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
