### PR TITLE
Allow to call scalarize on non-packed views

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -304,6 +304,13 @@ using OnlyPack = typename std::enable_if<PackType::packtag,PackType>::type;
 template <typename PackType, typename ReturnType>
 using OnlyPackReturn = typename std::enable_if<PackType::packtag,ReturnType>::type;
 
+// A more general SFINAE utility, which can be used to select pack or non-pack
+template<typename T>
+struct IsPack : std::false_type {};
+template<typename T, int N>
+struct IsPack<Pack<T,N>> : std::true_type {};
+
+
 // Later, we might support type promotion. For now, caller must explicitly
 // promote a pack's scalar type in mixed-type arithmetic.
 

--- a/src/ekat/ekat_pack_kokkos.hpp
+++ b/src/ekat/ekat_pack_kokkos.hpp
@@ -241,9 +241,14 @@ typename std::enable_if<NewPackT::packtag && OldPackT::packtag &&
 repack_impl (const Kokkos::View<OldPackT**, ViewProps...>& vp) {
   constexpr auto new_pack_size = NewPackT::n;
   constexpr auto old_pack_size = OldPackT::n;
-  static_assert(new_pack_size > 0 &&
-                old_pack_size % new_pack_size == 0,
-                "New pack size must divide old pack size.");
+  static_assert(new_pack_size > 0, "New pack size must be positive");
+
+  // It's overly restrictive to check compatibility between pack sizes.
+  // What really matters is that the new pack size divides the last extent
+  // of the "scalarized" view.
+  // This MUST be a runtime check.
+  assert ( (vp.extent_int(1)*old_pack_size) % new_pack_size == 0);
+
   return Unmanaged<Kokkos::View<NewPackT**, ViewProps...> >(
     reinterpret_cast<NewPackT*>(vp.data()),
     vp.extent_int(0),
@@ -261,13 +266,17 @@ typename std::enable_if<NewPackT::packtag && OldPackT::packtag &&
 repack_impl (const Kokkos::View<OldPackT**, ViewProps...>& vp) {
   constexpr auto new_pack_size = NewPackT::n;
   constexpr auto old_pack_size = OldPackT::n;
-  static_assert(old_pack_size > 0 &&
-                new_pack_size % old_pack_size == 0,
-                "Old pack size must divide new pack size.");
+  static_assert(new_pack_size > 0, "New pack size must be positive");
+  // It's not enough to check that the new pack is a multiple of the old pack.
+  // We actually need to check that the new pack size divides the last extent
+  // of the "scalarized" view.
+  // This MUST be a runtime check.
+  assert ( (vp.extent_int(1)*old_pack_size) % new_pack_size == 0);
+
   return Unmanaged<Kokkos::View<NewPackT**, ViewProps...> >(
     reinterpret_cast<NewPackT*>(vp.data()),
     vp.extent_int(0),
-    (new_pack_size / old_pack_size) * vp.extent_int(1));
+    vp.extent_int(1) / (new_pack_size / old_pack_size) );
 }
 
 // 2d staying the same
@@ -301,9 +310,14 @@ typename std::enable_if<NewPackT::packtag && OldPackT::packtag &&
 repack_impl (const Kokkos::View<OldPackT*, ViewProps...>& vp) {
   constexpr auto new_pack_size = NewPackT::n;
   constexpr auto old_pack_size = OldPackT::n;
-  static_assert(new_pack_size > 0 &&
-                old_pack_size % new_pack_size == 0,
-                "New pack size must divide old pack size.");
+  static_assert(new_pack_size > 0, "New pack size must be positive");
+
+  // It's overly restrictive to check compatibility between pack sizes.
+  // What really matters is that the new pack size divides the last extent
+  // of the "scalarized" view.
+  // This MUST be a runtime check.
+  assert ( (vp.extent_int(0)*old_pack_size) % new_pack_size == 0);
+
   return Unmanaged<Kokkos::View<NewPackT*, ViewProps...> >(
     reinterpret_cast<NewPackT*>(vp.data()),
     (old_pack_size / new_pack_size) * vp.extent_int(0));
@@ -320,9 +334,14 @@ typename std::enable_if<NewPackT::packtag && OldPackT::packtag &&
 repack_impl (const Kokkos::View<OldPackT*, ViewProps...>& vp) {
   constexpr auto new_pack_size = NewPackT::n;
   constexpr auto old_pack_size = OldPackT::n;
-  static_assert(new_pack_size > 0 &&
-                new_pack_size % old_pack_size == 0,
-                "Old pack size must divide new pack size.");
+  static_assert(new_pack_size > 0, "New pack size must be positive");
+
+  // It's not enough to check that the new pack is a multiple of the old pack.
+  // We actually need to check that the new pack size divides the last extent
+  // of the "scalarized" view.
+  // This MUST be a runtime check.
+  assert ( (vp.extent_int(0)*old_pack_size) % new_pack_size == 0);
+
   EKAT_KERNEL_ASSERT(vp.extent_int(0) % (new_pack_size / old_pack_size) == 0);
   return Unmanaged<Kokkos::View<NewPackT*, ViewProps...> >(
     reinterpret_cast<NewPackT*>(vp.data()),

--- a/tests/algorithm/lin_interp_test.cpp
+++ b/tests/algorithm/lin_interp_test.cpp
@@ -64,7 +64,7 @@ template<typename ViewT>
 auto get_col (const ViewT& packed_view, int i) ->
   decltype(ekat::scalarize(ekat::subview(packed_view,i))) {
     return ekat::scalarize(ekat::subview(packed_view,i));
-};
+}
 
 #ifdef EKAT_ENABLE_FORTRAN
 TEST_CASE("lin_interp_soak", "lin_interp") {


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Since
 - if we have a piece of code that needs non-packed views, calling `scalarize` is the easy solution;
 - we write generic code templated on scalar types, which should be usable with either pack types or scalar types
it is desirable for `scalarize` to work also on views that are already scalarized (meaning that `value_type` is not a pack). Ideally, `scalarize` should be an "idempotency", meaning that `scalarize(scalarize(v))=scalarize(v)`. This is, of course, assuming that `v` is a view of packs of a scalar type, and not a "double packed" view like`View<Pack<Pack<T,N>,M>*>` (in that case, applying `scalarize` once should return `View<Pack<T,N>*>` and a second application of `scalarize` should return `View<T*>`).

This PR extends the scalarize utilities to support this.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
I think there are some areas in EKAT and EAMxx that could benefit from being able to call `scalarize(v)` in some generic code areas.
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added tests that verify that `scalarize(scalarize(v))==scalarize(v)`.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
