### PR TITLE
Allow to use where_expression inside min/max

### DIFF
--- a/src/ekat/util/ekat_where.hpp
+++ b/src/ekat/util/ekat_where.hpp
@@ -17,6 +17,7 @@ class where_expression<bool,V>
 public:
   using mask_t = bool;
   using value_t = V;
+  using scalar_t = typename ekat::ScalarTraits<value_t>::scalar_type;
 
   where_expression (const bool& m, V& v)
    : m_mask (m) , m_value (v)
@@ -27,6 +28,21 @@ public:
 
   KOKKOS_FORCEINLINE_FUNCTION
   const mask_t& mask () const { return m_mask; }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  scalar_t max (const scalar_t& v) const {
+    if (m_mask)
+      return impl::max(v,m_value);
+    else
+      return v;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  scalar_t min (const scalar_t& v) const {
+    if (m_mask)
+      return impl::min(v,m_value);
+    else
+      return v;
+  }
 
   template<typename S>
   KOKKOS_FORCEINLINE_FUNCTION
@@ -76,6 +92,7 @@ class where_expression<Mask<N>,Pack<V,N>>
 public:
   using mask_t = Mask<N>;
   using value_t = Pack<V,N>;
+  using scalar_t = typename ekat::ScalarTraits<value_t>::scalar_type;
 
   where_expression (const mask_t& m, value_t& v)
    : m_mask (m) , m_value (v)
@@ -170,6 +187,16 @@ public:
     return m_value;
   }
 
+  KOKKOS_FORCEINLINE_FUNCTION
+  scalar_t max (const scalar_t& v) const {
+    return ekat::max(m_mask,v,m_value);
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  scalar_t min (const scalar_t& v) const {
+    return ekat::min(m_mask,v,m_value);
+  }
+
   bool any  () const { return m_mask.any(); }
   bool all  () const { return m_mask.all(); }
   bool none () const { return m_mask.none(); }
@@ -190,6 +217,20 @@ where_expression<bool,S>
 where (const bool& mask, S& scalar)
 {
   return where_expression<bool,S>(mask,scalar);
+}
+
+template<typename M, typename V>
+typename where_expression<M,V>::scalar_t
+max (const where_expression<M,V>& w, const typename where_expression<M,V>::scalar_t& s)
+{
+  return w.max(s);
+}
+
+template<typename M, typename V>
+typename where_expression<M,V>::scalar_t
+min (const where_expression<M,V>& w, const typename where_expression<M,V>::scalar_t& s)
+{
+  return w.min(s);
 }
 
 } // namespace ekat

--- a/tests/pack/pack_where.cpp
+++ b/tests/pack/pack_where.cpp
@@ -38,6 +38,13 @@ void run_scalar_tests ()
   REQUIRE (v2==2);
   zero_w /= 2;
   REQUIRE (v2==1);
+
+  // max/min
+  v2 = 3;
+  REQUIRE (max(zero_w,2)==3);
+  REQUIRE (max(zero_w,4)==4);
+  REQUIRE (min(zero_w,2)==2);
+  REQUIRE (min(zero_w,4)==3);
 }
 
 template<typename T, int N>
@@ -155,6 +162,24 @@ void run_packed_tests ()
   for (int i=half; i<N; ++i) {
     REQUIRE (p2[i]==p1[i]);
   }
+
+  // max/min
+  ekat::Mask<N> even (false);
+  int min_even = 0, max_even = 0;
+  for (int i=0; i<N; ++i) {
+    p2[i] = i;
+    if (i % 2 == 0) {
+      even.set(i,true);
+      max_even = std::max(max_even,i);
+    }
+  }
+
+  auto p_even = where(even,p2);
+
+  REQUIRE (max(p_even,N)==N);
+  REQUIRE (max(p_even,-1)==max_even);
+  REQUIRE (min(p_even,-1)==-1);
+  REQUIRE (min(p_even,N)==min_even);
 }
 
 TEST_CASE("where") {

--- a/tests/pack/pack_where.cpp
+++ b/tests/pack/pack_where.cpp
@@ -165,21 +165,32 @@ void run_packed_tests ()
 
   // max/min
   ekat::Mask<N> even (false);
-  int min_even = 0, max_even = 0;
+  int min_at_even = 1, max_at_even = 0;
+  T sum_at_even = 0;
+  T prod_at_even = 1;
   for (int i=0; i<N; ++i) {
-    p2[i] = i;
+    p2[i] = i+1;
     if (i % 2 == 0) {
       even.set(i,true);
-      max_even = std::max(max_even,i);
+      max_at_even = std::max(max_at_even,i+1);
+      sum_at_even += p2[i];
+      prod_at_even *= p2[i];
     }
   }
 
-  auto p_even = where(even,p2);
+  auto p_at_even = where(even,p2);
 
-  REQUIRE (max(p_even,N)==N);
-  REQUIRE (max(p_even,-1)==max_even);
-  REQUIRE (min(p_even,-1)==-1);
-  REQUIRE (min(p_even,N)==min_even);
+  REQUIRE (max(p_at_even,N)==N);
+  REQUIRE (max(p_at_even,-1)==max_at_even);
+  REQUIRE (min(p_at_even,-1)==-1);
+  REQUIRE (min(p_at_even,N)==min_at_even);
+
+  // reductions
+  T sum = 0, prod = 1;
+  sum += p_at_even;
+  prod *= p_at_even;
+  REQUIRE (sum==sum_at_even);
+  REQUIRE (prod==prod_at_even);
 }
 
 TEST_CASE("where") {


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In view of using `where_expression` in EAMxx, we need to support min/max operation inside reduction loops. This PR allows to do `max(w,s)` where `w` is a `where_expression` and `s` is the scalar type associated to the the value type of the expression. Namely, for `where_expression<MaskT,ValueT>`, `s` is of type `ekat::ScalarTraits<ValueT>::scalar_type`. If `ValueT` is a built-in scalar, that's the same as `ValueT`, but for pack types, it returns the type of the pack entries. With this modification, we can do something like
```c++
using value_t = decltype(my_view(0));
using scalar_t = ekat::ScalarTraits<value_t>::scalar_type;
Kokkos::parallel_reduce (tvr, KOKKOS_LAMBDA(int k, scalar_t& lmax)
{
   w = where(my_view(k) > 1e-10);
   lmax = max(w,lmax);
},Kokkos::Max<scalar_t>(output));
```
This will work regardless of whether the input view stores packs or built-in scalars, allowing a) code that is more readable, and b) the possibility to change scalar type (e.g. pack vs double) without having to change the code.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a test in the "where" unit tests.
<!--- 
Anything else we need to know in evaluating this pull request?
 -->
## Additional Information
It may be interesting to implement overloads such as
```c++
template<typename M, typename V>
typename where_expression<M,V>::scalar_t
operator+= (typename where_expression<M,V>::scalar_t& lhs, const where_expression<M,V>& rhs);
```
Notice that this is different from doing `where += scalar`, in which the user almost certainly meant "add scalar to all active entries of the where expression". In `scalar += where`, there aren't really many ways to interpret the output. And it is probably useful in case one wants to do a masked sum reduction:
```c++
using value_t = decltype(my_view(0));
using scalar_t = ekat::ScalarTraits<value_t>::scalar_type;
scalar_t sum;
Kokkos::parallel_reduce (tvr, KOKKOS_LAMBDA(int k, scalar_t& lsum)
{
   lsum += where(my_view(k)>1e-10);
},sum);
```

@tcclevenger I think I may add that to this PR, since it's still a reduction of a where_expression with a scalar starting point, just a different reduction type (`+=` (or other op) instead of `max`/`min`). But you may start taking a look if you want.