### PR TITLE
fix (in)equality for multi-sliced subview functions

### DIFF
--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -343,7 +343,7 @@ subview(const ViewLR<ST**, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim <= v.rank);
+  assert(idim >= 0 && idim < v.rank);
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -362,7 +362,7 @@ subview(const ViewLR<ST***, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim <= v.rank);
+  assert(idim >= 0 && idim < v.rank);
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -386,7 +386,7 @@ subview(const ViewLR<ST****, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim <= v.rank);
+  assert(idim >= 0 && idim < v.rank);
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -413,7 +413,7 @@ subview(const ViewLR<ST*****, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim <= v.rank);
+  assert(idim >= 0 && idim < v.rank);
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -443,7 +443,7 @@ subview(const ViewLR<ST******, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim <= v.rank);
+  assert(idim >= 0 && idim < v.rank);
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation

In working on EAMxx, caught a mistake I made in the multi-slice `subview()` functions I'd implemented. Namely, changed
```cpp
assert(idim >= 0 && idim <= v.rank);
```
to
```cpp
assert(idim >= 0 && idim < v.rank);
```
