### PR TITLE
Implement "where" construct

### DIFF
--- a/src/ekat/ekat_pack.hpp
+++ b/src/ekat/ekat_pack.hpp
@@ -126,6 +126,15 @@ Mask<n> operator ! (const Mask<n>& m) {
   return not_m;
 }
 
+// Compare masks
+template <int n> KOKKOS_INLINE_FUNCTION
+bool operator == (const Mask<n>& m1, const Mask<n>& m2) {
+  Mask<n> out;
+  vector_simd for (int i=0; i<n; ++i)
+    out.set(i, m1[i]==m2[i]);
+  return out.all();
+}
+
 // Implementation detail for generating Pack assignment operators. _p means the
 // input is a Pack; _s means the input is a scalar.
 // NOTE: for volatile overload, you should return void. If not, if/when Kokkos

--- a/src/ekat/util/ekat_where.hpp
+++ b/src/ekat/util/ekat_where.hpp
@@ -64,7 +64,7 @@ public:
   bool all  () const { return m_mask; }
   bool none () const { return !m_mask; }
 private:
-  const mask_t&  m_mask;
+  const mask_t   m_mask;
   value_t&       m_value;
 };
 
@@ -174,7 +174,7 @@ public:
   bool all  () const { return m_mask.all(); }
   bool none () const { return m_mask.none(); }
 private:
-  const mask_t&  m_mask;
+  const mask_t   m_mask;
   value_t&       m_value;
 };
 

--- a/src/ekat/util/ekat_where.hpp
+++ b/src/ekat/util/ekat_where.hpp
@@ -1,0 +1,197 @@
+#ifndef EKAT_WHERE_HPP
+#define EKAT_WHERE_HPP
+
+#include "ekat/ekat_pack.hpp"
+
+namespace ekat
+{
+
+// No impl for the general case
+template<typename M, typename V>
+class where_expression;
+
+// Scalar case: the mask is just a bool
+template<typename V>
+class where_expression<bool,V>
+{
+public:
+  using mask_t = bool;
+  using value_t = V;
+
+  where_expression (const bool& m, V& v)
+   : m_mask (m) , m_value (v)
+  { /* Nothing to do here */ }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  value_t& value () { return m_value; }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  const mask_t& mask () const { return m_mask; }
+
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  value_t& operator=(const S rhs)  {
+    if (m_mask) m_value=rhs;
+    return m_value;
+  }
+
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  value_t& operator+=(const S rhs)  {
+    if (m_mask) m_value+=rhs;
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  value_t& operator-=(const S rhs)  {
+    if (m_mask) m_value-=rhs;
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  value_t& operator*=(const S rhs)  {
+    if (m_mask) m_value*=rhs;
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  value_t& operator/=(const S rhs)  {
+    if (m_mask) m_value/=rhs;
+    return m_value;
+  }
+
+  bool any  () const { return m_mask; }
+  bool all  () const { return m_mask; }
+  bool none () const { return !m_mask; }
+private:
+  const mask_t&  m_mask;
+  value_t&       m_value;
+};
+
+// Packed case: the mask is an ekat::Mask, and the value is an ekat::Pack
+
+template<int N, typename V>
+class where_expression<Mask<N>,Pack<V,N>>
+{
+public:
+  using mask_t = Mask<N>;
+  using value_t = Pack<V,N>;
+
+  where_expression (const mask_t& m, value_t& v)
+   : m_mask (m) , m_value (v)
+  { /* Nothing to do here */ }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  value_t& value () { return m_value; }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  const mask_t& mask () { return m_mask; }
+
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator=(const S rhs)  {
+    m_value.set(m_mask,rhs);
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator=(const Pack<S,N>& rhs)  {
+    m_value.set(m_mask,rhs);
+    return m_value;
+  }
+
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator+=(const S rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] += rhs;
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator+=(const Pack<S,N>& rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] += rhs[i];
+    return m_value;
+  }
+
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator-=(const S rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] -= rhs;
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator-=(const Pack<S,N>& rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] -= rhs[i];
+    return m_value;
+  }
+
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator*=(const S rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] *= rhs;
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator*=(const Pack<S,N>& rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] *= rhs[i];
+    return m_value;
+  }
+
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator/=(const S rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] /= rhs;
+    return m_value;
+  }
+  template<typename S>
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<std::is_convertible<V,S>::value,value_t&>::type
+  operator/=(const Pack<S,N>& rhs)  {
+    ekat_masked_loop(m_mask,i)
+      m_value[i] /= rhs[i];
+    return m_value;
+  }
+
+  bool any  () const { return m_mask.any(); }
+  bool all  () const { return m_mask.all(); }
+  bool none () const { return m_mask.none(); }
+private:
+  const mask_t&  m_mask;
+  value_t&       m_value;
+};
+
+template<typename S, int N>
+where_expression<Mask<N>,Pack<S,N>>
+where (const Mask<N>& m, Pack<S,N>& p)
+{
+  return where_expression<Mask<N>,Pack<S,N>>(m,p);
+}
+
+template<typename S>
+where_expression<bool,S>
+where (const bool& mask, S& scalar)
+{
+  return where_expression<bool,S>(mask,scalar);
+}
+
+} // namespace ekat
+
+#endif // EKAT_WHERE_HPP

--- a/tests/pack/CMakeLists.txt
+++ b/tests/pack/CMakeLists.txt
@@ -22,3 +22,6 @@ endif ()
 
 # Test pack index arithmetics utils
 EkatCreateUnitTest(pack_utils pack_utils_tests.cpp LIBS ekat)
+
+# Thest the where construct
+EkatCreateUnitTest(pack_where pack_where.cpp LIBS ekat)

--- a/tests/pack/pack_where.cpp
+++ b/tests/pack/pack_where.cpp
@@ -47,60 +47,110 @@ void run_packed_tests ()
 
   PT p1;
   for (int i=0; i<N; ++i) {
-    p1[i] = i;
+    p1[i] = 2*(i+1);
   }
-  const T tgt = N/2;
+
   const int half = N/2;
+  ekat::Mask<N> m (false);
+  for (int i=0; i<half; ++i)
+    m.set(i,true);
 
   PT p2 = p1;
+  PT p3 = -p1;
 
-  auto small_p = where(p1<tgt,p2);
+  auto p_masked = where(m,p2);
 
-  REQUIRE (small_p.any()==(N>1));
-  REQUIRE (not small_p.all());
-  REQUIRE (small_p.none()==(N==1));
-  REQUIRE ((small_p.value()==p2).all());
-  REQUIRE (small_p.mask()==(p1<tgt));
+  REQUIRE ((p_masked.value()==p2).all());
+  REQUIRE (p_masked.mask()==m);
+  REQUIRE (p_masked.any()==(N>1));
+  REQUIRE (not p_masked.all());
+  REQUIRE (p_masked.none()==(N==1));
 
-  small_p = -1;
+  // Assignment
+  p2 = p1;
+  p_masked = -1;   // = scalar
   for (int i=0; i<N/2; ++i) {
     REQUIRE (p2[i]==-1);
   }
   for (int i=half; i<N; ++i) {
-    REQUIRE (p2[i]==i);
+    REQUIRE (p2[i]==p1[i]);
   }
-
   p2 = p1;
-  small_p += 10;
+  p_masked = p3;   // = pack
   for (int i=0; i<N/2; ++i) {
-    REQUIRE (p2[i]==(p1[i]+10));
+    REQUIRE (p2[i]==p3[i]);
   }
   for (int i=half; i<N; ++i) {
     REQUIRE (p2[i]==p1[i]);
   }
 
+  // operator +=
   p2 = p1;
-  small_p -= 10;
+  p_masked += 2;  // += scalar
   for (int i=0; i<N/2; ++i) {
-    REQUIRE (p2[i]==(p1[i]-10));
+    REQUIRE (p2[i]==(p1[i]+2));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+  p2 = p1;
+  p_masked += p3;  // += pack
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==0);
   }
   for (int i=half; i<N; ++i) {
     REQUIRE (p2[i]==p1[i]);
   }
 
+  // operator -=
   p2 = p1;
-  small_p *= 10;
+  p_masked -= 2; // -= scalar
   for (int i=0; i<N/2; ++i) {
-    REQUIRE (p2[i]==(p1[i]*10));
+    REQUIRE (p2[i]==(p1[i]-2));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+  p2 = p1;
+  p_masked -= p3; // -= pack
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==2*p1[i]); // b/c p3=-p1
   }
   for (int i=half; i<N; ++i) {
     REQUIRE (p2[i]==p1[i]);
   }
 
+  // opeartor *=
   p2 = p1;
-  small_p /= 10;
+  p_masked *= 2; // *= scalar
   for (int i=0; i<N/2; ++i) {
-    REQUIRE (p2[i]==(p1[i]/10));
+    REQUIRE (p2[i]==(p1[i]*2));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+  p2 = p1;
+  p_masked *= p3; // *= pack
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==(-p1[i]*p1[i]));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+
+  // opeartor /=
+  p2 = p1;
+  p_masked /= 2; // /= scalar
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==(p1[i]/2));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+  p2 = p1;
+  p_masked /= p3; // /= pack
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==-1); // b/c p3=-p1
   }
   for (int i=half; i<N; ++i) {
     REQUIRE (p2[i]==p1[i]);

--- a/tests/pack/pack_where.cpp
+++ b/tests/pack/pack_where.cpp
@@ -1,0 +1,114 @@
+#include "catch2/catch.hpp"
+
+#include "ekat/util/ekat_where.hpp"
+
+template<typename T>
+void run_scalar_tests ()
+{
+  using namespace ekat;
+
+  T v1 = 0;
+  T v2 = 0;
+  auto zero_w = where (v1==0,v2);
+  auto one_w = where (v1==1,v2);
+
+  // Internals
+  REQUIRE (zero_w.mask());
+  REQUIRE (zero_w.value()==0);
+  REQUIRE (zero_w.any());
+  REQUIRE (zero_w.all());
+  REQUIRE (not zero_w.none());
+
+  REQUIRE (not one_w.mask());
+  REQUIRE (one_w.value()==0);
+  REQUIRE (not one_w.any());
+  REQUIRE (not one_w.all());
+  REQUIRE (one_w.none());
+
+  // assignment op
+  zero_w = 1;
+  REQUIRE (v2==1);
+
+  // op= calls
+  zero_w += 1;
+  REQUIRE (v2==2);
+  zero_w -= 1;
+  REQUIRE (v2==1);
+  zero_w *= 2;
+  REQUIRE (v2==2);
+  zero_w /= 2;
+  REQUIRE (v2==1);
+}
+
+template<typename T, int N>
+void run_packed_tests ()
+{
+  using PT = ekat::Pack<T,N>;
+
+  PT p1;
+  for (int i=0; i<N; ++i) {
+    p1[i] = i;
+  }
+  const T tgt = N/2;
+  const int half = N/2;
+
+  PT p2 = p1;
+
+  auto small_p = where(p1<tgt,p2);
+
+  REQUIRE (small_p.any()==(N>1));
+  REQUIRE (not small_p.all());
+  REQUIRE (small_p.none()==(N==1));
+  REQUIRE ((small_p.value()==p2).all());
+  REQUIRE (small_p.mask()==(p1<tgt));
+
+  small_p = -1;
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==-1);
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==i);
+  }
+
+  p2 = p1;
+  small_p += 10;
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==(p1[i]+10));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+
+  p2 = p1;
+  small_p -= 10;
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==(p1[i]-10));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+
+  p2 = p1;
+  small_p *= 10;
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==(p1[i]*10));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+
+  p2 = p1;
+  small_p /= 10;
+  for (int i=0; i<N/2; ++i) {
+    REQUIRE (p2[i]==(p1[i]/10));
+  }
+  for (int i=half; i<N; ++i) {
+    REQUIRE (p2[i]==p1[i]);
+  }
+}
+
+TEST_CASE("where") {
+  run_scalar_tests<double>();
+  run_packed_tests<double,1>();
+  run_packed_tests<double,16>();
+}


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Code that uses masked conditionals is not compatible with non-packed scalar types, and vicevers. That is, if an app has non-packed code
```c++
for (int i=0; i<len; ++i) {
  if (my_view_A(i) > 10) {
     my_view_B(i) += my_view_C(i) * my_view_D(i);
  }
}
```
supporting packed, masked loops requires dropping support for views of built in types. Of course, builtin can be supported via packs of length 1, but it is still hard coding Pack as a scalar type.


A `where_expression` is basically a reference to a LHS pack with a mask attached. Later, it can be updated (via arith ops), and the stored mask will be used to operate only on the desired entries. This effectively does the same job as the Pack methods `update` and similar, but the advantage is that we can specialize the `where_expression` for non-pack types, so that one single templated code base can work in the same way _without_ assuming anything on the templated scalar type. The helper function `where` is used to create a `where_expression`. For instance, the user can do

```c++
  auto w = where(A>10, B);
  w += C*D;
```
which performs `B+=C*D` only where `A>10`. The expression can be stored (as above) in case one wants to do the 2nd line (which requires the calculation of C*D even though A may be <=10 always) only if A>10 _somwhere_. Otherwise, one can just use it inline:

```c++
where(A>10,B) += C*D; // Shorter, but C*D will ALWAYS be computed, regardless of the A>10 mask entries
auto w = where(A>10,B);
if (w.any()) 
  w += C*D; // Only computes C*D if at least one entry of the mask is true
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added unit tests for where expressions.
<!--- 

Anything else we need to know in evaluating this pull request?
 -->
## Additional Information
I thought about not doing this, and instead switch ekat::Pack to be some sort of alias to Kokkos::simd types. In fact, this PR mimics the `where_expression` syntax of Kokkos. However, in Kokkos, simd types only exist (on CPU) for a length that matches the vector unit length on the current architecture (e.g., on SKX it will hard-code a vector length of 8), and resort to compiler intrinsics for all the operations. Since in Hommexx/EAMxx we discovered that there is little advantage in using those over simple Pack structures, the only way to have a "general-length" `where_expression` is to hand-roll our own. Fortunately, the impl is rather short.