### PR TITLE
Revert one change in LinInterp

### DIFF
--- a/src/ekat/util/ekat_lin_interp_impl.hpp
+++ b/src/ekat/util/ekat_lin_interp_impl.hpp
@@ -104,9 +104,10 @@ void LinInterp<ScalarT, PackSize, DeviceT>::lin_interp_impl(
 
   const int i = col == -1 ? team.league_rank() : col;
 
-  Pack x1_k1, x1_k1ph, y1_k1, y1_k1ph;
-  IPackT k1ph;
   Kokkos::parallel_for(range_boundary, [&] (Int k2) {
+    Pack x1_k1, x1_k1ph, y1_k1, y1_k1ph;
+    IPackT k1ph;
+
     // Basic formula is y2(k2) = y1(k1) + m * (x2(k2)-x1(k1))
     // where m = (y1(k1+1)-y2(k1))/(x1(k1+1)-x1(k1)) is the slope of the line
     // going through (x1(k1),y1(k1)) and (x1(k1+1),y1(k1+1)).


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Automatic variables created outside a nested pfor cannot be written onto from inside the pfor. See [this](https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/HierarchicalParallelism.html#team-loops) kokkos wiki paragraph on this. Thanks @tcclevenger for catching this!

That said, with 1 thread on CPU, I _did_ notice the code being faster creating the temps before the loop, and recycling them inside. It would be nice to maybe use scratch memory for this stuff, but Pack's cannot be created from pre-allocated memory (as of now).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
