### PR TITLE
Disable wsm_omp16 test when valgrind is on

### DIFF
--- a/tests/kokkos/CMakeLists.txt
+++ b/tests/kokkos/CMakeLists.txt
@@ -10,12 +10,20 @@ if (EKAT_TEST_DOUBLE_PRECISION)
   )
 
   # Test workspace manager
-  EkatCreateUnitTest(wsm${DP_POSTFIX} workspace_tests.cpp
-    LIBS ekat
-    PRINT_OMP_AFFINITY
-    COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
-    THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC}
-  )
+  if (EKAT_ENABLE_VALGRIND)
+    # wsm multithead test is extremely slow when valgrind is on
+    EkatCreateUnitTest(wsm${DP_POSTFIX} workspace_tests.cpp
+      LIBS ekat
+      PRINT_OMP_AFFINITY
+      COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
+      THREADS 1 1)
+  else()
+    EkatCreateUnitTest(wsm${DP_POSTFIX} workspace_tests.cpp
+      LIBS ekat
+      PRINT_OMP_AFFINITY
+      COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
+      THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC})
+  endif()
 endif ()
 
 if (EKAT_TEST_SINGLE_PRECISION)


### PR DESCRIPTION
It's way too slow to be practical. I tried some smaller thread counts and they were all quite slow as well, only 1 is 'fast'. The non-valgrind release test of wsm_omp16 is super fast, so this is not hiding some kind of performance issue with WSM.

## Motivation

Should fix timeouts for nightly valgrind testing for eamxx on mappy.

## Testing

Just confirmed that the wsm_omp16 is gone when valgrind is on.
