### PR TITLE
Add `get_subview()` Implementations for Multi-Sliced Subfields

### DIFF
--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -330,6 +330,7 @@ subview(const ViewLR<ST*, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim = 0) {
   assert(v.data() != nullptr);
+  assert(idim == 0);
   assert(kp0.first >= 0 && kp0.first < kp0.second);
   return Unmanaged<ViewLS<ST*,Props...>>(Kokkos::subview(v, kp0));
 }

--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -317,7 +317,10 @@ subview_1(const ViewLR<ST******,Props...>& v,
 // ================ Multi-sliced Subviews ======================= //
 // e.g., instead of a single-entry slice like v(:, 42, :), we slice over a range
 // of values, as in v(:, 27:42, :)
-// this means that the subview has the same rank as the source view
+// Note that this obtains entries for which in dimesion 2 is in the
+// range [27, 42) == {v(i, j, k), where 27 <= j < 42}
+// Note also that this slicing means that the subview has the same rank
+// as the source view
 
 // --- Rank1 multi-slice --- //
 template <typename ST, typename... Props>
@@ -325,15 +328,10 @@ KOKKOS_INLINE_FUNCTION
 Unmanaged<ViewLS<ST*, Props...>>
 subview(const ViewLR<ST*, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
-        const int idim) {
+        const int idim = 0) {
   assert(v.data() != nullptr);
-  assert(idim == 0);
-  // NOTE: the final comparison is originally int <= long unsigned int
-  // the cast silences a warning, but may be unnecessary
-  assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second <= v.extent_int(idim));
+  assert(kp0.first >= 0 && kp0.first < kp0.second);
   return Unmanaged<ViewLS<ST*,Props...>>(Kokkos::subview(v, kp0));
-
 }
 
 // --- Rank2 multi-slice --- //
@@ -345,10 +343,8 @@ subview(const ViewLR<ST**, Props...>& v,
         const int idim) {
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim <= v.rank);
-  // NOTE: the final comparison is originally int <= long unsigned int
-  // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second <= v.extent_int(idim));
+         && kp0.second < v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, kp0, Kokkos::ALL));
   } else {
@@ -366,10 +362,8 @@ subview(const ViewLR<ST***, Props...>& v,
         const int idim) {
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim <= v.rank);
-  // NOTE: the final comparison is originally int <= long unsigned int
-  // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second <= v.extent_int(idim));
+         && kp0.second < v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST***,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL));
@@ -392,10 +386,8 @@ subview(const ViewLR<ST****, Props...>& v,
         const int idim) {
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim <= v.rank);
-  // NOTE: the final comparison is originally int <= long unsigned int
-  // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second <= v.extent_int(idim));
+         && kp0.second < v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST****,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
@@ -421,10 +413,8 @@ subview(const ViewLR<ST*****, Props...>& v,
         const int idim) {
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim <= v.rank);
-  // NOTE: the final comparison is originally int <= long unsigned int
-  // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second <= v.extent_int(idim));
+         && kp0.second < v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST*****,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
@@ -453,10 +443,8 @@ subview(const ViewLR<ST******, Props...>& v,
         const int idim) {
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim <= v.rank);
-  // NOTE: the final comparison is originally int <= long unsigned int
-  // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second <= v.extent_int(idim));
+         && kp0.second < v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST******,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
@@ -484,7 +472,6 @@ subview(const ViewLR<ST******, Props...>& v,
                       Kokkos::ALL, kp0));
   }
 }
-
 } // namespace ekat
 
 #endif // EKAT_SUBVIEW_UTILS_HPP

--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -93,18 +93,6 @@ subview(const ViewLR<ST****,Props...>& v,
       &v.impl_map().reference(i0, i1, i2, 0),v.extent(3));
 }
 
-// --- Rank4 multi-slice --- //
-template <typename ST, typename... Props>
-KOKKOS_INLINE_FUNCTION
-ViewLS<ST****, Props...>
-subview(const ViewLR<ST****, Props...>& v,
-        const Kokkos::pair<int, int> &kp0,
-        const int idim) {
-  assert(v.data() != nullptr);
-  auto sv = Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
-  return Unmanaged<ViewLS<ST****,Props...>>(sv);
-}
-
 // --- Rank5 --- //
 template <typename ST, typename... Props>
 KOKKOS_INLINE_FUNCTION
@@ -279,7 +267,7 @@ subview_1(const ViewLR<ST****,Props...>& v,
   // Since we are keeping the first dimension, the stride is unchanged.
   auto vm = tmp.impl_map();
   vm.m_impl_offset.m_stride = v.impl_map().stride_0();
-  auto test =  Unmanaged<ViewLR<ST***,Props...>>(v.impl_track(),vm);
+  // auto test =  Unmanaged<ViewLR<ST***,Props...>>(v.impl_track(),vm);
   return Unmanaged<ViewLR<ST***,Props...>>(
       v.impl_track(),vm);
 }
@@ -326,6 +314,191 @@ subview_1(const ViewLR<ST******,Props...>& v,
   vm.m_impl_offset.m_stride = v.impl_map().stride_0();
   return Unmanaged<ViewLR<ST*****,Props...>>(
       v.impl_track(),vm);
+}
+
+// ================ Multi-sliced Subviews ======================= //
+// e.g., instead of a single-entry slice like v(:, 42, :), we slice over a range
+// of values, as in v(:, 27:42, :)
+// this means that the subview has the same rank as the "parent" view
+
+// --- Rank1 multi-slice --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST*, Props...>>
+subview(const ViewLR<ST*, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim) {
+  assert(v.data() != nullptr);
+  assert(idim >= 0 && idim == v.rank);
+  // NOTE: the final comparison is originally int <= long unsigned int
+  // the cast silences a warning, but may be unnecessary
+  assert(kp0.first >= 0 && kp0.first < kp0.second
+         && (unsigned int)kp0.second <= v.extent(idim));
+  if (idim == 0) {
+    return Unmanaged<ViewLS<ST*,Props...>>(Kokkos::subview(v, kp0, Kokkos::ALL));
+  } else {
+    // FIXME: better way to do this? necessary?
+    assert(false);
+  }
+}
+
+// --- Rank2 multi-slice --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST**, Props...>>
+subview(const ViewLR<ST**, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim) {
+  assert(v.data() != nullptr);
+  assert(idim >= 0 && idim <= v.rank);
+  // NOTE: the final comparison is originally int <= long unsigned int
+  // the cast silences a warning, but may be unnecessary
+  assert(kp0.first >= 0 && kp0.first < kp0.second
+         && (unsigned int)kp0.second <= v.extent(idim));
+  if (idim == 0) {
+    return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, kp0, Kokkos::ALL));
+  } else if (idim == 1) {
+    return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, Kokkos::ALL, kp0));
+  } else {
+    // FIXME: better way to do this? necessary?
+    assert(false);
+  }
+}
+
+// --- Rank3 multi-slice --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST***, Props...>>
+subview(const ViewLR<ST***, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim) {
+  assert(v.data() != nullptr);
+  assert(idim >= 0 && idim <= v.rank);
+  // NOTE: the final comparison is originally int <= long unsigned int
+  // the cast silences a warning, but may be unnecessary
+  assert(kp0.first >= 0 && kp0.first < kp0.second
+         && (unsigned int)kp0.second <= v.extent(idim));
+  if (idim == 0) {
+    return Unmanaged<ViewLS<ST***,Props...>>(
+      Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 1) {
+    return Unmanaged<ViewLS<ST***,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, kp0, Kokkos::ALL));
+  } else if (idim == 2) {
+    return Unmanaged<ViewLS<ST***,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, kp0));
+  } else {
+    // FIXME: better way to do this? necessary?
+    assert(false);
+  }
+}
+
+// --- Rank4 multi-slice --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST****, Props...>>
+subview(const ViewLR<ST****, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim) {
+  assert(v.data() != nullptr);
+  assert(idim >= 0 && idim <= v.rank);
+  // NOTE: the final comparison is originally int <= long unsigned int
+  // the cast silences a warning, but may be unnecessary
+  assert(kp0.first >= 0 && kp0.first < kp0.second
+         && (unsigned int)kp0.second <= v.extent(idim));
+  if (idim == 0) {
+    return Unmanaged<ViewLS<ST****,Props...>>(
+      Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 1) {
+    return Unmanaged<ViewLS<ST****,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, kp0, Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 2) {
+    return Unmanaged<ViewLS<ST****,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, kp0, Kokkos::ALL));
+  } else if (idim == 3) {
+    return Unmanaged<ViewLS<ST****,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, kp0));
+  } else {
+    // FIXME: better way to do this? necessary?
+    assert(false);
+  }
+}
+
+// --- Rank5 multi-slice --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST*****, Props...>>
+subview(const ViewLR<ST*****, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim) {
+  assert(v.data() != nullptr);
+  assert(idim >= 0 && idim <= v.rank);
+  // NOTE: the final comparison is originally int <= long unsigned int
+  // the cast silences a warning, but may be unnecessary
+  assert(kp0.first >= 0 && kp0.first < kp0.second
+         && (unsigned int)kp0.second <= v.extent(idim));
+  if (idim == 0) {
+    return Unmanaged<ViewLS<ST*****,Props...>>(
+      Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 1) {
+    return Unmanaged<ViewLS<ST*****,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 2) {
+    return Unmanaged<ViewLS<ST*****,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, kp0, Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 3) {
+    return Unmanaged<ViewLS<ST*****,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, kp0, Kokkos::ALL));
+  } else if (idim == 4) {
+    return Unmanaged<ViewLS<ST*****,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, kp0));
+  } else {
+    // FIXME: better way to do this? necessary?
+    assert(false);
+  }
+}
+
+// --- Rank6 multi-slice --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST******, Props...>>
+subview(const ViewLR<ST******, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim) {
+  assert(v.data() != nullptr);
+  assert(idim >= 0 && idim <= v.rank);
+  // NOTE: the final comparison is originally int <= long unsigned int
+  // the cast silences a warning, but may be unnecessary
+  assert(kp0.first >= 0 && kp0.first < kp0.second
+         && (unsigned int)kp0.second <= v.extent(idim));
+  if (idim == 0) {
+    return Unmanaged<ViewLS<ST******,Props...>>(
+      Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                      Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 1) {
+    return Unmanaged<ViewLS<ST******,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, kp0, Kokkos::ALL, Kokkos::ALL,
+                      Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 2) {
+    return Unmanaged<ViewLS<ST******,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, kp0, Kokkos::ALL,
+                      Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 3) {
+    return Unmanaged<ViewLS<ST******,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, kp0,
+                      Kokkos::ALL, Kokkos::ALL));
+  } else if (idim == 4) {
+    return Unmanaged<ViewLS<ST******,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                      kp0, Kokkos::ALL));
+  } else if (idim == 5) {
+    return Unmanaged<ViewLS<ST******,Props...>>(
+      Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                      Kokkos::ALL, kp0));
+  } else {
+    // FIXME: better way to do this? necessary?
+    assert(false);
+  }
 }
 
 } // namespace ekat

--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -93,6 +93,18 @@ subview(const ViewLR<ST****,Props...>& v,
       &v.impl_map().reference(i0, i1, i2, 0),v.extent(3));
 }
 
+// --- Rank4 multi-slice --- //
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+ViewLS<ST****, Props...>
+subview(const ViewLR<ST****, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim) {
+  assert(v.data() != nullptr);
+  auto sv = Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
+  return Unmanaged<ViewLS<ST****,Props...>>(sv);
+}
+
 // --- Rank5 --- //
 template <typename ST, typename... Props>
 KOKKOS_INLINE_FUNCTION

--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -267,7 +267,6 @@ subview_1(const ViewLR<ST****,Props...>& v,
   // Since we are keeping the first dimension, the stride is unchanged.
   auto vm = tmp.impl_map();
   vm.m_impl_offset.m_stride = v.impl_map().stride_0();
-  // auto test =  Unmanaged<ViewLR<ST***,Props...>>(v.impl_track(),vm);
   return Unmanaged<ViewLR<ST***,Props...>>(
       v.impl_track(),vm);
 }
@@ -329,17 +328,13 @@ subview(const ViewLR<ST*, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim == v.rank);
+  assert(idim == 0);
   // NOTE: the final comparison is originally int <= long unsigned int
   // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && (unsigned int)kp0.second <= v.extent(idim));
-  if (idim == 0) {
-    return Unmanaged<ViewLS<ST*,Props...>>(Kokkos::subview(v, kp0, Kokkos::ALL));
-  } else {
-    // FIXME: better way to do this? necessary?
-    assert(false);
-  }
+  return Unmanaged<ViewLS<ST*,Props...>>(Kokkos::subview(v, kp0));
+
 }
 
 // --- Rank2 multi-slice --- //
@@ -357,11 +352,9 @@ subview(const ViewLR<ST**, Props...>& v,
          && (unsigned int)kp0.second <= v.extent(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, kp0, Kokkos::ALL));
-  } else if (idim == 1) {
-    return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, Kokkos::ALL, kp0));
   } else {
-    // FIXME: better way to do this? necessary?
-    assert(false);
+    assert(idim == 1);
+    return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, Kokkos::ALL, kp0));
   }
 }
 
@@ -384,12 +377,10 @@ subview(const ViewLR<ST***, Props...>& v,
   } else if (idim == 1) {
     return Unmanaged<ViewLS<ST***,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, kp0, Kokkos::ALL));
-  } else if (idim == 2) {
+  } else {
+    assert(idim == 2);
     return Unmanaged<ViewLS<ST***,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, kp0));
-  } else {
-    // FIXME: better way to do this? necessary?
-    assert(false);
   }
 }
 
@@ -415,12 +406,10 @@ subview(const ViewLR<ST****, Props...>& v,
   } else if (idim == 2) {
     return Unmanaged<ViewLS<ST****,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, kp0, Kokkos::ALL));
-  } else if (idim == 3) {
+  } else {
+    assert(idim == 3);
     return Unmanaged<ViewLS<ST****,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, kp0));
-  } else {
-    // FIXME: better way to do this? necessary?
-    assert(false);
   }
 }
 
@@ -449,12 +438,10 @@ subview(const ViewLR<ST*****, Props...>& v,
   } else if (idim == 3) {
     return Unmanaged<ViewLS<ST*****,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, kp0, Kokkos::ALL));
-  } else if (idim == 4) {
+  } else {
+    assert(idim == 4);
     return Unmanaged<ViewLS<ST*****,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, kp0));
-  } else {
-    // FIXME: better way to do this? necessary?
-    assert(false);
   }
 }
 
@@ -491,13 +478,11 @@ subview(const ViewLR<ST******, Props...>& v,
     return Unmanaged<ViewLS<ST******,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                       kp0, Kokkos::ALL));
-  } else if (idim == 5) {
+  } else {
+    assert(idim == 5);
     return Unmanaged<ViewLS<ST******,Props...>>(
       Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                       Kokkos::ALL, kp0));
-  } else {
-    // FIXME: better way to do this? necessary?
-    assert(false);
   }
 }
 

--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -244,7 +244,6 @@ subview_1(const ViewLR<ST***,Props...>& v,
   // Since we are keeping the first dimension, the stride is unchanged.
   auto vm = tmp.impl_map();
   vm.m_impl_offset.m_stride = v.impl_map().stride_0();
-  auto test =  Unmanaged<ViewLR<ST**,Props...>>(v.impl_track(),vm);
   return Unmanaged<ViewLR<ST**,Props...>>(
       v.impl_track(),vm);
 }
@@ -318,7 +317,7 @@ subview_1(const ViewLR<ST******,Props...>& v,
 // ================ Multi-sliced Subviews ======================= //
 // e.g., instead of a single-entry slice like v(:, 42, :), we slice over a range
 // of values, as in v(:, 27:42, :)
-// this means that the subview has the same rank as the "parent" view
+// this means that the subview has the same rank as the source view
 
 // --- Rank1 multi-slice --- //
 template <typename ST, typename... Props>
@@ -332,7 +331,7 @@ subview(const ViewLR<ST*, Props...>& v,
   // NOTE: the final comparison is originally int <= long unsigned int
   // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && (unsigned int)kp0.second <= v.extent(idim));
+         && kp0.second <= v.extent_int(idim));
   return Unmanaged<ViewLS<ST*,Props...>>(Kokkos::subview(v, kp0));
 
 }
@@ -349,7 +348,7 @@ subview(const ViewLR<ST**, Props...>& v,
   // NOTE: the final comparison is originally int <= long unsigned int
   // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && (unsigned int)kp0.second <= v.extent(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, kp0, Kokkos::ALL));
   } else {
@@ -370,7 +369,7 @@ subview(const ViewLR<ST***, Props...>& v,
   // NOTE: the final comparison is originally int <= long unsigned int
   // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && (unsigned int)kp0.second <= v.extent(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST***,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL));
@@ -396,7 +395,7 @@ subview(const ViewLR<ST****, Props...>& v,
   // NOTE: the final comparison is originally int <= long unsigned int
   // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && (unsigned int)kp0.second <= v.extent(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST****,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
@@ -425,7 +424,7 @@ subview(const ViewLR<ST*****, Props...>& v,
   // NOTE: the final comparison is originally int <= long unsigned int
   // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && (unsigned int)kp0.second <= v.extent(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST*****,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
@@ -457,7 +456,7 @@ subview(const ViewLR<ST******, Props...>& v,
   // NOTE: the final comparison is originally int <= long unsigned int
   // the cast silences a warning, but may be unnecessary
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && (unsigned int)kp0.second <= v.extent(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST******,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -544,4 +544,230 @@ TEST_CASE("subviews") {
   }
 }
 
+TEST_CASE("multi-slice subviews") {
+  using kt = ekat::KokkosTypes<ekat::DefaultDevice>;
+
+  const int i0 = 5;
+  const int i1 = 4;
+  const int i2 = 3;
+  const int i3 = 2;
+  const int i4 = 1;
+  const int idx0[6] = {0, 3, 1, 0, 1, 0};
+  const int idx1[6] = {3, 5, 4, 2, 2, 1};
+
+  auto p0 = Kokkos::make_pair<int, int>(idx0[0], idx1[0]);
+  auto p1 = Kokkos::make_pair<int, int>(idx0[1], idx1[1]);
+  auto p2 = Kokkos::make_pair<int, int>(idx0[2], idx1[2]);
+  auto p3 = Kokkos::make_pair<int, int>(idx0[3], idx1[3]);
+  auto p4 = Kokkos::make_pair<int, int>(idx0[4], idx1[4]);
+  auto p5 = Kokkos::make_pair<int, int>(idx0[5], idx1[5]);
+
+  // Create input view
+  kt::view_ND<Real, 6> v6("v6", 7, 6, 5, 4, 3, 2);
+  const int s = v6.size();
+  Kokkos::parallel_for(
+      kt::RangePolicy(0, s), KOKKOS_LAMBDA(int i) { *(v6.data() + i) = i; });
+
+  auto v5 = ekat::subview(v6, i0);
+  auto v4 = ekat::subview(v6, i0, i1);
+  auto v3 = ekat::subview(v6, i0, i1, i2);
+  auto v2 = ekat::subview(v6, i0, i1, i2, i3);
+  auto v1 = ekat::subview(v6, i0, i1, i2, i3, i4);
+
+  SECTION("subview_major") {
+    // Subviews of v6
+    auto v6_5 = ekat::subview(v6, p5, 5);
+    auto v6_4 = ekat::subview(v6, p4, 4);
+    auto v6_3 = ekat::subview(v6, p3, 3);
+    auto v6_2 = ekat::subview(v6, p2, 2);
+    auto v6_1 = ekat::subview(v6, p1, 1);
+    auto v6_0 = ekat::subview(v6, p0, 0);
+
+    // Subviews of v5
+    auto v5_4 = ekat::subview(v5, p5, 4);
+    auto v5_3 = ekat::subview(v5, p4, 3);
+    auto v5_2 = ekat::subview(v5, p3, 2);
+    auto v5_1 = ekat::subview(v5, p2, 1);
+    auto v5_0 = ekat::subview(v5, p1, 0);
+
+    // Subviews of v4
+    auto v4_3 = ekat::subview(v4, p5, 3);
+    auto v4_2 = ekat::subview(v4, p4, 2);
+    auto v4_1 = ekat::subview(v4, p3, 1);
+    auto v4_0 = ekat::subview(v4, p2, 0);
+
+    // Subviews of v3
+    auto v3_2 = ekat::subview(v3, p5, 2);
+    auto v3_1 = ekat::subview(v3, p4, 1);
+    auto v3_0 = ekat::subview(v3, p3, 0);
+
+    // Subviews of v2
+    auto v2_1 = ekat::subview(v2, p5, 1);
+    auto v2_0 = ekat::subview(v2, p4, 0);
+
+    // Subviews of v1
+    auto v1_0 = ekat::subview(v1, p5, 0);
+
+    // Compare with original views and count diffs
+    Kokkos::View<int> diffs("");
+    Kokkos::deep_copy(diffs, 0);
+    Kokkos::parallel_for(
+        kt::RangePolicy(0, 1), KOKKOS_LAMBDA(int) {
+          int i1, i2, j1, j2, k1, k2, l1, l2, m1, m2, n1, n2;
+
+          auto testv6(v6_0);
+          auto testv5(v5_0);
+          auto testv4(v4_0);
+          auto testv3(v3_0);
+          auto testv2(v2_0);
+          auto testv1(v1_0);
+
+          int& ndiffs = diffs();
+          for (int ens = 0; ens < 6; ens++) {
+            i1 = (ens == 0) ? idx0[0] : 0;
+            i2 = (ens == 0) ? idx1[0] : 7;
+            if (ens == 0)
+              testv6 = v6_0;
+            j1 = (ens == 1) ? idx0[1] : 0;
+            j2 = (ens == 1) ? idx1[1] : 6;
+            if (ens == 1)
+              testv6 = v6_1;
+            k1 = (ens == 2) ? idx0[2] : 0;
+            k2 = (ens == 2) ? idx1[2] : 5;
+            if (ens == 2)
+              testv6 = v6_2;
+            l1 = (ens == 3) ? idx0[3] : 0;
+            l2 = (ens == 3) ? idx1[3] : 4;
+            if (ens == 3)
+              testv6 = v6_3;
+            m1 = (ens == 4) ? idx0[4] : 0;
+            m2 = (ens == 4) ? idx1[4] : 3;
+            if (ens == 4)
+              testv6 = v6_4;
+            n1 = (ens == 5) ? idx0[5] : 0;
+            n2 = (ens == 5) ? idx1[5] : 2;
+            if (ens == 5)
+              testv6 = v6_5;
+            for (int n = n1; n < n2; n++)
+              for (int m = m1; m < m2; m++)
+                for (int l = l1; l < l2; l++)
+                  for (int k = k1; k < k2; k++)
+                    for (int j = j1; j < j2; j++)
+                      for (int i = i1; i < i2; i++) {
+                        if (v6(i, j, k, l, m, n) != testv6(i - i1, j - j1,
+                                                           k - k1, l - l1,
+                                                           m - m1, n - n1))
+                          ++ndiffs;
+                      }
+          }
+          for (int ens = 1; ens < 6; ens++) {
+            j1 = (ens == 1) ? idx0[1] : 0;
+            j2 = (ens == 1) ? idx1[1] : 6;
+            if (ens == 1)
+              testv5 = v5_0;
+            k1 = (ens == 2) ? idx0[2] : 0;
+            k2 = (ens == 2) ? idx1[2] : 5;
+            if (ens == 2)
+              testv5 = v5_1;
+            l1 = (ens == 3) ? idx0[3] : 0;
+            l2 = (ens == 3) ? idx1[3] : 4;
+            if (ens == 3)
+              testv5 = v5_2;
+            m1 = (ens == 4) ? idx0[4] : 0;
+            m2 = (ens == 4) ? idx1[4] : 3;
+            if (ens == 4)
+              testv5 = v5_3;
+            n1 = (ens == 5) ? idx0[5] : 0;
+            n2 = (ens == 5) ? idx1[5] : 2;
+            if (ens == 5)
+              testv5 = v5_4;
+            for (int j = j1; j < j2; j++)
+              for (int k = k1; k < k2; k++)
+                for (int l = l1; l < l2; l++)
+                  for (int m = m1; m < m2; m++)
+                    for (int n = n1; n < n2; n++) {
+                      if (v5(j, k, l, m, n) !=
+                          testv5(j - j1, k - k1, l - l1, m - m1, n - n1))
+                        ++ndiffs;
+                    }
+          }
+          for (int ens = 2; ens < 6; ens++) {
+            k1 = (ens == 2) ? idx0[2] : 0;
+            k2 = (ens == 2) ? idx1[2] : 5;
+            if (ens == 2)
+              testv4 = v4_0;
+            l1 = (ens == 3) ? idx0[3] : 0;
+            l2 = (ens == 3) ? idx1[3] : 4;
+            if (ens == 3)
+              testv4 = v4_1;
+            m1 = (ens == 4) ? idx0[4] : 0;
+            m2 = (ens == 4) ? idx1[4] : 3;
+            if (ens == 4)
+              testv4 = v4_2;
+            n1 = (ens == 5) ? idx0[5] : 0;
+            n2 = (ens == 5) ? idx1[5] : 2;
+            if (ens == 5)
+              testv4 = v4_3;
+            for (int k = k1; k < k2; k++)
+              for (int l = l1; l < l2; l++)
+                for (int m = m1; m < m2; m++)
+                  for (int n = n1; n < n2; n++) {
+                    if (v4(k, l, m, n) !=
+                        testv4(k - k1, l - l1, m - m1, n - n1))
+                      ++ndiffs;
+                  }
+          }
+          for (int ens = 3; ens < 6; ens++) {
+            l1 = (ens == 3) ? idx0[3] : 0;
+            l2 = (ens == 3) ? idx1[3] : 4;
+            if (ens == 3)
+              testv3 = v3_0;
+            m1 = (ens == 4) ? idx0[4] : 0;
+            m2 = (ens == 4) ? idx1[4] : 3;
+            if (ens == 4)
+              testv3 = v3_1;
+            n1 = (ens == 5) ? idx0[5] : 0;
+            n2 = (ens == 5) ? idx1[5] : 2;
+            if (ens == 5)
+              testv3 = v3_2;
+            for (int l = l1; l < l2; l++)
+              for (int m = m1; m < m2; m++)
+                for (int n = n1; n < n2; n++) {
+                  if (v3(l, m, n) != testv3(l - l1, m - m1, n - n1))
+                    ++ndiffs;
+                }
+          }
+          for (int ens = 4; ens < 6; ens++) {
+            m1 = (ens == 4) ? idx0[4] : 0;
+            m2 = (ens == 4) ? idx1[4] : 3;
+            if (ens == 4)
+              testv2 = v2_0;
+            n1 = (ens == 5) ? idx0[5] : 0;
+            n2 = (ens == 5) ? idx1[5] : 2;
+            if (ens == 5)
+              testv2 = v2_1;
+            for (int m = m1; m < m2; m++)
+              for (int n = n1; n < n2; n++) {
+                if (v2(m, n) != testv2(m - m1, n - n1))
+                  ++ndiffs;
+              }
+          }
+          n1 = idx0[5];
+          n2 = idx1[5];
+          testv1 = v1_0;
+          for (int n = n1; n < n2; n++) {
+            if (v1(n) != testv1(n - n1))
+              ++ndiffs;
+          }
+          // Make sure that our diffs counting strategy works
+          // by checking that two entries that should be different
+          // are indeed different.
+          if (v1_0(0) != v6(i0, i1, i2, i3, i4, 1))
+            ++ndiffs;
+        });
+    auto diffs_h = Kokkos::create_mirror_view(diffs);
+    Kokkos::deep_copy(diffs_h, diffs);
+    REQUIRE(diffs_h() == 1);
+  }
+}
 } // anonymous namespace

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -606,7 +606,7 @@ TEST_CASE("multi-slice subviews") {
     auto v2_0 = ekat::subview(v2, p4, 0);
 
     // Subviews of v1
-    auto v1_0 = ekat::subview(v1, p5, 0);
+    auto v1_0 = ekat::subview(v1, p5);
 
     // Compare with original views and count diffs
     Kokkos::View<int> diffs("");


### PR DESCRIPTION
## Motivation

This PR is associated with https://github.com/E3SM-Project/scream/pull/2785 and provides `get_subview_<N>()` implementations for getting a multi-sliced `subfield`'s underlying view. I've created a separate overload function for each view rank of `N = 1, ... 6` and employ if statements within to differentiate between which dimension is being sliced. Using the logic blocks isn't my favorite solution from an efficiency standpoint, so I'd be happy to hear any suggestions about a better approach.

## Testing

The added functions are tested within EAMxx's[ tests for `Field`-related functionality](https://github.com/E3SM-Project/scream/blob/1439884714a394c5227b535de4b4a98c8614443a/components/eamxx/src/share/tests/field_tests.cpp). As of submitting this PR, some more tests are required, but I wanted to prioritize getting this out with the draft-submission for the EAMxx PR.
