### PR TITLE
GetMpiDistributionName: Fix for cray MPI

### DIFF
--- a/cmake/EkatMpiUtils.cmake
+++ b/cmake/EkatMpiUtils.cmake
@@ -35,13 +35,16 @@ macro (GetMpiDistributionName DISTRO_NAME)
 
     execute_process (COMMAND ${COMPILER} -show RESULT_VARIABLE SUPPORTS_SHOW OUTPUT_QUIET ERROR_QUIET)
     execute_process (COMMAND ${COMPILER} --cray-print-opts=cflags RESULT_VARIABLE SUPPORTS_CRAY_PRINT_OPTS OUTPUT_QUIET ERROR_QUIET)
-    if (SUPPORTS_SHOW EQUAL 0)
-      # (mpicxx/mpicc/mpifort)-like MPI compiler
-      execute_process (COMMAND ${COMPILER} -show OUTPUT_VARIABLE TEMP)
-    elseif (SUPPORTS_CRAY_PRINT_OPTS EQUAL 0)
+    if (SUPPORTS_CRAY_PRINT_OPTS EQUAL 0)
+      # If cray print-opts works, we want that to take precedence over -show.
       # craype-like MPI wrapper compiler
       # Cray wrappers have different options from mpicxx
       execute_process (COMMAND ${COMPILER} --cray-print-opts=cflags OUTPUT_VARIABLE TEMP)
+
+    elseif (SUPPORTS_SHOW EQUAL 0)
+      # (mpicxx/mpicc/mpifort)-like MPI compiler
+      execute_process (COMMAND ${COMPILER} -show OUTPUT_VARIABLE TEMP)
+
     else()
       # unknow MPI compiler
       string (CONCAT msgs


### PR DESCRIPTION
If the cray-specific one works, that should take precedence over the generic one if they both succeed.

## Motivation

The case SMS.ne30pg2_ne30pg2.F2010-SCREAMv1.pm-gpu_nvidiagpu was failing due to GetMpiDistributionName failing to probe the distribution. The reason is that it was trying to use the `-show` output instead of the `--cray-print-opts=cflags`. Both commands succeeded but the -show one took precedence due to being checked first. I think this is wrong and the cray-specific one should take highest precedence if it works.

## Testing

SMS.ne30pg2_ne30pg2.F2010-SCREAMv1.pm-gpu_nvidiagpu make it past cmake configure (with a macro fix).