### PR TITLE
Deprecate std_meta utility classes

### DIFF
--- a/src/ekat/ekat_parameter_list.cpp
+++ b/src/ekat/ekat_parameter_list.cpp
@@ -33,17 +33,6 @@ ParameterList& ParameterList::operator= (const ParameterList& src)
   return *this;
 }
 
-ParameterList ParameterList::soft_copy () const
-{
-  ParameterList p;
-
-  p.m_name = m_name;
-  p.m_params = m_params;
-  p.m_sublists = m_sublists;
-
-  return p;
-}
-
 ParameterList& ParameterList::sublist (const std::string& name) {
   if (m_sublists.find(name)==m_sublists.end()) {
     ParameterList p(name);

--- a/src/ekat/ekat_parameter_list.cpp
+++ b/src/ekat/ekat_parameter_list.cpp
@@ -1,4 +1,5 @@
 #include "ekat/ekat_parameter_list.hpp"
+#include "ekat/std_meta/ekat_std_utils.hpp"
 
 #include <ios>
 
@@ -8,12 +9,12 @@ ParameterList::
 ParameterList (const ParameterList& src)
 {
   m_name = src.m_name;
-  for (const auto& it : src.m_params) {
-    m_params[it.first] = it.second.clone();
+  for (const auto& [name,p] : src.m_params) {
+    m_params[name] = p;
   }
 
-  for (const auto& it : src.m_sublists) {
-    m_sublists[it.first] = it.second;
+  for (const auto& [name,sl] : src.m_sublists) {
+    m_sublists[name] = sl;
   }
 }
 
@@ -21,12 +22,12 @@ ParameterList& ParameterList::operator= (const ParameterList& src)
 {
   if (this!=&src) {
     m_name = src.m_name;
-    for (const auto& it : src.m_params) {
-      m_params[it.first] = it.second.clone();
+    for (const auto& [name,p] : src.m_params) {
+      m_params[name] = p;
     }
 
-    for (const auto& it : src.m_sublists) {
-      m_sublists[it.first] = it.second;
+    for (const auto& [name,sl] : src.m_sublists) {
+      m_sublists[name] = sl;
     }
   }
   return *this;
@@ -56,20 +57,35 @@ void ParameterList::print(std::ostream& out, const int indent, const int indent_
 
   out << tab << name() << ":\n";
   tab.append(indent_inc,' ');
-  for (auto it : m_params) {
-    out << std::showpoint << tab << it.first << ": " << it.second << "\n";
+  for (const auto& [name,p] : m_params) {
+    out << tab << name << ": ";
+
+    // Try a few common types
+         if (std::any_cast<int>(&p))     out << std::any_cast<int>(p);
+    else if (std::any_cast<float>(&p))   out << std::showpoint << std::any_cast<float>(p);
+    else if (std::any_cast<double>(&p))  out << std::showpoint << std::any_cast<double>(p);
+    else if (std::any_cast<bool>(&p))    out << std::boolalpha << std::any_cast<bool>(p);
+    else if (std::any_cast<std::vector<int>>(&p))     out << std::any_cast<std::vector<int>>(p);
+    else if (std::any_cast<std::vector<float>>(&p))   out << std::showpoint << std::any_cast<std::vector<float>>(p);
+    else if (std::any_cast<std::vector<double>>(&p))  out << std::showpoint << std::any_cast<std::vector<double>>(p);
+    else if (std::any_cast<std::vector<bool>>(&p))    out << std::boolalpha << std::any_cast<std::vector<bool>>(p);
+    else out << " (Cannot print type '" << p.type().name() << "')";
+
+    out << std::endl;
   }
-  for (auto it : m_sublists) {
-    it.second.print(out,indent+indent_inc,indent_inc);
+
+  for (const auto& [name,sl] : m_sublists) {
+    sl.print(out,indent+indent_inc,indent_inc);
   }
 }
 
-void ParameterList::import (const ParameterList& src) {
-  for (const auto& it : src.m_sublists) {
-    m_sublists[it.first] = it.second;
+void ParameterList::import (const ParameterList& src)
+{
+  for (const auto& [name,sl] : src.m_sublists) {
+    m_sublists[name] = sl;
   }
-  for (const auto& it : src.m_params) {
-    m_params[it.first] = it.second;
+  for (const auto& [name,p] : src.m_params) {
+    m_params[name] = p;
   }
 }
 

--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -45,8 +45,6 @@ public:
   // Change the name of the list
   void rename (const std::string& name) { m_name = name; }
 
-  ParameterList soft_copy () const;
-
   // Parameters getters and setters
   template<typename T>
   T& get (const std::string& name);

--- a/src/ekat/ekat_parameter_list.hpp
+++ b/src/ekat/ekat_parameter_list.hpp
@@ -1,11 +1,11 @@
 #ifndef EKAT_PARAMETER_LIST_HPP
 #define EKAT_PARAMETER_LIST_HPP
 
-#include "ekat/std_meta/ekat_std_any.hpp"
 #include "ekat/std_meta/ekat_std_map_key_iterator.hpp"
 #include "ekat_assert.hpp"
 
 #include <map>
+#include <any>
 
 namespace ekat {
 
@@ -83,7 +83,7 @@ public:
   void import (const ParameterList& src);
 
   // Access const iterators to stored data
-  using params_names_const_iter   = map_key_const_iterator<std::map<std::string,any>>;
+  using params_names_const_iter   = map_key_const_iterator<std::map<std::string,std::any>>;
   using sublists_names_const_iter = map_key_const_iterator<std::map<std::string,ParameterList>>;
 
   params_names_const_iter   params_names_cbegin ()   const { return params_names_const_iter(m_params.cbegin()); }
@@ -95,7 +95,7 @@ public:
 private:
 
   std::string                           m_name;
-  std::map<std::string,any>             m_params;
+  std::map<std::string,std::any>        m_params;
   std::map<std::string,ParameterList>   m_sublists;
 };
 
@@ -106,15 +106,15 @@ inline T& ParameterList::get (const std::string& name) {
   // Check entry exists
   EKAT_REQUIRE_MSG ( isParameter(name),
       "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
-  auto p = m_params[name];
-  EKAT_REQUIRE_MSG ( p.isType<T>(),
+  auto& p = m_params[name];
+  EKAT_REQUIRE_MSG ( std::any_cast<T>(&p),
       "Error! Attempting to access parameter using the wrong type.\n"
       "   - list name : " + m_name + "\n"
       "   - param name: " + name + "\n"
-      "   - param type: " + std::string(p.content().type().name()) + "\n"
+      "   - param type: " + std::string(p.type().name()) + "\n"
       "   - input type: " + std::string(typeid(T).name()) + "'.\n");
 
-  return any_cast<T>(p);
+  return *std::any_cast<T>(&p);
 }
 
 template<typename T>
@@ -122,32 +122,28 @@ inline const T& ParameterList::get (const std::string& name) const {
   EKAT_REQUIRE_MSG ( isParameter(name),
       "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
 
-  auto p = m_params.at(name);
-  EKAT_REQUIRE_MSG ( p.isType<T>(),
+  const auto& p = m_params.at(name);
+  EKAT_REQUIRE_MSG ( std::any_cast<T>(&p),
       "Error! Attempting to access parameter using the wrong type.\n"
       "   - list name : " + m_name + "\n"
       "   - param name: " + name + "\n"
-      "   - param type: " + std::string(p.content().type().name()) + "\n"
-      "   - input type: " + std::string(typeid(T).name()) + ".\n");
+      "   - param type: " + std::string(p.type().name()) + "\n"
+      "   - input type: " + std::string(typeid(T).name()) + "'.\n");
 
-  return any_cast<T>(p);
+  return *std::any_cast<T>(&p);
 }
 
 template<typename T>
 inline T& ParameterList::get (const std::string& name, const T& def_value) {
   if ( !isParameter(name) ) {
-    m_params[name].template reset<T>(def_value);
+    set(name,def_value);
   }
   return get<T>(name);
 }
 
 template<typename T>
 inline void ParameterList::set (const std::string& name, const T& value) {
-  if ( !isParameter(name) ) {
-    m_params[name].template reset<T>(value);
-  } else {
-    get<T>(name) = value;
-  }
+  m_params[name] = value;
 }
 
 template<typename T>
@@ -156,7 +152,7 @@ inline bool ParameterList::isType (const std::string& name) const {
   EKAT_REQUIRE_MSG ( isParameter(name),
       "Error! Key '" + name + "' not found in parameter list '" + m_name + "'.\n");
 
-  return m_params.at(name).isType<T>();
+  return std::any_cast<T>(&m_params.at(name));
 }
 
 } // namespace ekat

--- a/src/ekat/std_meta/ekat_std_any.hpp
+++ b/src/ekat/std_meta/ekat_std_any.hpp
@@ -22,7 +22,8 @@ namespace ekat {
 
 // ================ std::any ================= //
 
-class any {
+class [[deprecated("ekat::any will be removed in future releases; please, use std::any instead.")]]
+any {
 
   // Implementation detail of the any class
   class holder_base {

--- a/src/ekat/std_meta/ekat_std_enable_shared_from_this.hpp
+++ b/src/ekat/std_meta/ekat_std_enable_shared_from_this.hpp
@@ -41,7 +41,8 @@ namespace ekat {
  */
 
 template<typename T>
-class enable_shared_from_this
+class [[deprecated("ekat::enable_shared_from_this will be removed in future releases; please, use std::enable_shared_from_this instead.")]]
+enable_shared_from_this
 {
 public:
 

--- a/tests/utils/util_tests.cpp
+++ b/tests/utils/util_tests.cpp
@@ -21,10 +21,6 @@ TEST_CASE ("pl_copy") {
   REQUIRE (pl2.get<int>("int")==0);
   pl2.set<int>("int",3);
   REQUIRE (sub1.get<int>("int")==2);
-
-  auto pl3 = sub1.soft_copy();
-  sub1.set<int>("int",4);
-  REQUIRE (pl3.get<int>("int")==4);
 }
 
 TEST_CASE("precision", "util") {


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The `ekat::any` and `ekat::enable_shared_from_this` classes were introduced out of necessity when we were still requiring only C++14. The former did not exist at all in C++14, while the latter was missing the important member `weak_from_this`. A while ago we have started requiring C++17 (namely, when Kokkos started mandating it), where these two classes are present, and offer all the functionalities we need.

At this point, there really isn't a reason for these classes to still be shipped by ekat. We are deprecating them (rather than removing them), to give people time to transition away. We should plan an official ekat release (maybe with some documentation) in the next few months. I don't think we have a release or tag anywhere, so it's time to do that anyways.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
