### PR TITLE
Add missing quotes around FIXTURES options in create unit test utilities

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -347,11 +347,11 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
       endif()
 
       if (ecutfe_FIXTURES_SETUP)
-        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_SETUP ${ecutfe_FIXTURES_SETUP})
+        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_SETUP "${ecutfe_FIXTURES_SETUP}")
       endif()
 
       if (ecutfe_FIXTURES_REQUIRED)
-        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_REQUIRED ${ecutfe_FIXTURES_REQUIRED})
+        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_REQUIRED "${ecutfe_FIXTURES_REQUIRED}")
       endif()
 
       if (ecutfe_FIXTURES_CLEANUP)
@@ -361,7 +361,7 @@ function(EkatCreateUnitTestFromExec test_name test_exec)
           message (FATAL_ERROR
             "Error! FIXTURE_CLEANUP property set for test with multiple rank/thread combinations")
         endif()
-        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_CLEANUP ${ecutfe_FIXTURES_CLEANUP})
+        set_tests_properties(${FULL_TEST_NAME} PROPERTIES FIXTURES_CLEANUP "${ecutfe_FIXTURES_CLEANUP}")
       endif()
 
       if (ecutfe_FIXTURES_SETUP_INDIVIDUAL)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Without quotes, there is no way to pass 2+ fixtures to the routines.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually tested it in EAMxx.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
