### PR TITLE
Fix unused var warning in release build

### DIFF
--- a/src/ekat/util/ekat_scaling_factor.hpp
+++ b/src/ekat/util/ekat_scaling_factor.hpp
@@ -58,6 +58,7 @@ struct ScalingFactor {
     // If we have denominators or are negative, add parentheses, for clarity
     int sz_out = sz1 + (e_one ? 0 : sz2+1 + (b_den_or_neg ? 2 : 0) + (e_den_or_neg ? 2 : 0));
     assert ( sz_out<N );
+    (void) sz_out;
 
     std::array<char,N> out = {'\0'};
     int pos = 0;

--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -201,6 +201,7 @@ private:
                         + (comp1 ? 2 : 0)
                         + (comp2 ? 2 : 0);
     assert (size_out<UNITS_MAX_STR_LEN);
+    (void) size_out;
 
     int pos=0;
     if (comp1) {

--- a/tests/algorithm/tridiag_tests_correctness.cpp
+++ b/tests/algorithm/tridiag_tests_correctness.cpp
@@ -433,7 +433,7 @@ void run_test_configs (Fn& fn) {
         fn(tc);
       }
     } else {
-      const int concurrency = Kokkos::DefaultExecutionSpace::concurrency();
+      const int concurrency = Kokkos::DefaultExecutionSpace().concurrency();
       const int n_kokkos_thread = concurrency;
       for (const int n_kokkos_vec : {1, 2}) {
         tc.n_kokkos_thread = n_kokkos_thread;

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -290,7 +290,7 @@ void test_view_reduction(const int begin=0, const int end=TotalSize)
 
   Kokkos::View<Scalar*> results ("results", 1);
 
-  int team_size = ExeSpace::concurrency();
+  int team_size = ExeSpace().concurrency();
 #ifdef EKAT_ENABLE_GPU
   ExeSpace temp_space;
   #ifdef KOKKOS_ENABLE_SYCL

--- a/tests/kokkos/workspace_tests.cpp
+++ b/tests/kokkos/workspace_tests.cpp
@@ -32,7 +32,7 @@ static void unittest_workspace_overprovision()
 
   using WSM = WorkspaceManager<Real, Device>;
 
-  const int max_threads = ExeSpace::concurrency();
+  const int max_threads = ExeSpace().concurrency();
   const int nk = OnGpu<ExeSpace>::value ? 128 : (max_threads < 7 ? max_threads : 7);
 
   const auto temp_policy = ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(1, nk);
@@ -386,7 +386,7 @@ static void unittest_workspace()
   #ifdef WS_EXPENSIVE_TEST
       if (true)
   #else
-      if ( ExeSpace::concurrency() == 2 ) // the test below is expensive, we don't want all threads sweeps to run it
+      if ( ExeSpace().concurrency() == 2 ) // the test below is expensive, we don't want all threads sweeps to run it
   #endif
       {
         // Test weird take/release permutations.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Some warnings are for deprecated kokkos code, which can be errors if we decide to set Kokkos_ENABLE_DEPRECATED_CODE_4=OFF.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
