### PR TITLE
Change name of an internal macro to avoid name clash

### DIFF
--- a/src/ekat/ekat_assert.hpp
+++ b/src/ekat/ekat_assert.hpp
@@ -101,8 +101,8 @@ void throw_exception(const std::string& msg)
 #define EKAT_REQUIRE_2(cond, msg)        IMPL_THROW(cond, msg, std::runtime_error)
 #define EKAT_REQUIRE_1(cond)             IMPL_THROW(cond, "" , std::runtime_error)
 
-#define GET_MACRO(_1, _2, _3, NAME, ...) NAME
-#define EKAT_REQUIRE(...) GET_MACRO(__VA_ARGS__, EKAT_REQUIRE_3, EKAT_REQUIRE_2, EKAT_REQUIRE_1)(__VA_ARGS__)
+#define EKAT_GET_REQUIRE_MACRO(_1, _2, _3, NAME, ...) NAME
+#define EKAT_REQUIRE(...) EKAT_GET_REQUIRE_MACRO(__VA_ARGS__, EKAT_REQUIRE_3, EKAT_REQUIRE_2, EKAT_REQUIRE_1)(__VA_ARGS__)
 
 #define EKAT_REQUIRE_MSG(condition,msg) \
   EKAT_REQUIRE (condition,msg)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The current name `GET_MACRO` is way too common. In fact, on SYCL, it clashes with an internal oneapi macro name. This PR makes the name ekat-specific.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed to merge E3SM-Project/E3SM#6916

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
