### PR TITLE
Fix GetMpiDistributionName for Cray mpi compilers

### DIFF
--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -32,7 +32,13 @@ macro (GetMpiDistributionName DISTRO_NAME)
     else()
       set (COMPILER ${MPI_Fortran_COMPILER})
     endif()
-    execute_process (COMMAND ${COMPILER} -show OUTPUT_VARIABLE TEMP)
+
+    if (DEFINED ENV{CRAYPE_VERSION})
+      # Cray wrappers have different options from mpicxx
+      execute_process (COMMAND ${COMPILER} --cray-print-opts=cflags OUTPUT_VARIABLE TEMP)
+    else()
+      execute_process (COMMAND ${COMPILER} -show OUTPUT_VARIABLE TEMP)
+    endif()
 
     # Remove spaces/commas, and parse each entry. If it starts with -I, it may be
     # an include path with mpi.h


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Cray mpi compilers wrappers do not support the `-show` option, like `mpicxx` does. So in order to get the compiler line that shows the include paths for MPI headers, we need to use a Cray-specific option. Simply pick the option to use based on whether `CRAYPE_VERSION` is defined in the env.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in order to use current EKAT on Perlmutter.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I verified with EAMxx that with this branch CMake runs successfully on pm-cpu.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
