### PR TITLE
Better handle the detection of MPI compiler supported flags

### DIFF
--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -33,8 +33,8 @@ macro (GetMpiDistributionName DISTRO_NAME)
       set (COMPILER ${MPI_Fortran_COMPILER})
     endif()
 
-    execute_process (COMMAND ${COMPILER} -show RESULT_VARIABLE SUPPORTS_SHOW)
-    execute_process (COMMAND ${COMPILER} --cray-print-opts=cflags RESULT_VARIABLE SUPPORTS_CRAY_PRINT_OPTS)
+    execute_process (COMMAND ${COMPILER} -show RESULT_VARIABLE SUPPORTS_SHOW OUTPUT_QUIET ERROR_QUIET)
+    execute_process (COMMAND ${COMPILER} --cray-print-opts=cflags RESULT_VARIABLE SUPPORTS_CRAY_PRINT_OPTS OUTPUT_QUIET ERROR_QUIET)
     if (SUPPORTS_SHOW EQUAL 0)
       # (mpicxx/mpicc/mpifort)-like MPI compiler
       execute_process (COMMAND ${COMPILER} -show OUTPUT_VARIABLE TEMP)


### PR DESCRIPTION


<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
If the env var `CRAYPE_VERSION` was defined, we were _assuming_ we were using cray compilers (like CC/cc/ftn) to detect the distribution name. However, that's not necessarily true. Instead, we should check whether the MPI compiler command supports `-show` (like mpicxx/mpicc/mpifort) or `--cray-print-opts` (like CC/cc/ftn). This approach should be more robust.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed by SCREAM
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Tested on frontier and pm-cpu (the former uses mpicxx, the latter CC).
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
