### PR TITLE
Fix RepackType when packing const scalar data

### DIFF
--- a/src/ekat/ekat_pack_kokkos.hpp
+++ b/src/ekat/ekat_pack_kokkos.hpp
@@ -233,7 +233,7 @@ template<int N, typename OldType>
 struct RepackType {
   using type =
     typename std::conditional<std::is_const<OldType>::value,
-                              const Pack<OldType,N>,
+                              const Pack<std::remove_const_t<OldType>,N>,
                               Pack<OldType,N>>::type;
 };
 

--- a/tests/pack/pack_kokkos_tests.cpp
+++ b/tests/pack/pack_kokkos_tests.cpp
@@ -218,47 +218,59 @@ TEST_CASE("repack", "ekat::pack") {
   using ekat::Pack;
   using ekat::repack;
 
-  typedef Kokkos::View<Pack<double, 16>*> Array1;
-  typedef Kokkos::View<Pack<double, 32>**> Array2;
+  using Array1 = Kokkos::View<Pack<double, 16>*>;
+  using Array2 = Kokkos::View<Pack<double, 32>**>;
+  using CArray1 = Kokkos::View<Pack<double, 16>*>;
+  using CArray2 = Kokkos::View<Pack<double, 32>**>;
 
   {
     const Array1 a1("a1", 10);
     fill(a1);
 
-    const auto a2 = repack<8>(a1);
-    repack_test<8>(a1, a2);
+    auto run_test = [](const auto v1) {
+      const auto v2 = repack<8>(v1);
+      repack_test<8>(v1, v2);
 
-    const auto a3 = repack<4>(a2);
-    repack_test<4>(a2, a3);
+      const auto v3 = repack<4>(v2);
+      repack_test<4>(v2, v3);
 
-    const auto a4 = repack<2>(a3);
-    repack_test<2>(a3, a4);
+      const auto v4 = repack<2>(v3);
+      repack_test<2>(v3, v4);
 
-    const auto a5 = repack<2>(a1);
-    repack_test<2>(a1, a5);
+      const auto v5 = repack<2>(v1);
+      repack_test<2>(v1, v5);
 
-    const auto a6 = repack<16>(a1);
-    repack_test<16>(a1, a6);
+      const auto v6 = repack<16>(v1);
+      repack_test<16>(v1, v6);
+    };
+
+    run_test(a1);
+    run_test(CArray1(a1));
   }
 
   {
-    const Array2 a1("a1", 10, 4);
+    const Array2 a1("v1", 10, 4);
     fill(a1);
 
-    const auto a2 = repack<8>(a1);
-    repack_test<8>(a1, a2);
+    auto run_test = [](const auto v1) {
+      const auto v2 = repack<8>(v1);
+      repack_test<8>(v1, v2);
 
-    const auto a3 = repack<4>(a2);
-    repack_test<4>(a2, a3);
+      const auto v3 = repack<4>(v2);
+      repack_test<4>(v2, v3);
 
-    const auto a4 = repack<2>(a3);
-    repack_test<2>(a3, a4);
+      const auto v4 = repack<2>(v3);
+      repack_test<2>(v3, v4);
 
-    const auto a5 = repack<2>(a1);
-    repack_test<2>(a1, a5);
+      const auto v5 = repack<2>(v1);
+      repack_test<2>(v1, v5);
 
-    const auto a6 = repack<32>(a1);
-    repack_test<32>(a1, a6);
+      const auto v6 = repack<32>(v1);
+      repack_test<32>(v1, v6);
+    };
+
+    run_test(a1);
+    run_test(CArray2(a1));
   }
 }
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Calling `repack` passing a view of const scalar data type (not a `const Pack<T,N>`) in LinInterp::setup was causing an error, since the output of `repack` was a `View<const Pack<const T,N>,...>`, which is not compatible with what `setup_impl` expected, which is `View<const Pack<T,N>>`. The fix is very quick, though, and I manually verified that I can now call LinInterp::setup passing views of const doubles.

Note: everything was already working fine passing views of const packs, since the meta utility `RepackType` was already handling const correctly for pack types.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

