### PR TITLE
Fix subview dim checks for multi slice

### DIFF
--- a/src/ekat/kokkos/ekat_subview_utils.hpp
+++ b/src/ekat/kokkos/ekat_subview_utils.hpp
@@ -345,7 +345,7 @@ subview(const ViewLR<ST**, Props...>& v,
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second < v.extent_int(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST**,Props...>>(Kokkos::subview(v, kp0, Kokkos::ALL));
   } else {
@@ -364,7 +364,7 @@ subview(const ViewLR<ST***, Props...>& v,
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second < v.extent_int(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST***,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL));
@@ -388,7 +388,7 @@ subview(const ViewLR<ST****, Props...>& v,
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second < v.extent_int(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST****,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
@@ -415,7 +415,7 @@ subview(const ViewLR<ST*****, Props...>& v,
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second < v.extent_int(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST*****,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL));
@@ -445,7 +445,7 @@ subview(const ViewLR<ST******, Props...>& v,
   assert(v.data() != nullptr);
   assert(idim >= 0 && idim < static_cast<int>(v.rank));
   assert(kp0.first >= 0 && kp0.first < kp0.second
-         && kp0.second < v.extent_int(idim));
+         && kp0.second <= v.extent_int(idim));
   if (idim == 0) {
     return Unmanaged<ViewLS<ST******,Props...>>(
       Kokkos::subview(v, kp0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -544,7 +544,7 @@ TEST_CASE("subviews") {
   }
 }
 
-TEST_CASE("multi-slice subviews") {
+TEST_CASE("multi-slice-subviews") {
   using kt = ekat::KokkosTypes<ekat::DefaultDevice>;
 
   const int i0 = 5;

--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -552,8 +552,8 @@ TEST_CASE("multi-slice subviews") {
   const int i2 = 3;
   const int i3 = 2;
   const int i4 = 1;
-  const int idx0[6] = {0, 3, 1, 0, 1, 0};
-  const int idx1[6] = {3, 5, 4, 2, 2, 1};
+  const int idx0[6] = {0, 4, 1, 0, 1, 0};
+  const int idx1[6] = {3, 6, 4, 2, 2, 1};
 
   auto p0 = Kokkos::make_pair<int, int>(idx0[0], idx1[0]);
   auto p1 = Kokkos::make_pair<int, int>(idx0[1], idx1[1]);


### PR DESCRIPTION
Multi slice indexing was asserting the "end" index was inclusive, when in fact to get the last possible slice, `end=view.extent(slice_dim)`.

## Related Issues
Needed for https://github.com/E3SM-Project/E3SM/pull/6981 (changes to subfield requests triggered the old assert erroneously).

## Testing
Changed test to trigger the error (w/o fix).
