### PR TITLE
Make copy constructor/assignment of ParameterList do a deep_copy

### DIFF
--- a/src/ekat/ekat_parameter_list.cpp
+++ b/src/ekat/ekat_parameter_list.cpp
@@ -4,6 +4,45 @@
 
 namespace ekat {
 
+ParameterList::
+ParameterList (const ParameterList& src)
+{
+  m_name = src.m_name;
+  for (const auto& it : src.m_params) {
+    m_params[it.first] = it.second.clone();
+  }
+
+  for (const auto& it : src.m_sublists) {
+    m_sublists[it.first] = it.second;
+  }
+}
+
+ParameterList& ParameterList::operator= (const ParameterList& src)
+{
+  if (this!=&src) {
+    m_name = src.m_name;
+    for (const auto& it : src.m_params) {
+      m_params[it.first] = it.second.clone();
+    }
+
+    for (const auto& it : src.m_sublists) {
+      m_sublists[it.first] = it.second;
+    }
+  }
+  return *this;
+}
+
+ParameterList ParameterList::soft_copy () const
+{
+  ParameterList p;
+
+  p.m_name = m_name;
+  p.m_params = m_params;
+  p.m_sublists = m_sublists;
+
+  return p;
+}
+
 ParameterList& ParameterList::sublist (const std::string& name) {
   if (m_sublists.find(name)==m_sublists.end()) {
     ParameterList p(name);

--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -33,16 +33,19 @@ public:
 
   // Constructor(s) & Destructor
   ParameterList () = default;
+  ParameterList (const ParameterList& src);
   explicit ParameterList (const std::string& name) : m_name(name) {}
   ~ParameterList () = default;
 
-  ParameterList& operator= (const ParameterList&) = default;
+  ParameterList& operator= (const ParameterList&);
 
   // The name of the list
   const std::string& name () const { return m_name; }
 
   // Change the name of the list
   void rename (const std::string& name) { m_name = name; }
+
+  ParameterList soft_copy () const;
 
   // Parameters getters and setters
   template<typename T>

--- a/src/ekat/std_meta/ekat_std_any.hpp
+++ b/src/ekat/std_meta/ekat_std_any.hpp
@@ -32,6 +32,8 @@ class any {
     virtual const std::type_info& type () const = 0;
 
     virtual void print (std::ostream& os) const = 0;
+
+    virtual holder_base* clone () const = 0;
   };
 
   template <typename HeldType>
@@ -59,6 +61,10 @@ class any {
 
     HeldType& value () { return *m_value; }
     std::shared_ptr<HeldType> ptr () const { return m_value; }
+
+    holder_base* clone () const override {
+      return create(*m_value);
+    }
 
     void print (std::ostream& os) const {
       if (static_cast<bool>(m_value)) {
@@ -119,6 +125,12 @@ public:
   template<typename ConcreteType>
   bool isType () const {
     return std::type_index(content().type())==std::type_index(typeid(ConcreteType));
+  }
+
+  any clone() const {
+    any a;
+    a.m_content = std::shared_ptr<holder_base>(m_content->clone());
+    return a;
   }
 
   template<typename ConcreteType>

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_meta.hpp"
 #include "ekat/ekat_parameter_list.hpp"
@@ -9,6 +10,22 @@
 #include "ekat_test_config.h"
 
 namespace {
+
+TEST_CASE ("pl_copy") {
+  ekat::ParameterList pl;
+  auto& sub1 = pl.sublist("a");
+  sub1.set("int",0);
+
+  ekat::ParameterList pl2 = sub1;
+  sub1.get<int>("int") = 2;
+  REQUIRE (pl2.get<int>("int")==0);
+  pl2.set<int>("int",3);
+  REQUIRE (sub1.get<int>("int")==2);
+
+  auto pl3 = sub1.soft_copy();
+  sub1.set<int>("int",4);
+  REQUIRE (pl3.get<int>("int")==4);
+}
 
 TEST_CASE("precision", "util") {
   CHECK_FALSE(ekat::is_single_precision<double>::value);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Since parameters are stored via ekat::any, and ekat::any uses shared_ptr internally, a default copy constructor/assignment would simply copy the shared pointers, which means that the new list will share data with the old list for any existing parameter (new parameter added after the copy will be local to each list though).

This PR makes the copy a deep one, so that changing the value of parameters in the original list will not be reflected in the new list (and vice versa). To allow sharing pointers, I added a `soft_copy` method, in case sharing data is desired. Notice though that a soft copy will not share the stored maps (string->params and string->sublist), but simply copy them (which, as explained above, means existing params will be shared).
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
I kind of need this to allow easier usage of pyeamxx in SCREAM repo

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a test to verify that the copy constructor/assignment does not cause to share data with the original parameter list.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
