### PR TITLE
Add missing specialization of IsPack meta-utility

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -366,7 +366,8 @@ template<typename T>
 struct IsPack : std::false_type {};
 template<typename T, int N>
 struct IsPack<Pack<T,N>> : std::true_type {};
-
+template<typename T, int N>
+struct IsPack<const Pack<T,N>> : std::true_type {};
 
 // Later, we might support type promotion. For now, caller must explicitly
 // promote a pack's scalar type in mixed-type arithmetic.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Our `repack` util uses `IsPack` to detect if a view has a pack scalar type or not, and uses that info to decide which version of `repack_impl` to call. However, when passing a view of const packs, the lack of a specialization of `IsPack` for `const Pack<T,N>` causes the base case to be selected (which corresponds to the `false` scenario). This PR adds the missing specialization.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Using current master in EAMxx revealed the bug (at build time). With this branch, the code builds fine.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
