### PR TITLE
Fix warnings in subview utils

### DIFF
--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -343,7 +343,7 @@ subview(const ViewLR<ST**, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim < v.rank);
+  assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -362,7 +362,7 @@ subview(const ViewLR<ST***, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim < v.rank);
+  assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -386,7 +386,7 @@ subview(const ViewLR<ST****, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim < v.rank);
+  assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -413,7 +413,7 @@ subview(const ViewLR<ST*****, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim < v.rank);
+  assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {
@@ -443,7 +443,7 @@ subview(const ViewLR<ST******, Props...>& v,
         const Kokkos::pair<int, int> &kp0,
         const int idim) {
   assert(v.data() != nullptr);
-  assert(idim >= 0 && idim < v.rank);
+  assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
          && kp0.second < v.extent_int(idim));
   if (idim == 0) {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
A comparison between signed and unsigned int was generating >10MB logs in eamxx standalone testing.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Manually verified this eliminates all ekat-related warnings in eamxx.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
