### PR TITLE
Make index_and_shift guard against OOB access in debug mode

### DIFF
--- a/src/ekat/ekat_pack_kokkos.hpp
+++ b/src/ekat/ekat_pack_kokkos.hpp
@@ -18,7 +18,7 @@ namespace ekat {
 template<typename Array1, typename IdxPack> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<IdxPack, Pack<typename Array1::non_const_value_type, IdxPack::n> >
 index (const Array1& a, const IdxPack& i0,
-       typename std::enable_if<Array1::Rank == 1>::type* = nullptr) {
+       typename std::enable_if<Array1::rank == 1>::type* = nullptr) {
   Pack<typename Array1::non_const_value_type, IdxPack::n> p;
   vector_simd for (int i = 0; i < IdxPack::n; ++i)
     p[i] = a(i0[i]);
@@ -28,7 +28,7 @@ index (const Array1& a, const IdxPack& i0,
 template<typename Array2, typename IdxPack> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<IdxPack, Pack<typename Array2::non_const_value_type, IdxPack::n> >
 index (const Array2& a, const IdxPack& i0, const IdxPack& i1,
-       typename std::enable_if<Array2::Rank == 2>::type* = nullptr) {
+       typename std::enable_if<Array2::rank == 2>::type* = nullptr) {
   Pack<typename Array2::non_const_value_type, IdxPack::n> p;
   vector_simd for (int i = 0; i < IdxPack::n; ++i)
     p[i] = a(i0[i], i1[i]);
@@ -38,7 +38,7 @@ index (const Array2& a, const IdxPack& i0, const IdxPack& i1,
 template<typename Array3, typename IdxPack> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<IdxPack, Pack<typename Array3::non_const_value_type, IdxPack::n> >
 index (const Array3& a, const IdxPack& i0, const IdxPack& i1, const IdxPack& i2,
-       typename std::enable_if<Array3::Rank == 3>::type* = nullptr) {
+       typename std::enable_if<Array3::rank == 3>::type* = nullptr) {
   Pack<typename Array3::non_const_value_type, IdxPack::n> p;
   vector_simd for (int i = 0; i < IdxPack::n; ++i)
     p[i] = a(i0[i], i1[i], i2[i]);
@@ -48,7 +48,7 @@ index (const Array3& a, const IdxPack& i0, const IdxPack& i1, const IdxPack& i2,
 template<typename Array4, typename IdxPack> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<IdxPack, Pack<typename Array4::non_const_value_type, IdxPack::n> >
 index (const Array4& a, const IdxPack& i0, const IdxPack& i1, const IdxPack& i2, const IdxPack& i3,
-       typename std::enable_if<Array4::Rank == 4>::type* = nullptr) {
+       typename std::enable_if<Array4::rank == 4>::type* = nullptr) {
   Pack<typename Array4::non_const_value_type, IdxPack::n> p;
   vector_simd for (int i = 0; i < IdxPack::n; ++i)
     p[i] = a(i0[i], i1[i], i2[i], i3[i]);
@@ -58,7 +58,7 @@ index (const Array4& a, const IdxPack& i0, const IdxPack& i1, const IdxPack& i2,
 template<typename Array5, typename IdxPack> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<IdxPack, Pack<typename Array5::non_const_value_type, IdxPack::n> >
 index (const Array5& a, const IdxPack& i0, const IdxPack& i1, const IdxPack& i2, const IdxPack& i3, const IdxPack& i4,
-       typename std::enable_if<Array5::Rank == 5>::type* = nullptr) {
+       typename std::enable_if<Array5::rank == 5>::type* = nullptr) {
   Pack<typename Array5::non_const_value_type, IdxPack::n> p;
   vector_simd for (int i = 0; i < IdxPack::n; ++i)
     p[i] = a(i0[i], i1[i], i2[i], i3[i], i4[i]);
@@ -76,7 +76,7 @@ index (const Array5& a, const IdxPack& i0, const IdxPack& i1, const IdxPack& i2,
 template<int Shift, typename Array1, typename IdxPack> KOKKOS_INLINE_FUNCTION
 void
 index_and_shift (const Array1& a, const IdxPack& i0, Pack<typename Array1::non_const_value_type, IdxPack::n>& index, Pack<typename Array1::non_const_value_type, IdxPack::n>& index_shift,
-                 typename std::enable_if<Array1::Rank == 1>::type* = nullptr) {
+                 typename std::enable_if<Array1::rank == 1>::type* = nullptr) {
   vector_simd for (int i = 0; i < IdxPack::n; ++i) {
     const auto i0i = i0[i];
     index[i]       = a(i0i);

--- a/src/ekat/util/ekat_arch.cpp
+++ b/src/ekat/util/ekat_arch.cpp
@@ -73,7 +73,7 @@ std::string ekat_config_string () {
 #endif
   ss << " #host threads: " <<
 #ifdef KOKKOS_ENABLE_OPENMP
-         Kokkos::OpenMP::concurrency()
+         Kokkos::OpenMP().concurrency()
 #elif defined _OPENMP
          omp_get_max_threads()
 #else

--- a/tests/pack/pack_kokkos_tests.cpp
+++ b/tests/pack/pack_kokkos_tests.cpp
@@ -11,7 +11,7 @@
 namespace {
 
 template <typename View, int rank, typename T = void>
-using OnlyRank = typename std::enable_if<View::Rank == rank, T>::type;
+using OnlyRank = typename std::enable_if<View::rank == rank, T>::type;
 
 template <typename View>
 void fill(const View& a)
@@ -91,8 +91,8 @@ void do_index_test(const View& data)
   static constexpr int pack_size = Packn;
   using IdxPack = ekat::Pack<int, pack_size>;
   fill(data);
-  Kokkos::View<IdxPack[View::Rank]> idx("idx");
-  Kokkos::parallel_for(View::Rank, KOKKOS_LAMBDA(const int r) {
+  Kokkos::View<IdxPack[View::rank]> idx("idx");
+  Kokkos::parallel_for(View::rank, KOKKOS_LAMBDA(const int r) {
     for (int i = 0; i < pack_size; ++i) { idx(r)[i] = (r+2)*i; } // 2*i, 3*i, etc as rank increases
   });
 

--- a/tests/pack/pack_kokkos_tests.cpp
+++ b/tests/pack/pack_kokkos_tests.cpp
@@ -836,9 +836,9 @@ TEST_CASE("host_device_packs_3d", "ekat::pack")
 
 TEST_CASE("index_and_shift", "ekat::pack")
 {
-  static constexpr int pack_size = 8;
-  static constexpr int num_ints = 100;
-  static constexpr int shift = 2;
+  constexpr int pack_size = 8;
+  constexpr int num_ints = 100;
+  constexpr int shift = 2;
   using IntPack = ekat::Pack<int, pack_size>;
 
   Kokkos::View<int*> data("data", num_ints);
@@ -858,8 +858,29 @@ TEST_CASE("index_and_shift", "ekat::pack")
       ++errs;
     }
   }, nerr);
-
   REQUIRE(nerr == 0);
+
+#ifndef NDEBUG
+  // Check index_and_shift sets output to invalid in debug mode
+  auto data_h = Kokkos::create_mirror_view(data);
+  Kokkos::deep_copy(data_h,data);
+
+  auto data_s = ekat::scalarize(data_h);
+
+  const int num_packs = ekat::npack<IntPack>(num_ints);
+  for (int ipack=0; ipack<num_packs; ++ipack) {
+    auto range = ekat::range<IntPack>(ipack*pack_size);
+    IntPack data_i, data_ips;
+    ekat::index_and_shift<shift>(data_h,range,data_i,data_ips);
+    for (int n=0; n<pack_size; ++n) {
+      if ((range[n]+shift)<num_ints) {
+        REQUIRE(data_ips[n]==data_s[ipack*pack_size+n+shift]);
+      } else {
+        REQUIRE (ekat::is_invalid(data_ips[n]));
+      }
+    }
+  }
+#endif
 }
 
 } // namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Turning on kokkos debug checks cause `index_and_shift` to throw if the shift and indices are such that the input array is read OOB. This PR adds a check in debug mode, and, if we are accessing OOB, we set the output to an invalid number (to spot bad usage).

Also, I fixed usage of some deprecated kokkos code, which causes errors if one configures with `Kokkos_ENABLE_DEPRECATED_CODE_4=OFF`.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a test that, in debug mode, checks that OOB entries are set equal to `ekat::ScalarTraits<T>::invalid()`;
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
