### PR TITLE
Fix bug related to omp

### DIFF
--- a/src/kokkos/ekat_kokkos_session.cpp
+++ b/src/kokkos/ekat_kokkos_session.cpp
@@ -54,8 +54,6 @@ std::string kokkos_config_string ()
 
 #ifdef KOKKOS_ENABLE_OPENMP
   int num_host_threads = Kokkos::OpenMP().concurrency();
-#elif defined _OPENMP
-  int num_host_threads = omp_get_max_threads();
 #else
   int num_host_threads = 1;
 #endif


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
There's an inconsistency in how we handle the _OPENMP macro. Before the refactor PR, we also printed host thread info even if KOKKOS_ENABLE_OPENMP wasn't defined but _OPENMP was.

Here, we decide that if KOKKOS_ENABLE_OPENMP is not defined, we do not print omp settings, even if _OPENMP is defined, as those have nothing to do with the kokkos (and therefore EKAT) configuration.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed to fix next build fails in E3SM

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
