### PR TITLE
Add all_libs target to the export list

### DIFF
--- a/cmake/EkatConfig.cmake.in
+++ b/cmake/EkatConfig.cmake.in
@@ -2,6 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 
+# Make the install prefix available
+set (EKAT_PREFIX @CMAKE_INSTALL_PREFIX@)
+
 ###############################
 #      TPLs dependencies      #
 ###############################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,3 +49,6 @@ if (EKAT_ENABLE_YAML_PARSER)
 endif()
 
 add_subdirectory(testing-support)
+
+install (TARGETS ekat_all_libs
+         EXPORT  EkatTargets)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
A customer of EKAT (Haero) is linking against ekat::AllLibs, but that means that the target (ekat_all_libs) must be added to the EXPORT list.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Tested with haero and its downstream customer mam4xx
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
