### PR TITLE
Refactor how Units class handles the string representation

### DIFF
--- a/src/ekat/util/ekat_scaling_factor.hpp
+++ b/src/ekat/util/ekat_scaling_factor.hpp
@@ -1,9 +1,9 @@
 #ifndef EKAT_SCALING_FACTOR_HPP
 #define EKAT_SCALING_FACTOR_HPP
 
-#include <iostream>
 #include "ekat/util/ekat_rational_constant.hpp"
 
+#include <iostream>
 #include <array>
 
 namespace ekat
@@ -33,6 +33,21 @@ struct ScalingFactor {
 
   static constexpr ScalingFactor one () { return ScalingFactor(1); }
   static constexpr ScalingFactor zero () { return ScalingFactor(0); }
+
+  inline std::string to_string(const Format exp_fmt = Format::Rat) const {
+    std::string s = base.to_string(Format::Float);
+    if (exp!=RationalConstant::one()) {
+      s +=  '^';
+      if (exp.den!=1 and exp_fmt==Format::Rat) {
+        s+= '(';
+      }
+      s += exp.to_string(exp_fmt);
+      if (exp.den!=1 and exp_fmt==Format::Rat) {
+        s+= ')';
+      }
+    }
+    return s;
+  }
 
 private:
 
@@ -77,7 +92,7 @@ constexpr ScalingFactor operator* (const ScalingFactor& lhs, const ScalingFactor
   // otherwise, recall that, with all terms being integers,
   //    (a/b)^(c/d) * (x/y)^(w/z)
   // is equivalent to
-  //    ((a/b)^(cz) * (x/w)^(wd)) ^ (1/dz)
+  //    ((a/b)^(cz) * (x/y)^(wd)) ^ (1/dz)
   using iType = RationalConstant::iType;
 
   return lhs.base==rhs.base 
@@ -101,7 +116,7 @@ constexpr ScalingFactor operator/ (const ScalingFactor& lhs, const ScalingFactor
   // otherwise, recall that, with all terms being integers,
   //    (a/b)^(c/d) / (x/y)^(w/z)
   // is equivalent to
-  //    ((a/b)^(cz) / (x/w)^(wd)) ^ (1/dz)
+  //    ((a/b)^(cz) / (x/y)^(wd)) ^ (1/dz)
   using iType = RationalConstant::iType;
 
   return lhs.base==rhs.base 
@@ -132,16 +147,8 @@ constexpr ScalingFactor sqrt (const ScalingFactor& x) {
   return ScalingFactor(x.base,x.exp/2);
 }
 
-inline std::string to_string(const ScalingFactor& x, const Format exp_fmt = Format::Rat) {
-  std::string s = to_string(x.base,Format::Float);
-  if (x.exp!=RationalConstant::one()) {
-    s +=  "^" + to_string(x.exp,exp_fmt);
-  }
-  return s;
-}
-
 inline std::ostream& operator<< (std::ostream& out, const ScalingFactor& s) {
-  out << to_string(s);
+  out << s.to_string();
   return out;
 }
 

--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <limits>
+#include <string_view>
 
 namespace ekat
 {
@@ -14,8 +15,11 @@ namespace ekat
 namespace units
 {
 
+constexpr int UNITS_MAX_STR_LEN = 128;
 constexpr int NUM_BASIC_UNITS = 7;
-constexpr const char* BASIC_UNITS_SYMBOLS[7] = {"m", "s", "kg", "K", "A", "mol", "cd"};
+constexpr std::array<char,UNITS_MAX_STR_LEN> BASIC_UNITS_SYMBOLS[7] = {
+  {"m"}, {"s"}, {"kg"}, {"K"}, {"A"}, {"mol"}, {"cd"}
+};
 
 /*
  *  Units: a class to store physical units in terms of fundamental ones
@@ -37,7 +41,7 @@ constexpr const char* BASIC_UNITS_SYMBOLS[7] = {"m", "s", "kg", "K", "A", "mol",
  *
  *  Note: we do *not* overload operator^. Although it would be nice to write
  *            auto my_units = m^2 / s^2;
- *        it would be very bug prone, since ^ has lower precedence than + - * /.
+ *        it would be very bug prone, since ^ has lower precedence than * /.
  *        Sure, using parentheses makes it safe, but then you may as well write
  *            auto my_units = pow(m,2) / pow(s,2);
  *            auto my_units = (m*m) / (s*s);
@@ -66,46 +70,74 @@ public:
 
   // Construct a general quantity
   constexpr Units (const RationalConstant& lengthExp,
-         const RationalConstant& timeExp,
-         const RationalConstant& massExp,
-         const RationalConstant& temperatureExp,
-         const RationalConstant& currentExp,
-         const RationalConstant& amountExp,
-         const RationalConstant& luminousIntensityExp,
-         const ScalingFactor& scalingFactor = ScalingFactor::one(),
-         const char* name = nullptr)
+                   const RationalConstant& timeExp,
+                   const RationalConstant& massExp,
+                   const RationalConstant& temperatureExp,
+                   const RationalConstant& currentExp,
+                   const RationalConstant& amountExp,
+                   const RationalConstant& luminousIntensityExp,
+                   const ScalingFactor& scalingFactor = ScalingFactor::one(),
+                   const std::array<char,UNITS_MAX_STR_LEN>& n = {'\0'})
    : m_scaling {scalingFactor}
    , m_units {lengthExp,timeExp,massExp,temperatureExp,currentExp,amountExp,luminousIntensityExp}
-   , m_name {name}
-  {
-    // Nothing to do here
-  }
-  constexpr Units (const Units& rhs, const char* n)
-   : m_scaling (rhs.m_scaling)
-   , m_units   (rhs.m_units)
-   , m_name    (n)
+   , m_string_repr(n)
   {
     // Nothing to do here
   }
 
+  constexpr Units (const Units& rhs, const std::string_view& s)
+   : Units(rhs)
+  {
+    assert (s.size()<UNITS_MAX_STR_LEN);
+    for (size_t i=0; i<s.size(); ++i) {
+      m_string_repr[i] = s[i];
+    }
+    m_string_repr[s.size()] = '\0';
+  }
   constexpr Units (const Units&) = default;
 
   constexpr Units& operator= (const Units&) = default;
 
   static constexpr Units nondimensional () {
-    return Units(ScalingFactor::one());
+    Units u(ScalingFactor::one());
+    u.m_string_repr[0] = '1';
+    return u;
   }
   static constexpr Units invalid () {
     constexpr auto infty = std::numeric_limits<RationalConstant::iType>::max();
     return ScalingFactor(-infty)*nondimensional();
   }
 
-  void set_string (const char* name) {
-    m_name = name;
+  std::string get_si_string () const {
+    std::string s;
+    for (int i=0; i<NUM_BASIC_UNITS; ++i) {
+      if (m_units[i].num==0) {
+        continue;
+      }
+      s += std::string(BASIC_UNITS_SYMBOLS[i].data());
+      if (m_units[i]!=RationalConstant::one()) {
+        s += "^" + m_units[i].to_string(Format::Rat);
+      }
+      s += " ";
+    }
+
+    // Prepend the scaling only if it's not one, or if this is a dimensionless unit
+    if (m_scaling!=ScalingFactor::one() || is_dimensionless()) {
+      s = m_scaling.to_string() + " " + s;
+    }
+
+    // Remove leading/trailing whitespaces
+    return trim(s);
   }
 
-  std::string get_string () const {
-    return m_name==nullptr ? to_string(*this) : m_name;
+  std::string to_string () const {
+    std::string s = m_string_repr.data();
+    if (m_scaling!=ScalingFactor::one() or (is_dimensionless() and m_string_repr[0]=='\0')) {
+      s = m_scaling.to_string() + " " + s;
+    }
+
+    // Remove trailing/leading spaces
+    return trim(s);
   }
 
   constexpr bool is_dimensionless () const {
@@ -119,6 +151,74 @@ public:
   }
 
 private:
+  constexpr const std::array<char,UNITS_MAX_STR_LEN>& string_repr () const {
+    return m_string_repr;
+  }
+
+  // Returns true if the unit is composite (i.e., does not have a one-word symbol,
+  // but instead is a compound of symbols, such as a*b/c)
+  static constexpr bool composite (const std::array<char,UNITS_MAX_STR_LEN>& sv) {
+    for (const auto& c : sv) {
+      if (c=='*' or c=='/' or c=='^')
+        return true;
+      if (c=='\0')
+        return false;
+    }
+    return false;
+  };
+
+  static constexpr std::array<char,UNITS_MAX_STR_LEN>
+  concat_repr (const std::array<char,UNITS_MAX_STR_LEN>& lhs,
+               const std::array<char,UNITS_MAX_STR_LEN>& rhs,
+               const char op)
+  {
+    std::array<char,UNITS_MAX_STR_LEN> out = {'\0'};
+    const auto comp1 = composite(lhs);
+    const auto comp2 = composite(rhs);
+    int size1 = 0;
+    for (auto c : lhs) {
+      if (c=='\0') break;
+      ++size1;
+    }
+    int size2 = 0;
+    for (auto c : rhs) {
+      if (c=='\0') break;
+      ++size2;
+    }
+    if (size1==0) {
+      return rhs;
+    } else if (size2==0) {
+      return lhs;
+    }
+    const auto size_out = size1 + size2 + 1
+                        + (comp1 ? 2 : 0)
+                        + (comp2 ? 2 : 0);
+    assert (size_out<UNITS_MAX_STR_LEN);
+
+    int pos=0;
+    if (comp1) {
+      out[pos++]='(';
+    }
+    for (int i=0; i<size1; ++i) {
+      out [pos++] = lhs[i];
+    }
+    if (comp1) {
+      out[pos++] = ')';
+    }
+    out[pos++] = op;
+    if (comp2) {
+      out[pos++]='(';
+    }
+    for (int i=0; i<size2; ++i) {
+      out [pos++] = rhs[i];
+    }
+    if (comp2) {
+      out[pos++] = ')';
+    }
+    out[pos] = '\0';
+    return out;
+  }
+private:
 
   friend constexpr bool operator==(const Units&,const Units&);
 
@@ -129,14 +229,11 @@ private:
   friend constexpr Units operator/(const ScalingFactor&,const Units&);
   friend constexpr Units pow(const Units&,const RationalConstant&);
   friend constexpr Units sqrt(const Units&);
-  friend constexpr Units root(const Units&,const int);
-
-  friend std::string to_string(const Units&);
 
   ScalingFactor                   m_scaling;
   std::array<RationalConstant,7>  m_units;
 
-  const char*                     m_name;
+  std::array<char,UNITS_MAX_STR_LEN> m_string_repr = {'\0'};
 };
 
 // === Operators/functions overload === //
@@ -165,27 +262,21 @@ constexpr bool operator!=(const Units& lhs, const Units& rhs) {
 
 // --- Multiplicaiton --- //
 constexpr Units operator*(const Units& lhs, const Units& rhs) {
-  return Units(lhs.m_units[0]+rhs.m_units[0],
-               lhs.m_units[1]+rhs.m_units[1],
-               lhs.m_units[2]+rhs.m_units[2],
-               lhs.m_units[3]+rhs.m_units[3],
-               lhs.m_units[4]+rhs.m_units[4],
-               lhs.m_units[5]+rhs.m_units[5],
-               lhs.m_units[6]+rhs.m_units[6],
-               lhs.m_scaling*rhs.m_scaling);
+  return Units (lhs.m_units[0]+rhs.m_units[0],
+                lhs.m_units[1]+rhs.m_units[1],
+                lhs.m_units[2]+rhs.m_units[2],
+                lhs.m_units[3]+rhs.m_units[3],
+                lhs.m_units[4]+rhs.m_units[4],
+                lhs.m_units[5]+rhs.m_units[5],
+                lhs.m_units[6]+rhs.m_units[6],
+                lhs.m_scaling*rhs.m_scaling,
+                Units::concat_repr(lhs.string_repr(),rhs.string_repr(),'*'));
 }
 constexpr Units operator*(const ScalingFactor& lhs, const Units& rhs) {
-  return Units(rhs.m_units[0],
-               rhs.m_units[1],
-               rhs.m_units[2],
-               rhs.m_units[3],
-               rhs.m_units[4],
-               rhs.m_units[5],
-               rhs.m_units[6],
-               lhs*rhs.m_scaling);
+  return Units(lhs)*rhs;
 }
 constexpr Units operator*(const Units& lhs, const ScalingFactor& rhs) {
-  return rhs*lhs;
+  return lhs*Units(rhs);
 }
 constexpr Units operator*(const RationalConstant& lhs, const Units& rhs) {
   return ScalingFactor(lhs)*rhs;
@@ -203,27 +294,14 @@ constexpr Units operator/(const Units& lhs, const Units& rhs) {
                lhs.m_units[4]-rhs.m_units[4],
                lhs.m_units[5]-rhs.m_units[5],
                lhs.m_units[6]-rhs.m_units[6],
-               lhs.m_scaling/rhs.m_scaling);
+               lhs.m_scaling/rhs.m_scaling,
+               Units::concat_repr(lhs.string_repr(),rhs.string_repr(),'/'));
 }
 constexpr Units operator/(const Units& lhs, const ScalingFactor& rhs) {
-  return Units(lhs.m_units[0],
-               lhs.m_units[1],
-               lhs.m_units[2],
-               lhs.m_units[3],
-               lhs.m_units[4],
-               lhs.m_units[5],
-               lhs.m_units[6],
-               lhs.m_scaling/rhs);
+  return lhs/Units(rhs);
 }
 constexpr Units operator/(const ScalingFactor& lhs, const Units& rhs) {
-  return Units(-rhs.m_units[0],
-               -rhs.m_units[1],
-               -rhs.m_units[2],
-               -rhs.m_units[3],
-               -rhs.m_units[4],
-               -rhs.m_units[5],
-               -rhs.m_units[6],
-               lhs/rhs.m_scaling);
+  return Units(lhs)/rhs;
 }
 constexpr Units operator/(const RationalConstant& lhs, const Units& rhs) {
   return ScalingFactor(lhs)/rhs;
@@ -233,7 +311,6 @@ constexpr Units operator/(const Units& lhs, const RationalConstant& rhs) {
 }
 
 // --- Powers and roots --- //
-
 constexpr Units pow(const Units& x, const RationalConstant& p) {
   return Units(x.m_units[0]*p,
                x.m_units[1]*p,
@@ -242,55 +319,24 @@ constexpr Units pow(const Units& x, const RationalConstant& p) {
                x.m_units[4]*p,
                x.m_units[5]*p,
                x.m_units[6]*p,
-               pow(x.m_scaling,p));
+               pow(x.m_scaling,p),
+               Units::concat_repr(x.string_repr(),p.string_repr<UNITS_MAX_STR_LEN>(),'^'));
 }
 
 constexpr Units sqrt(const Units& x) {
-  return Units(x.m_units[0] / 2,
-               x.m_units[1] / 2,
-               x.m_units[2] / 2,
-               x.m_units[3] / 2,
-               x.m_units[4] / 2,
-               x.m_units[5] / 2,
-               x.m_units[6] / 2,
-               pow(x.m_scaling,RationalConstant(1,2)));
-}
-
-inline std::string to_string(const Units& x) {
-  std::string s;
-  int num_non_trivial = 0;
-  for (int i=0; i<NUM_BASIC_UNITS; ++i) {
-    if (x.m_units[i].num==0) {
-      continue;
-    }
-    ++num_non_trivial;
-    s += BASIC_UNITS_SYMBOLS[i];
-    if (x.m_units[i]!=RationalConstant::one()) {
-      s += "^" + to_string(x.m_units[i],Format::Rat);
-    }
-    s += " ";
-  }
-
-  // Prepend the scaling only if it's not one, or if this is a dimensionless unit
-  if (x.m_scaling!=ScalingFactor::one() || num_non_trivial==0) {
-    s = to_string(x.m_scaling) + " " + s;
-  }
-
-  // Remove leading/trailing whitespaces
-  return trim(s);
+  return pow(x,RationalConstant(1,2));
 }
 
 inline std::ostream& operator<< (std::ostream& out, const Units& x) {
-  out << to_string(x);
+  out << x.to_string();
   return out;
 }
 
-// ================== SHORT NAMES FOR COMMON PHYSICAL UNITS =============== //
+// ================== SHORT NAMES FOR COMMON SI PHYSICAL UNITS =============== //
 
 // Note to developers:
-// I added the 'most common' units. I avoided 'Siemes', since
-// the symbol is 'S', which is way too close to 's' (seconds).
-// TODO: should we add 'common' scaled ones, such as km=kilo*m?
+// I added the 'most common' SI units, but I avoided 'Siemens', since the symbol
+// is 'S', which is way too close to 's' (seconds).
 
 // === FUNDAMENTAL === //
 
@@ -304,7 +350,7 @@ constexpr Units A   = Units(0,0,0,0,1,0,0,ScalingFactor::one(),BASIC_UNITS_SYMBO
 constexpr Units mol = Units(0,0,0,0,0,1,0,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[5]);
 constexpr Units cd  = Units(0,0,0,0,0,0,1,ScalingFactor::one(),BASIC_UNITS_SYMBOLS[6]);
 
-// === DERIVED === //
+// === DERIVED SI UNITS === //
 
 // Thermomechanics
 constexpr Units day  = 86400*s;                   // day          (time)

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -62,25 +62,38 @@ TEST_CASE("units_framework", "") {
     const auto kPa = kilo*Pa;
 
     constexpr Units nondim (ScalingFactor(1));
-    constexpr Units milliJ = milli*J;
+    constexpr Units mJ = milli*J;
     constexpr Units mix_ratio = kg/kg;
 
     // Verify operations
-    REQUIRE (milliJ == kPa*pow(m,3)/mega);
+    REQUIRE (mJ == kPa*pow(m,3)/mega);
     REQUIRE (m/s*day/km == Units(one*86400/1000));
     REQUIRE (pow(sqrt(m),2)==m);
 
-    // Verify printing
+    // Verify all printing properties
     REQUIRE (nondim.to_string()=="1");
-    REQUIRE (milliJ.to_string()=="0.001 J");
-    REQUIRE (milliJ.get_si_string()=="0.001 m^2 s^-2 kg");
+    REQUIRE (mJ.to_string()=="mJ");
+    REQUIRE ((J/1000).to_string()=="J/1000");
+    REQUIRE (mJ.get_si_string()=="1/1000 m^2 s^-2 kg");
 
-    // Verify changing the string works and does not affect the to_string function
     REQUIRE (mix_ratio==nondim);
     REQUIRE (mix_ratio.get_si_string()=="1");
     REQUIRE (mix_ratio.to_string()=="kg/kg");
     REQUIRE ((m*mix_ratio).to_string()=="m*(kg/kg)");
     REQUIRE ((m*mix_ratio).get_si_string()=="m");
+
+    constexpr Units uJ = micro*J;
+    constexpr Units ug = micro*g;
+    constexpr Units mbar = milli*bar;
+
+    REQUIRE (uJ.to_string()=="uJ");
+    REQUIRE ((ug/kg).to_string()=="ug/kg");
+    REQUIRE ((mbar/h).to_string()=="mbar/h");
+
+    REQUIRE ((mbar/h).get_si_string()=="1/36 m^-1 s^-3 kg");
+    REQUIRE ((ug/kg).get_si_string()=="1/1000000000");
+
+    REQUIRE ((kilo*(ug/kg)).to_string()=="(10^3)*(ug/kg)");
   }
 
   SECTION ("issue-52") {

--- a/tests/units/units.cpp
+++ b/tests/units/units.cpp
@@ -26,6 +26,9 @@ TEST_CASE("units_framework", "") {
     REQUIRE_THROWS(pow(zero,zero));
     REQUIRE_THROWS(pow(-one,half));
 #endif
+
+    REQUIRE ((-half).to_string()==std::string("-1/2"));
+    REQUIRE ((-half).to_string(Format::Float)==std::string("-0.5"));
   }
 
   SECTION ("scaling_factor") {
@@ -42,8 +45,8 @@ TEST_CASE("units_framework", "") {
     REQUIRE( pow(three_halves,2)*pow(four_thirds,3) == 16*one/3);
 
     // Verify printing
-    REQUIRE(to_string(root2)=="2^1/2");
-    REQUIRE(to_string(root2,Format::Float)=="2^0.5");
+    REQUIRE(root2.to_string()=="2^(1/2)");
+    REQUIRE(root2.to_string(Format::Float)=="2^0.5");
 
 #if defined(EKAT_CONSTEXPR_ASSERT) && !defined(NDEBUG)
     const RationalConstant three(3);
@@ -59,8 +62,8 @@ TEST_CASE("units_framework", "") {
     const auto kPa = kilo*Pa;
 
     constexpr Units nondim (ScalingFactor(1));
-    constexpr Units milliJ = milli*N*m;
-    constexpr Units mix_ratio (kg/kg,"kg/kg");
+    constexpr Units milliJ = milli*J;
+    constexpr Units mix_ratio = kg/kg;
 
     // Verify operations
     REQUIRE (milliJ == kPa*pow(m,3)/mega);
@@ -68,18 +71,16 @@ TEST_CASE("units_framework", "") {
     REQUIRE (pow(sqrt(m),2)==m);
 
     // Verify printing
-    REQUIRE (to_string(nondim)=="1");
-    REQUIRE (to_string(milliJ)=="0.001 m^2 s^-2 kg");
+    REQUIRE (nondim.to_string()=="1");
+    REQUIRE (milliJ.to_string()=="0.001 J");
+    REQUIRE (milliJ.get_si_string()=="0.001 m^2 s^-2 kg");
 
     // Verify changing the string works and does not affect the to_string function
     REQUIRE (mix_ratio==nondim);
-    REQUIRE (to_string(mix_ratio)=="1");
-    REQUIRE (mix_ratio.get_string()=="kg/kg");
-
-    Units my_J = N*m;
-    my_J.set_string("J");
-    REQUIRE (my_J.get_string()==std::string("J"));
-
+    REQUIRE (mix_ratio.get_si_string()=="1");
+    REQUIRE (mix_ratio.to_string()=="kg/kg");
+    REQUIRE ((m*mix_ratio).to_string()=="m*(kg/kg)");
+    REQUIRE ((m*mix_ratio).get_si_string()=="m");
   }
 
   SECTION ("issue-52") {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In EAMxx, we use units such as `kg/kg`, to represent "mixing ratios". Since the `Units` class would interpret this as a non-dimensional unit, we allowed to set a string representation:
```c++
Units mix_ratio = kg/kg;
mix_ratio.set_string("kg/kg");
```
Over time, this has become a bit annoying. This PR changes the handling of the string representation altogether. Here's a summary of the mods:

- changed `to_string` from a free function to a method, for `Units`, `ScalingFactor`, and `RationalConstant`
- added `get_si_string` to get the representation of the `Units` obj in terms of fundamental SI units.
- the overload of `*`,`/`,`^` ops for `Units` will simply "compount" the string representation of the two terms.

For instance:
```c++
Units blah = m*kg/kg;
std::cout << blah.to_string(); // prints "m*(kg/kg)"
std::cout << blah.get_si_string(); // prints "m"
```
The user can still set funky string representation at construction time:
```c++
Units blah (kg/kg*kg/kg,"?!?");
std::cout << (m*blah/s).to_string(); // prints "(m*?!?)/s"
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added some testing for the string representatin

## Additional Information
This PR breaks current code, since the free functions `to_string(X)`, for X=`Units`, `ScalingFactor`, and `RationalConstant` has been removed in favor of a class method.