### PR TITLE
Improve EKAT_REQUIRE macro to allow passing exception type

### DIFF
--- a/src/ekat/ekat_assert.hpp
+++ b/src/ekat/ekat_assert.hpp
@@ -25,16 +25,19 @@
 #define EKAT_BACKTRACE __FILE__ << ":" << __LINE__
 #endif
 
-// Internal do not call directly
-#define IMPL_THROW(condition, msg, exception_type)    \
-  do {                                                \
-    if ( ! (condition) ) {                            \
-      std::stringstream _ss_;                         \
-      _ss_ << "\n FAIL:\n" << #condition  << "\n";   \
-      _ss_ << EKAT_BACKTRACE;                         \
-      _ss_ << "\n" << msg;                            \
-      throw exception_type(_ss_.str());               \
-    }                                                 \
+// Internal do not call directly.
+// NOTE: the ... at the end is to allow using EKAT_REQUIRE with
+//       a variadic number of args, adding placeholders at the end
+//       to ensure that the call to IMPL_THROW matches the signature
+#define IMPL_THROW(condition, msg, exception_type, ...)  \
+  do {                                                  \
+    if ( ! (condition) ) {                              \
+      std::stringstream _ss_;                           \
+      _ss_ << "\n FAIL:\n" << #condition  << "\n";      \
+      _ss_ << EKAT_BACKTRACE;                           \
+      _ss_ << "\n" << msg;                              \
+      throw exception_type(_ss_.str());                 \
+    }                                                   \
   } while(0)
 
 // SYCL cannot printf like the other backends quite yet
@@ -58,19 +61,29 @@
 #endif
 
 #ifndef NDEBUG
-#define EKAT_ASSERT(condition)                      IMPL_THROW(condition, "",  std::logic_error)
 #define EKAT_ASSERT_MSG(condition, msg)             IMPL_THROW(condition, msg, std::logic_error)
-#define EKAT_KERNEL_ASSERT(condition)               IMPL_KERNEL_THROW(condition, "")
 #define EKAT_KERNEL_ASSERT_MSG(condition, msg)      IMPL_KERNEL_THROW(condition, msg)
 #else
-#define EKAT_ASSERT(condition)  ((void) (0))
 #define EKAT_ASSERT_MSG(condition, msg)  ((void) (0))
-#define EKAT_KERNEL_ASSERT(condition) ((void) (0))
 #define EKAT_KERNEL_ASSERT_MSG(condition, msg) ((void) (0))
 #endif
 
-#define EKAT_REQUIRE(condition)                       IMPL_THROW(condition, "", std::logic_error)
-#define EKAT_REQUIRE_MSG(condition, msg)              IMPL_THROW(condition, msg, std::logic_error)
+#define EKAT_ASSERT(condition)          EKAT_ASSERT_MSG(condition, "")
+#define EKAT_KERNEL_ASSERT(condition)   EKAT_KERNEL_ASSERT_MSG(condition, "")
+
+#define EKAT_COUNT_ARGS_IMPL(_1, _2, _3, N, ...) N
+#define EKAT_COUNT_ARGS(...)  EKAT_COUNT_ARGS_IMPL(__VA_ARGS__, 3, 2, 1, 0)
+
+// NOTE: in the else, if __VA_ARGS__ has length 2, std::logic_error will NOT be used
+#define EKAT_REQUIRE(condition,...) \
+  do { \
+    if (EKAT_COUNT_ARGS(__VA_ARGS__)==0) { \
+      IMPL_THROW(condition, "", std::logic_error); \
+    } else { \
+      IMPL_THROW(condition, __VA_ARGS__, std::logic_error); \
+    } \
+  } while(0)
+#define EKAT_REQUIRE_MSG(condition,msg) EKAT_REQUIRE (condition,msg)
 
 #define EKAT_KERNEL_REQUIRE(condition)                IMPL_KERNEL_THROW(condition, "")
 #define EKAT_KERNEL_REQUIRE_MSG(condition, msg)       IMPL_KERNEL_THROW(condition, msg)

--- a/tests/utils/debug_tools_tests.cpp
+++ b/tests/utils/debug_tools_tests.cpp
@@ -178,6 +178,14 @@ TEST_CASE ("fpes","") {
   }
 }
 
+class MyException : public std::exception {
+public:
+  MyException(const std::string& s) : msg(s) {}
+  const char* what() const noexcept override { return msg.c_str(); }
+
+  std::string msg;
+};
+
 TEST_CASE ("assert-macros") {
   printf ("*) testing assert macros...\n");
   auto test_req_msg = [](const bool test, const std::string& msg) {
@@ -186,11 +194,16 @@ TEST_CASE ("assert-macros") {
   auto test_err_msg = [](const std::string& msg) {
     EKAT_ERROR_MSG(msg);
   };
+  auto test_with_etype = [](const bool test, const std::string& msg) {
+    EKAT_REQUIRE (test,msg,MyException);
+  };
   REQUIRE_THROWS (test_req_msg(1>3,"Uh? I wonder what Sharkowsky would have to say about this...\n"));
 
   REQUIRE_NOTHROW (test_req_msg(3>1,"Uh? I wonder what Sharkowsky would have to say about this...\n"));
 
   REQUIRE_THROWS (test_err_msg("Hello world!\n"));
+
+  REQUIRE_THROWS_AS (test_with_etype(1>3,"What?"),MyException);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
## Motivation
When doing unit tests, I often check that exceptions are raised when appropriate, via something like
```c++
  REQUIRE_THROWS (some_call_which_throws());
```
But if the function can throw at several points in its execution, this check may not verify the desired behavior. E.g., consdider this
```c++
void func (int i, int j) {
  EKAT_REQUIRE_MSG (i>0, "wrong i");
  EKAT_REQUIRE_MSG (j>0, "wrong j");
}
TEST_CASE ("my-test")
{
  int i=2, j=3;
  func(i,j); // This should work
  
  i = -1;
  REQUIRE_THROWS (func(i,j)); // should fail b/c i<=0
  j = -1;
  REQUIRE_THROWS (func(i,j)); // should fail b/c j<=0
}
```
The second `REQUIRE_THROWS` _will_ throw, but NOT b/c `j<0`, bur rather b/c `i<0`, since we did not change its value back to 2.

With this PR, I can do
```c++
class ExceptionA : public std::runtime_error {};
class ExceptionB : public std::logic_error {};
void func (int i, int j) {
  EKAT_REQUIRE_MSG (i>0, "wrong i",ExceptionA);
  EKAT_REQUIRE_MSG (j>0, "wrong j",ExceptionB);
}
TEST_CASE ("my-test")
{
  int i=2, j=3;
  func(i,j); // This should work
  
  i = -1;
  REQUIRE_THROWS_AS (func(i,j),ExceptionA); // should fail b/c i<=0
  j = -1;
  REQUIRE_THROWS_AS (func(i,j),ExceptionB); // should fail b/c j<=0
}
```
Now, the test will fail, since the 2nd `REQUIRE_THROWS` will still throw `ExceptionA`.

Note: this change is backward compatible.

## Testing
I added a unit test that verifies we can now throw a user-defined exception type.