### PR TITLE
fix unused warnings in release builds

### DIFF
--- a/src/ekat/util/ekat_scaling_factor.hpp
+++ b/src/ekat/util/ekat_scaling_factor.hpp
@@ -56,9 +56,7 @@ struct ScalingFactor {
     auto e_one = exp==RationalConstant::one();
 
     // If we have denominators or are negative, add parentheses, for clarity
-    int sz_out = sz1 + (e_one ? 0 : sz2+1 + (b_den_or_neg ? 2 : 0) + (e_den_or_neg ? 2 : 0));
-    assert ( sz_out<N );
-    (void) sz_out;
+    assert ( sz1 + (e_one ? 0 : sz2+1 + (b_den_or_neg ? 2 : 0) + (e_den_or_neg ? 2 : 0)) < N );
 
     std::array<char,N> out = {'\0'};
     int pos = 0;

--- a/src/ekat/util/ekat_units.hpp
+++ b/src/ekat/util/ekat_units.hpp
@@ -197,11 +197,8 @@ private:
     } else if (size2==0) {
       return lhs;
     }
-    const auto size_out = size1 + size2 + (sep=='\0' ? 0 : 1)
-                        + (comp1 ? 2 : 0)
-                        + (comp2 ? 2 : 0);
-    assert (size_out<UNITS_MAX_STR_LEN);
-    (void) size_out;
+
+    assert ( size1 + size2 + (sep == '\0' ? 0 : 1) + (comp1 ? 2 : 0) + (comp2 ? 2 : 0) < UNITS_MAX_STR_LEN );
 
     int pos=0;
     if (comp1) {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

reduce warnings in release builds

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

n/a

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->

n/a

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->

---

This was previously supposed to have been fixed but it was present on pm-gpu. See https://github.com/E3SM-Project/EKAT/pull/345/commits/d1f98cfba86b5a1e93315033b344af192af885cd. The sz_out is the one I had in my standalone shoc build.
