### PR TITLE
Avoid running compute-sanitizer in very large kernel

### DIFF
--- a/tests/ekat_test_config.h.in
+++ b/tests/ekat_test_config.h.in
@@ -29,4 +29,7 @@ using Real = float;
 // Whether fp model is strict
 #cmakedefine01 EKAT_TEST_STRICT_FP
 
+// Whether or not tests will be run with nvidia's compute-sanitizer tool
+#cmakedefine EKAT_ENABLE_COMPUTE_SANITIZER
+
 #endif

--- a/tests/kokkos/workspace_tests.cpp
+++ b/tests/kokkos/workspace_tests.cpp
@@ -122,7 +122,14 @@ static void unittest_workspace()
   using namespace ekat;
 
   unittest_workspace_overprovision();
+  
+#ifndef EKAT_ENABLE_COMPUTE_SANITIZER  
+  // This function executes a kernel over quite a large range, causing 
+  // the compute-sanitizer tool to take a long time (~25min).
+  // Disable in that case, all WSM functions will be run through 
+  // the sanitizer in the other kernels from this unit test.
   unittest_workspace_idx_lock();
+#endif
 
   static constexpr const int n_slots_per_team = 4;
   const int ni = 128;


### PR DESCRIPTION
## Motivation
Trying to shorten the time taken by compute sanitizer nightlies for EAMxx. The WSM unit test contains a kernel over a large range that would take the racecheck tool ~25 min to complete. I don't think there is any value in running that kernel through the sanitizer since the other kernels in that unit test will run through all the WSM src code, and take on the order of a few seconds. This is the only ekat test that takes over a few seconds.