### PR TITLE
Fix missing header in installed ekats

### DIFF
--- a/src/kokkos/CMakeLists.txt
+++ b/src/kokkos/CMakeLists.txt
@@ -47,6 +47,7 @@ set (HEADERS
   ekat_kokkos_types.hpp
   ekat_math_utils.hpp
   ekat_subview_utils.hpp
+  ekat_kokkos_str_utils.hpp
   ekat_team_policy_utils.hpp
   ekat_upper_bound.hpp
   ekat_view_utils.hpp


### PR DESCRIPTION
## Motivation

The sharedlib build for Ekat installs the package. I discovered E3SM didn't build due to a missing header.

## Testing
By hand, E3SM builds with this change.