### PR TITLE
Add update method for packs

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -292,6 +292,58 @@ struct Pack {
     return *this;
   }
 
+  // In the update methods, return *this, so we can pipe updates.
+  // By default, the update uses alpha=1 and beta=0, which means it's the equivalent of op= and set methods
+  template<typename T, typename CoeffT = scalar>
+  KOKKOS_FORCEINLINE_FUNCTION
+  Pack& update (const Pack<T,n>& x, const CoeffT alpha = 1, const CoeffT beta = 0) {
+    vector_simd
+    for (int i=0; i<n; ++i) {
+      d[i] = beta*d[i] + alpha*x[i];
+    }
+    return *this;
+  }
+
+  template<typename T, typename CoeffT = scalar>
+  KOKKOS_FORCEINLINE_FUNCTION
+  Pack& update (const Mask<n>& m, const Pack<T,n>& x, const CoeffT alpha = 1, const CoeffT beta = 0) {
+    ekat_masked_loop(m,i)
+      d[i] = beta*d[i] + alpha*x[i];
+    return *this;
+  }
+
+  template<typename T, typename S, typename CoeffT = scalar>
+  KOKKOS_FORCEINLINE_FUNCTION
+  Pack& update (const Mask<n>& m, const Pack<T,n>& x_true, const Pack<S,n>& x_false, const CoeffT alpha = 1, const CoeffT beta = 0) {
+    vector_simd
+    for (int i=0; i<n; ++i) {
+      if (m[i])
+        d[i] = beta*d[i] + alpha*x_true[i];
+      else
+        d[i] = beta*d[i] + alpha*x_false[i];
+    }
+    return *this;
+  }
+
+  // Shortcuts that call the corresponding update version with beta=1
+  template<typename T, typename CoeffT = scalar>
+  KOKKOS_FORCEINLINE_FUNCTION
+  Pack& add (const Pack<T,n>& x, const CoeffT alpha = 1) {
+    return update(x,alpha,CoeffT(1));
+  }
+
+  template<typename T, typename CoeffT = scalar>
+  KOKKOS_FORCEINLINE_FUNCTION
+  Pack& add (const Mask<n>& m, const Pack<T,n>& x, const CoeffT alpha = 1) {
+    return update(m,x,alpha,CoeffT(1));
+  }
+
+  template<typename T, typename S, typename CoeffT = scalar>
+  KOKKOS_FORCEINLINE_FUNCTION
+  Pack& add (const Mask<n>& m, const Pack<T,n>& x_true, const Pack<S,n>& x_false, const CoeffT alpha = 1) {
+    return update(m,x_true,x_false,alpha,CoeffT(1));
+  }
+
 private:
   scalar d[n];
 };

--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -292,8 +292,13 @@ struct Pack {
     return *this;
   }
 
-  // In the update methods, return *this, so we can pipe updates.
-  // By default, the update uses alpha=1 and beta=0, which means it's the equivalent of op= and set methods
+  // Update the current pack y as y = beta*y + alpha*x. The second and third overload behave like the
+  // set method, in that they allow to select the entries where the update happens.
+  // NOTES:
+  //  - by default, the update uses alpha=1 and beta=0, which means it's the equivalent of operator=
+  //    (or set, for the overloads with a mask).
+  //  - we return *this, so we can pipe calls: y.update(x,2,1)[2] performs the update and then
+  //    extracts the 3rd entry
   template<typename T, typename CoeffT = scalar>
   KOKKOS_FORCEINLINE_FUNCTION
   Pack& update (const Pack<T,n>& x, const CoeffT alpha = 1, const CoeffT beta = 0) {

--- a/tests/pack/pack_tests.cpp
+++ b/tests/pack/pack_tests.cpp
@@ -1,7 +1,7 @@
 #include "catch2/catch.hpp"
 
 #include "ekat/ekat_pack.hpp"
-#include "ekat/util//ekat_math_utils.hpp"
+#include "ekat/util/ekat_math_utils.hpp"
 #include "ekat/kokkos/ekat_kokkos_types.hpp"
 #include "ekat_test_config.h"
 #include <sstream>
@@ -501,6 +501,42 @@ TEST_CASE("isnan", "ekat::pack") {
     REQUIRE (!mz[i]); // the view 'zero' should not contain nans
     REQUIRE (mn[i]);  // the view 'nan'  should contain nans
   }
+}
+
+TEST_CASE("pack_update") {
+  constexpr int N = EKAT_TEST_PACK_SIZE;
+
+  using pt = ekat::Pack<Real,N>;
+  using mt = ekat::Mask<N>;
+
+  mt even;
+  for (int i=0; i<N; ++i) {
+    even.set(i, i%2==0);
+  }
+  pt y;
+
+  pt zero (0), one(1), two(2);
+
+  y = -two;
+  y.add(two);
+  REQUIRE ((y==zero).all());
+
+  y = one;
+  y.update(two,2,-3);
+  REQUIRE ( (y==one).all() );
+
+  // alpha=0, beta=1 -> nothing changes
+  y = one;
+  y.update(two,0,1);
+  REQUIRE ( (y==one).all() );
+
+  y = zero;
+  y.add(even,one);
+  for (int i=0; i<N; ++i) REQUIRE (y[i]==(i%2==0 ? 1 : 0));
+
+  y = zero;
+  y.add(even,one,-one);
+  for (int i=0; i<N; ++i) REQUIRE (y[i]==(i%2==0 ? 1 : -1));
 }
 
 } // namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This snippet is a good example of why this feature would be helpful:
```c++
    auto& T_k = some_view(k); // T_k is a pack
    T_k = some_func();

    // Update: at_top, at_bot, and at_mid are "complementary" masks
    T_k.set(at_top, T_k - coeff*pack2);
    T_k.set(at_bot, T_k - coeff*pack3);
    T_k.set(at_mid, T_k - coeff*(pack2+pack3));
```
Each call to `set` is creating temporaries on the fly, to store the result of the pack to be used as rhs where the mask is true. Compare this with
```c++
    auto& T_k = some_view(k); // T_k is a pack
    T_k = some_func();

    // Update: at_top, at_bot, and at_mid are "complementary" masks
    T_k.add(not_at_bop, pack2, -coeff);
    T_k.add(not_at_top, pack3, -coeff);
```

This PR adds two sets of methods, `update` and `add`. The former is more general, and allows to do `y = beta*y + alpha*x`, while the latter is a shortcut for `y += alpha*x`. Both methods have 3 overloads: one for when the update is to be performed on the whole pack, and two for a masked update.

Notice that the set method is now a particular case of `y.update(mask,x,1,0)`. However, I'm not going to remove it, b/c a) it's clearer to see `a.set(m,val)` than `a.update(m,val)` or `a.update(m,val,1,0)`, and b) set does not have to do additions/multiplications, so it's pointless to resort to an impl that does them.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added small unit tests.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
