### PR TITLE
Fix retrieval of SM count from cuda

### DIFF
--- a/tests/kokkos/kokkos_utils_tests.cpp
+++ b/tests/kokkos/kokkos_utils_tests.cpp
@@ -296,7 +296,7 @@ void test_view_reduction(const int begin=0, const int end=TotalSize)
   #ifdef KOKKOS_ENABLE_SYCL
   auto num_sm = temp_space.impl_internal_space_instance()->m_queue->get_device().get_info<sycl::info::device::max_compute_units>();
   #else
-  auto num_sm = temp_space.impl_internal_space_instance()->m_multiProcCount;
+  auto num_sm = temp_space.cuda_device_prop().multiProcessorCount;
   #endif
   team_size /= (ekat::is_single_precision<Real>::value ? num_sm*64 : num_sm*32);
 #endif


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The recent kokkos upgrade broke a test in ekat, a fact that was exposed by eamxx nightly testing (which also tests ekat). This PR fixes it.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Verified tests now build and run on ghci-snl-cuda's containerized e3sm machine.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
