### PR TITLE
Fix variadic EKAT_REQUIRE macro

### DIFF
--- a/tests/utils/debug_tools_tests.cpp
+++ b/tests/utils/debug_tools_tests.cpp
@@ -204,6 +204,11 @@ TEST_CASE ("assert-macros") {
   REQUIRE_THROWS (test_err_msg("Hello world!\n"));
 
   REQUIRE_THROWS_AS (test_with_etype(1>3,"What?"),MyException);
+
+  // Make sure these compile
+  EKAT_REQUIRE (2>0);
+  EKAT_REQUIRE (2>0, "some string");
+  EKAT_REQUIRE (2>0, "some string", std::logic_error);
 }
 
 } // anonymous namespace


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The implementation added in PR #354 was wrong, and it wasn't detected until I checked out that branch in EAMxx. Namely, the error was due to how `__VA_ARGS__` expands. Instead of passing it to `IMPL_THROW`, we should JUST use it to detect which macro to call. The new impl does just that, with three shorthand versions of EKAT_REQUIRE.

Also, I changed the default exception type to runtime_error, since it's more general than logic_error.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a call to the three versions of EKAT_REQUIRE in a test, to ensure they all compile correctly.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
