### PR TITLE
Disable boost stacktrace by default, only look for it if user asks for it

### DIFF
--- a/cmake/tpls/EkatTPLs.cmake
+++ b/cmake/tpls/EkatTPLs.cmake
@@ -130,20 +130,25 @@ endif()
 #   Boost stacktrace (Optional)   #
 ###################################
 
-# Stacktrace is available with Boost>=1.65
-message (STATUS "Looking for boost::stacktrace ...")
-find_package(Boost 1.65.0
-  COMPONENTS stacktrace_addr2line
-)
+# Always looking for stacktrace can cause problems when cross compiling
+# Hence, avoid finding boost if user didn't ask for it. If they do,
+# then it's fair to expect they have a Boost_ROOT env var defined
+option (EKAT_ENABLE_BOOST_STACKTRACE "Whether to enable Boost stacktrace" OFF)
+if (EKAT_ENABLE_BOOST_STACKTRACE)
+  message (STATUS "Looking for boost::stacktrace ...")
+  # Stacktrace is available with Boost>=1.65
+  find_package(Boost 1.65.0 REQUIRED
+    COMPONENTS stacktrace_addr2line
+  )
 
-if (Boost_STACKTRACE_ADDR2LINE_FOUND)
-  message (STATUS "Looking for boost::stacktrace ... Found")
-  message ("    -> EKAT's assert macros will provide a stacktrace.")
-  set (EKAT_HAS_STACKTRACE TRUE)
+  if (Boost_STACKTRACE_ADDR2LINE_FOUND)
+    message (STATUS "Looking for boost::stacktrace ... Found")
+    message ("    -> EKAT's assert macros will provide a stacktrace.")
+    set (EKAT_HAS_STACKTRACE TRUE)
+  endif()
 else()
-  message (STATUS "Looking for boost::stacktrace ... NOT Found")
+  message (STATUS "EKAT_ENABLE_BOOST_STACKTRACE: OFF")
   message ("    -> EKAT's assert macros will NOT provide a stacktrace.")
 endif()
-
 
 message (STATUS " *** End processing EKAT's TPLs ***")


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When cross compiling, it is not uncommon to have a Boost installation in the system directories of the login node, but not on the compute nodes. In such scenario, with current master, EKAT would pick up the location of Boost at config/build time, but would not have it available at run time on the compute node, causing crashes. I did observe this happening on a machine (I forgot which one it was).

To fix this, we do _not_ look for boost unless the user explicitly asked for it. If they do, the tpl becomes a REQUIRED dependency. Also, we _assume_ that if the user asks for boost, they have the Boost_ROOT env var set to the proper location at config time, so that CMake picks up the right installation (rather than a system one, which may not be present on compute nodes).

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
