### PR TITLE
Another modification for EAMxx Multi-sliced Subfields

### DIFF
--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -213,6 +213,17 @@ subview(const ViewLR<ST******,Props...>& v,
 //       If the input view has rank=2, then the output view MUST have
 //       LayoutStride (there is no alternative).
 
+// NOTE: DO NOT USE--used to prevent compile time error in get_strided_view()
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST,Props...>>
+subview_1(const ViewLR<ST*,Props...>& v,
+          const int i1) {
+  EKAT_ERROR_MSG("Error! Cannot call subview_1() for rank == 1.\n"
+                 "This should never be called at run time.\n"
+                 "Please contact developer if this functionality is required\n");
+}
+
 // --- Rank2 --- //
 template <typename ST, typename... Props>
 KOKKOS_INLINE_FUNCTION
@@ -321,6 +332,19 @@ subview_1(const ViewLR<ST******,Props...>& v,
 // range [27, 42) == {v(i, j, k), where 27 <= j < 42}
 // Note also that this slicing means that the subview has the same rank
 // as the source view
+
+// --- Rank0 multi-slice --- //
+// NOTE: DO NOT USE--used to prevent compile time error in get_strided_view()
+template <typename ST, typename... Props>
+KOKKOS_INLINE_FUNCTION
+Unmanaged<ViewLS<ST, Props...>>
+subview(const ViewLR<ST, Props...>& v,
+        const Kokkos::pair<int, int> &kp0,
+        const int idim = 0) {
+  assert(v.data() != nullptr);
+  EKAT_ERROR_MSG("Error! Cannot call multi-slice subview() for rank == 0.\n"
+                 "This should never be called at run time.\n");
+}
 
 // --- Rank1 multi-slice --- //
 template <typename ST, typename... Props>

--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -219,9 +219,12 @@ KOKKOS_INLINE_FUNCTION
 Unmanaged<ViewLS<ST,Props...>>
 subview_1(const ViewLR<ST*,Props...>& v,
           const int i1) {
-  EKAT_ERROR_MSG("Error! Cannot call subview_1() for rank == 1.\n"
-                 "This should never be called at run time.\n"
-                 "Please contact developer if this functionality is required\n");
+  // The error message **would** be:
+  // "Error! Cannot call subview_1() for rank == 1."
+  // "This should never be called at run time."
+  // "Please contact developer if this functionality is required"
+  assert(false);
+  return Unmanaged<ViewLR<ST,Props...>>();
 }
 
 // --- Rank2 --- //
@@ -342,8 +345,11 @@ subview(const ViewLR<ST, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim = 0) {
   assert(v.data() != nullptr);
-  EKAT_ERROR_MSG("Error! Cannot call multi-slice subview() for rank == 0.\n"
-                 "This should never be called at run time.\n");
+  // The error message **would** be:
+  // "Error! Cannot call multi-slice subview() for rank == 0."
+  // "This should never be called at run time."
+  assert(false);
+  return Unmanaged<ViewLR<ST, Props...>>();
 }
 
 // --- Rank1 multi-slice --- //


### PR DESCRIPTION
This is another small one. Just adds a couple of non-functional overloads to `get_subview()`-type functions that helps the compiler not crash. I'm not sure whether the `assert(false)` calls are the proper idea, so take a look and let me know--thanks!