### PR TITLE
A couple of fixes in create unit test routines

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -347,11 +347,11 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
       endif()
 
       if (ecutfe_FIXTURES_SETUP)
-        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_SETUP ${ecutfe_FIXTURES_SETUP})
+        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_SETUP "${ecutfe_FIXTURES_SETUP}")
       endif()
 
       if (ecutfe_FIXTURES_REQUIRED)
-        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_REQUIRED ${ecutfe_FIXTURES_REQUIRED})
+        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_REQUIRED "${ecutfe_FIXTURES_REQUIRED}")
       endif()
 
       if (ecutfe_FIXTURES_CLEANUP)
@@ -361,7 +361,7 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
           message (FATAL_ERROR
             "Error! FIXTURE_CLEANUP property set for test with multiple rank/thread combinations")
         endif()
-        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_CLEANUP ${ecutfe_FIXTURES_CLEANUP})
+        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_CLEANUP "${ecutfe_FIXTURES_CLEANUP}")
       endif()
 
       if (ecutfe_FIXTURES_SETUP_INDIVIDUAL)

--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -27,7 +27,8 @@ set(CUT_EXEC_MV_ARGS
 #       downstream test can check their results. With this options, we can have
 #       one individual downstream test for each rank/thread combination,
 #       allowing the user to debug possible errors with a test more quickly.
-set(CUT_TEST_OPTIONS SERIAL THREADS_SERIAL RANKS_SERIAL PRINT_OMP_AFFINITY WILL_FAIL)
+set(CUT_TEST_OPTIONS SERIAL THREADS_SERIAL RANKS_SERIAL PRINT_OMP_AFFINITY)
+set(CUT_TEST_1V_ARGS WILL_FAIL)
 set(CUT_TEST_MV_ARGS DEP EXE_ARGS MPI_RANKS THREADS LABELS PROPERTIES
     FIXTURES_SETUP FIXTURES_REQUIRED FIXTURES_CLEANUP
     FIXTURES_SETUP_INDIVIDUAL FIXTURES_REQUIRED_INDIVIDUAL FIXTURES_CLEANUP_INDIVIDUAL)

--- a/tests/algorithm/CMakeLists.txt
+++ b/tests/algorithm/CMakeLists.txt
@@ -59,5 +59,5 @@ endif()
 EkatCreateUnitTestFromExec(tridiag_invalid_flags ${invalid_flags_exec}
   EXE_ARGS "--non-existent-flag"
   LABELS "MustFail"
-  WILL_FAIL
+  WILL_FAIL TRUE
 )

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -45,14 +45,14 @@ EkatCreateUnitTest(math_util math_util_tests.cpp
 # of input is not parsed as test filter, by fwding a file
 EkatCreateUnitTest(regress_fail regress_fail.cpp
   LIBS ekat EXE_ARGS " < CTestTestfile.cmake"
-  WILL_FAIL
+  WILL_FAIL TRUE
   LABELS "MustFail"
 )
 
 # Test that Catch returns a failure if invalid flags are passed
 EkatCreateUnitTestFromExec(catch_main_invalid_flags regress_fail
   EXE_ARGS " --non-existent-flag"
-  WILL_FAIL
+  WILL_FAIL TRUE
   LABELS "MustFail"
 )
 
@@ -60,7 +60,7 @@ EkatCreateUnitTestFromExec(catch_main_invalid_flags regress_fail
 EkatCreateUnitTestExec (fpe_check "fpe_check.cpp")
 if (EKAT_ENABLE_FPE_DEFAULT_MASK)
   EkatCreateUnitTestFromExec (fpe_check fpe_check
-    WILL_FAIL
+    WILL_FAIL TRUE
     LABELS "MustFail")
 else()
   EkatCreateUnitTestFromExec (fpe_check fpe_check)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
- The FIXTURE arguments were not escaped with quotes, so lists were not expanded correctly.
- Turn `WILL_FAIL` from an "option" to a "1-value" arg for create unit test. This makes it easier to declare a test where will fail is true/false depending on other params
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Both fixes make life easier in EAMxx
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Tested in EAMxx
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
