### PR TITLE
Adjacent difference utility

### DIFF
--- a/tests/pack/CMakeLists.txt
+++ b/tests/pack/CMakeLists.txt
@@ -1,22 +1,24 @@
 include(EkatCreateUnitTest)
 
-# Test packs
-set (PACK_TESTS_SRCS
-  pack_tests.cpp
-  pack_kokkos_tests.cpp
-)
-
 if (EKAT_TEST_DOUBLE_PRECISION)
-  EkatCreateUnitTest(packs${DP_POSTFIX} "${PACK_TESTS_SRCS}"
+  EkatCreateUnitTest(pack${DP_POSTFIX} pack_tests.cpp
+    LIBS ekat
+    COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
+  )
+  EkatCreateUnitTest(pack_kokkos${DP_POSTFIX} pack_kokkos_tests.cpp
     LIBS ekat
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
   )
 endif ()
 
 if (EKAT_TEST_SINGLE_PRECISION)
-  EkatCreateUnitTest(packs${SP_POSTFIX} "${PACK_TESTS_SRCS}"
+  EkatCreateUnitTest(pack${SP_POSTFIX} pack_tests.cpp
     LIBS ekat
-    COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
+    COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
+  )
+  EkatCreateUnitTest(pack_kokkos${SP_POSTFIX} pack_kokkos_tests.cpp
+    LIBS ekat
+    COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
   )
 endif ()
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The function `index_and_shift` is often used simply to compute something like `v(i+1)-v(i)`. This can make the code hide a bit the meaning.

This PR adds the utility `adj_diff`, which, given a view (of either packs or scalars), computes ONE adjacent difference, at a given index. If the view is of scalars, it will return a single scalar (the difference at that index), while if the view is of packs it will return a pack of differences (starting at that index). There are two modes: forward and backward. In the scalar case, forward returns `v(index+1)-v(index)`, while backward returns `v(index)-v(index-1)`. In the packed case, `v(index+1)` and `v(index-1)` are replaced with the proper shift (left/right) of `v(index)`, padded with the correct value at the right/left of the pack.

The handling of the boundaries is rather simple, and assumes that the user will correctly discard the meaningless returned values. For instance, assuming a scalar view:
- Forward: for index=v.size()-1 (the last entry of the view) there is no "index+1" entry, so we use 0, which makes the fcn return simply `-v(last)`
- Backward: for index=0 (the first entry of the view) there is no "index-1" entry, so we use 0, which makes the fcn return simply `v(0)`

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
It could simplify some code in EAMxx

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a unit test for both scalar/packed views, also testing both the case where the view length is a multiple of the pack size or not.
<!--- 

Anything else we need to know in evaluating this pull request?
 -->
## Additional Information
I thought about making this utility act on all the entries of the view. While this may simplify some aspect of it (e.g., index refers to the _SCALAR_ entry in the scalar version, and to the _PACKED_ entry in the pack version), it would also add more complexity at the call site, having to make arrangements for a temp view. Not to mention the fact that the user would have to pass a range struct or a team obj, so that the function can dispatch the proper parallel_for inside. All in all, I think the "single-entry difference" version ("single" meaning a single scalar or a single pack) is the most flexible.