### PR TITLE
Add ability to broadcast views to higher-dimensional arrays

### DIFF
--- a/src/kokkos/ekat_view_broadcast.hpp
+++ b/src/kokkos/ekat_view_broadcast.hpp
@@ -22,6 +22,12 @@ public:
   using view_type  = Unmanaged<ToView>;
   using reference_type = typename view_type::reference_type;
 
+  // Broadcast an input view to the type provided by the class template arg
+  //  - from_v: view to be broadcasted
+  //  - extents: list of extents of the outfacing view (of type ToView).
+  //    Must have rank=ToView::rank(). Must contain FromView::rank() entries
+  //    that are <=0, which signal that those dimensions' extents will be
+  //    retrieved from the input view.
   template<typename FromView>
   ViewBroadcast (const FromView& from_v,
                  const std::vector<int>& extents)
@@ -29,6 +35,9 @@ public:
     constexpr int from_rank = FromView::rank();
     constexpr int to_rank = ToView::rank();
 
+    EKAT_REQUIRE_MSG (from_rank>=1,
+        "[ViewBroadcast] Error! FromView rank must be at least 1.\n"
+        " FromView::rank(): " << FromView::rank() << "\n");
     EKAT_REQUIRE_MSG (from_rank<=to_rank,
         "[ViewBroadcast] Error! FromView rank exceeds ToView rank.\n"
         " FromView::rank(): " << FromView::rank() << "\n"
@@ -41,46 +50,113 @@ public:
         "[ViewBroadcast] Badly sized extents vector.\n");
 
     // Init all dims as "ignored", then set up the ones actually picked
-    typename ToView::traits::array_layout impl_layout,shape_layout;
+    typename ToView::traits::array_layout impl_layout;
     int ifrom = 0;
     for (int i=0; i<to_rank; ++i) {
       if (extents[i]<=0) {
         EKAT_REQUIRE_MSG (ifrom<from_rank,
             "Error! Too many missing extents in input vector.\n");
         impl_layout.dimension[i] = from_v.extent_int(ifrom);
-        shape_layout.dimension[i] = from_v.extent_int(ifrom);
-        coeff[i] = 1;
+        m_shape[i] = from_v.extent_int(ifrom);
+        m_coeff[i] = 1;
         ++ifrom;
       } else {
         impl_layout.dimension[i] = 1;
-        shape_layout.dimension[i] = extents[i];
-        coeff[i] = 0;
+        m_shape[i] = extents[i];
+        m_coeff[i] = 0;
       }
     }
     EKAT_REQUIRE_MSG (ifrom==from_rank,
         "Error! Too many positive extents in input vector.\n");
 
     m_view_impl = view_type(from_v.data(),impl_layout);
-    m_view_shape = view_type(from_v.data(),shape_layout);
   }
 
   KOKKOS_INLINE_FUNCTION
-  int extent(int i) { return m_view_shape.extent(i); }
+  int extent(int i) {
+    EKAT_KERNEL_ASSERT_MSG (i>=0 and i<=m_view_impl.rank(),
+        "[ViewBroadcast::extent] Error! Index out of bounds.\n");
+    return m_shape[i];
+  }
 
-  template<typename... Is>
+  // Rank 1
+  template<typename IntType>
   KOKKOS_FORCEINLINE_FUNCTION
-  reference_type operator()(Is... indices) const {
-    int i=0;
-    ((indices *= coeff[i++]),...);
-    return m_view_impl(indices...);
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0) const {
+    return m_view_impl(i0*m_coeff[0]);
+  }
+
+  // Rank 2
+  template<typename IntType>
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0, IntType i1) const {
+    return m_view_impl(i0*m_coeff[0],i1*m_coeff[1]);
+  }
+
+  // Rank 3
+  template<typename IntType>
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0, IntType i1, IntType i2) const {
+    return m_view_impl(i0*m_coeff[0],i1*m_coeff[1],i2*m_coeff[2]);
+  }
+
+  // Rank 4
+  template<typename IntType>
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0, IntType i1, IntType i2, IntType i3) const {
+    return m_view_impl(i0*m_coeff[0],i1*m_coeff[1],i2*m_coeff[2],i3*m_coeff[3]);
+  }
+
+  // Rank 5
+  template<typename IntType>
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0, IntType i1, IntType i2, IntType i3,
+             IntType i4) const {
+    return m_view_impl(i0*m_coeff[0],i1*m_coeff[1],i2*m_coeff[2],i3*m_coeff[3],
+                       i4*m_coeff[4]);
+  }
+
+  // Rank 6
+  template<typename IntType>
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0, IntType i1, IntType i2, IntType i3,
+             IntType i4, IntType i5) const {
+    return m_view_impl(i0*m_coeff[0],i1*m_coeff[1],i2*m_coeff[2],i3*m_coeff[3],
+                       i4*m_coeff[4],i5*m_coeff[5]);
+  }
+
+  // Rank 7
+  template<typename IntType>
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0, IntType i1, IntType i2, IntType i3,
+             IntType i4, IntType i5, IntType i6) const {
+    return m_view_impl(i0*m_coeff[0],i1*m_coeff[1],i2*m_coeff[2],i3*m_coeff[3],
+                       i4*m_coeff[4],i5*m_coeff[5],i6*m_coeff[6]);
+  }
+
+  // Rank 8
+  template<typename IntType>
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::enable_if_t<std::is_integral_v<IntType>,reference_type>
+  operator()(IntType i0, IntType i1, IntType i2, IntType i3,
+             IntType i4, IntType i5, IntType i6, IntType i7) const {
+    return m_view_impl(i0*m_coeff[0],i1*m_coeff[1],i2*m_coeff[2],i3*m_coeff[3],
+                       i4*m_coeff[4],i5*m_coeff[5],i6*m_coeff[6],i7*m_coeff[7]);
   }
 
 protected:
 
  view_type  m_view_impl;
- view_type  m_view_shape;
 
- int coeff[8];
+ int m_shape[8];
+ int m_coeff[8];
 };
 
 

--- a/src/kokkos/ekat_view_broadcast.hpp
+++ b/src/kokkos/ekat_view_broadcast.hpp
@@ -1,0 +1,88 @@
+#ifndef EKAT_BROADCAST_VIEW_HPP
+#define EKAT_BROADCAST_VIEW_HPP
+
+#include "ekat_kokkos_meta.hpp"
+#include "ekat_assert.hpp"
+
+namespace ekat {
+
+/*
+ * Broadcast a view into a higher dimensional view
+ *
+ * This allows to replicate (e.g. extrude) a view as a higher
+ * dimensional one, without having to manually copy entries.
+ * E.g., one can replicate a column vector v into a matrix A
+ * with each column equal to v, so that A(i,j) = v(j) for every i.
+ */
+
+template<typename ToView>
+class ViewBroadcast
+{
+public:
+  using view_type  = Unmanaged<ToView>;
+  using reference_type = typename view_type::reference_type;
+
+  template<typename FromView>
+  ViewBroadcast (const FromView& from_v,
+                 const std::vector<int>& extents)
+  {
+    constexpr int from_rank = FromView::rank();
+    constexpr int to_rank = ToView::rank();
+
+    EKAT_REQUIRE_MSG (from_rank<=to_rank,
+        "[ViewBroadcast] Error! FromView rank exceeds ToView rank.\n"
+        " FromView::rank(): " << FromView::rank() << "\n"
+        " ToView::rank(): " << ToView::rank() << "\n");
+    EKAT_REQUIRE_MSG (to_rank<=8,
+        "[ViewBroadcast] Error! ToView rank exceeds maximum rank (8).\n"
+        " ToView::rank(): " << ToView::rank() << "\n");
+
+    EKAT_REQUIRE_MSG (extents.size()==to_rank,
+        "[ViewBroadcast] Badly sized extents vector.\n");
+
+    // Init all dims as "ignored", then set up the ones actually picked
+    typename ToView::traits::array_layout impl_layout,shape_layout;
+    int ifrom = 0;
+    for (int i=0; i<to_rank; ++i) {
+      if (extents[i]<=0) {
+        EKAT_REQUIRE_MSG (ifrom<from_rank,
+            "Error! Too many missing extents in input vector.\n");
+        impl_layout.dimension[i] = from_v.extent_int(ifrom);
+        shape_layout.dimension[i] = from_v.extent_int(ifrom);
+        coeff[i] = 1;
+        ++ifrom;
+      } else {
+        impl_layout.dimension[i] = 1;
+        shape_layout.dimension[i] = extents[i];
+        coeff[i] = 0;
+      }
+    }
+    EKAT_REQUIRE_MSG (ifrom==from_rank,
+        "Error! Too many positive extents in input vector.\n");
+
+    m_view_impl = view_type(from_v.data(),impl_layout);
+    m_view_shape = view_type(from_v.data(),shape_layout);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  int extent(int i) { return m_view_shape.extent(i); }
+
+  template<typename... Is>
+  KOKKOS_FORCEINLINE_FUNCTION
+  reference_type operator()(Is... indices) const {
+    int i=0;
+    ((indices *= coeff[i++]),...);
+    return m_view_impl(indices...);
+  }
+
+protected:
+
+ view_type  m_view_impl;
+ view_type  m_view_shape;
+
+ int coeff[8];
+};
+
+} // namespace ekat
+
+#endif // EKAT_BROADCAST_VIEW_HPP

--- a/src/kokkos/ekat_view_broadcast.hpp
+++ b/src/kokkos/ekat_view_broadcast.hpp
@@ -83,6 +83,14 @@ protected:
  int coeff[8];
 };
 
+
+template<typename ToView,typename FromView>
+ViewBroadcast<ToView> broadcast (const FromView& from,
+                                 const std::vector<int>& extents)
+{
+  return ViewBroadcast<ToView>(from,extents);
+}
+
 } // namespace ekat
 
 #endif // EKAT_BROADCAST_VIEW_HPP

--- a/tests/kokkos/CMakeLists.txt
+++ b/tests/kokkos/CMakeLists.txt
@@ -12,6 +12,10 @@ EkatCreateUnitTest(math_utils math_utils.cpp
 EkatCreateUnitTest(view_utils view_utils.cpp
   LIBS ekat::KokkosUtils)
 
+# Test view broadcast
+EkatCreateUnitTest(view_broadcast view_broadcast.cpp
+  LIBS ekat::KokkosUtils)
+
 # Test subview utils
 EkatCreateUnitTest(subview_utils subview_utils.cpp
   LIBS ekat::KokkosUtils)

--- a/tests/kokkos/view_broadcast.cpp
+++ b/tests/kokkos/view_broadcast.cpp
@@ -1,0 +1,229 @@
+#include <catch2/catch.hpp>
+
+#include "ekat_view_broadcast.hpp"
+
+namespace {
+
+TEST_CASE("view_broadcast") {
+  using namespace ekat;
+
+  SECTION ("from_1d") {
+    using from_t = Kokkos::View<int*>;
+    const int n = 5;
+    from_t orig("",n);
+    auto orig_h = Kokkos::create_mirror_view(orig);
+    for (int i=0; i<n; ++i) { orig_h(i) = i; }
+    Kokkos::deep_copy(orig,orig_h);
+
+    SECTION ("to_1d") {
+      using view_1d = Kokkos::View<int*>;
+      using b1d_t = ViewBroadcast<view_1d>;
+
+      REQUIRE_THROWS(b1d_t(orig,{0,1}));  // Badly sized extents
+      REQUIRE_THROWS(b1d_t(orig,{1}));    // Too many positive extents
+
+      int d0 = n;
+      b1d_t b1d(orig,{-1});
+
+      int err = 0;
+      auto lambda = KOKKOS_LAMBDA (int i, int& l_err) {
+        if (b1d(i)!=orig(i)) ++l_err;
+      };
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0),lambda,err);
+      REQUIRE (err==0);
+    }
+
+    SECTION ("to_2d") {
+      using view_2d = Kokkos::View<int**>;
+      using b2d_t = ViewBroadcast<view_2d>;
+
+      REQUIRE_THROWS(b2d_t(orig,{0,1,2})); // Badly sized extents
+      REQUIRE_THROWS(b2d_t(orig,{1,2}));   // Too many positive extents
+      REQUIRE_THROWS(b2d_t(orig,{0,0}));   // Too few positive extents
+
+      int d0,d1;
+     
+      SECTION ("along d0") {
+        d0 = 4;
+        d1 = n;
+        b2d_t b2d(orig,{d0,-1});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = idx / d1;
+          int j = idx % d1;
+          if (b2d(i,j)!=orig(j)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1),lambda,err);
+        REQUIRE (err==0);
+      }
+      SECTION ("along d1") {
+        d0 = n;
+        d1 = 4;
+        b2d_t b2d(orig,{-1,d1});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = idx / d1;
+          int j = idx % d1;
+          if (b2d(i,j)!=orig(i)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1),lambda,err);
+        REQUIRE (err==0);
+      }
+    }
+    SECTION("to_3d") {
+      using view_3d = Kokkos::View<int***>;
+      using b3d_t = ViewBroadcast<view_3d>;
+
+      REQUIRE_THROWS(b3d_t(orig,{0,1,2,3})); // Badly sized extents
+      REQUIRE_THROWS(b3d_t(orig,{1,2,3}));   // Too many positive extents
+      REQUIRE_THROWS(b3d_t(orig,{0,0,1}));   // Too few positive extents
+
+      int d0,d1,d2;
+     
+      SECTION ("along d0-d1") {
+        d0 = 4;
+        d1 = 3;
+        d2 = n;
+        b3d_t b3d(orig,{d0,d1,-1});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = (idx / d2) / d1;
+          int j = (idx / d2) % d1;
+          int k = idx % d2;
+          if (b3d(i,j,k)!=orig(k)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1*d2),lambda,err);
+        REQUIRE (err==0);
+      }
+      SECTION ("along d0-d2") {
+        d0 = 4;
+        d1 = n;
+        d2 = 3;
+        b3d_t b3d(orig,{d0,-1,d1});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = (idx / d2) / d1;
+          int j = (idx / d2) % d1;
+          int k = idx % d2;
+          if (b3d(i,j,k)!=orig(j)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1*d2),lambda,err);
+        REQUIRE (err==0);
+      }
+      SECTION ("along d1-d2") {
+        d0 = n;
+        d1 = 4;
+        d2 = 3;
+        b3d_t b3d(orig,{-1,d1,d2});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = (idx / d2) / d1;
+          int j = (idx / d2) % d1;
+          int k = idx % d2;
+          if (b3d(i,j,k)!=orig(i)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1*d2),lambda,err);
+        REQUIRE (err==0);
+      }
+    }
+  }
+
+  SECTION ("from_2d") {
+    using from_t = Kokkos::View<int**>;
+
+    const int m = 4;
+    const int n = 5;
+    from_t orig("",m,n);
+    auto orig_h = Kokkos::create_mirror_view(orig);
+    for (int i=0; i<m*n; ++i) { orig_h.data()[i] = i; }
+    Kokkos::deep_copy(orig,orig_h);
+
+    SECTION ("to_2d") {
+      using view_2d = Kokkos::View<int**>;
+      using b2d_t = ViewBroadcast<view_2d>;
+
+      REQUIRE_THROWS(b2d_t(orig,{0,1,2})); // Badly sized extents
+      REQUIRE_THROWS(b2d_t(orig,{1,0}));   // Too many positive extents
+
+      int d0 = m;
+      int d1 = n;
+      b2d_t b1d(orig,{-1,-1});
+
+      int err = 0;
+      auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+        int i = idx / d1;
+        int j = idx % d1;
+        if (b1d(i,j)!=orig(i,j)) ++l_err;
+      };
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1),lambda,err);
+      REQUIRE (err==0);
+    }
+
+    SECTION ("to_3d") {
+      using view_3d = Kokkos::View<int***>;
+      using b3d_t = ViewBroadcast<view_3d>;
+
+      REQUIRE_THROWS(b3d_t(orig,{0,1,2,3})); // Badly sized extents
+      REQUIRE_THROWS(b3d_t(orig,{1,2,0}));   // Too many positive extents
+      REQUIRE_THROWS(b3d_t(orig,{0,0,0}));   // Too few positive extents
+
+      int d0,d1,d2;
+     
+      SECTION ("along d0") {
+        d0 = 3;
+        d1 = m;
+        d2 = n;
+        b3d_t b3d(orig,{d0,-1,-1});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = (idx / d2) / d1;
+          int j = (idx / d2) % d1;
+          int k = idx % d2;
+          if (b3d(i,j,k)!=orig(j,k)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1*d2),lambda,err);
+        REQUIRE (err==0);
+      }
+      SECTION ("along d1") {
+        d0 = m;
+        d1 = 3;
+        d2 = n;
+        b3d_t b3d(orig,{-1,d1,-1});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = (idx / d2) / d1;
+          int j = (idx / d2) % d1;
+          int k = idx % d2;
+          if (b3d(i,j,k)!=orig(i,k)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1*d2),lambda,err);
+        REQUIRE (err==0);
+      }
+      SECTION ("along d2") {
+        d0 = m;
+        d1 = n;
+        d2 = 3;
+        b3d_t b3d(orig,{-1,-1,d2});
+
+        int err = 0;
+        auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
+          int i = (idx / d2) / d1;
+          int j = (idx / d2) % d1;
+          int k = idx % d2;
+          if (b3d(i,j,k)!=orig(i,j)) ++l_err;
+        };
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1*d2),lambda,err);
+        REQUIRE (err==0);
+      }
+    }
+  }
+}
+
+} // anonymous namespace

--- a/tests/kokkos/view_broadcast.cpp
+++ b/tests/kokkos/view_broadcast.cpp
@@ -35,18 +35,17 @@ TEST_CASE("view_broadcast") {
 
     SECTION ("to_2d") {
       using view_2d = Kokkos::View<int**>;
-      using b2d_t = ViewBroadcast<view_2d>;
 
-      REQUIRE_THROWS(b2d_t(orig,{0,1,2})); // Badly sized extents
-      REQUIRE_THROWS(b2d_t(orig,{1,2}));   // Too many positive extents
-      REQUIRE_THROWS(b2d_t(orig,{0,0}));   // Too few positive extents
+      REQUIRE_THROWS(broadcast<view_2d>(orig,{0,1,2})); // Badly sized extents
+      REQUIRE_THROWS(broadcast<view_2d>(orig,{1,2}));   // Too many positive extents
+      REQUIRE_THROWS(broadcast<view_2d>(orig,{0,0}));   // Too few positive extents
 
       int d0,d1;
      
       SECTION ("along d0") {
         d0 = 4;
         d1 = n;
-        b2d_t b2d(orig,{d0,-1});
+        auto b2d = broadcast<view_2d>(orig,{d0,-1});
 
         int err = 0;
         auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
@@ -60,7 +59,7 @@ TEST_CASE("view_broadcast") {
       SECTION ("along d1") {
         d0 = n;
         d1 = 4;
-        b2d_t b2d(orig,{-1,d1});
+        auto b2d = broadcast<view_2d>(orig,{-1,d1});
 
         int err = 0;
         auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
@@ -145,20 +144,19 @@ TEST_CASE("view_broadcast") {
 
     SECTION ("to_2d") {
       using view_2d = Kokkos::View<int**>;
-      using b2d_t = ViewBroadcast<view_2d>;
 
-      REQUIRE_THROWS(b2d_t(orig,{0,1,2})); // Badly sized extents
-      REQUIRE_THROWS(b2d_t(orig,{1,0}));   // Too many positive extents
+      REQUIRE_THROWS(broadcast<view_2d>(orig,{0,1,2})); // Badly sized extents
+      REQUIRE_THROWS(broadcast<view_2d>(orig,{1,0}));   // Too many positive extents
 
       int d0 = m;
       int d1 = n;
-      b2d_t b1d(orig,{-1,-1});
+      auto b2d = broadcast<view_2d>(orig,{-1,-1});
 
       int err = 0;
       auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
         int i = idx / d1;
         int j = idx % d1;
-        if (b1d(i,j)!=orig(i,j)) ++l_err;
+        if (b2d(i,j)!=orig(i,j)) ++l_err;
       };
       Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,d0*d1),lambda,err);
       REQUIRE (err==0);
@@ -166,11 +164,10 @@ TEST_CASE("view_broadcast") {
 
     SECTION ("to_3d") {
       using view_3d = Kokkos::View<int***>;
-      using b3d_t = ViewBroadcast<view_3d>;
 
-      REQUIRE_THROWS(b3d_t(orig,{0,1,2,3})); // Badly sized extents
-      REQUIRE_THROWS(b3d_t(orig,{1,2,0}));   // Too many positive extents
-      REQUIRE_THROWS(b3d_t(orig,{0,0,0}));   // Too few positive extents
+      REQUIRE_THROWS(broadcast<view_3d>(orig,{0,1,2,3})); // Badly sized extents
+      REQUIRE_THROWS(broadcast<view_3d>(orig,{1,2,0}));   // Too many positive extents
+      REQUIRE_THROWS(broadcast<view_3d>(orig,{0,0,0}));   // Too few positive extents
 
       int d0,d1,d2;
      
@@ -178,7 +175,7 @@ TEST_CASE("view_broadcast") {
         d0 = 3;
         d1 = m;
         d2 = n;
-        b3d_t b3d(orig,{d0,-1,-1});
+        auto b3d = broadcast<view_3d>(orig,{d0,-1,-1});
 
         int err = 0;
         auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
@@ -194,7 +191,7 @@ TEST_CASE("view_broadcast") {
         d0 = m;
         d1 = 3;
         d2 = n;
-        b3d_t b3d(orig,{-1,d1,-1});
+        auto b3d = broadcast<view_3d>(orig,{-1,d1,-1});
 
         int err = 0;
         auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {
@@ -210,7 +207,7 @@ TEST_CASE("view_broadcast") {
         d0 = m;
         d1 = n;
         d2 = 3;
-        b3d_t b3d(orig,{-1,-1,d2});
+        auto b3d = broadcast<view_3d>(orig,{-1,-1,d2});
 
         int err = 0;
         auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This is motivated by some work in EAMxx. Namely, I have an array (nx, ny, nz), which I need to mask with another array, which could have shape (nx) or (nx,nz). To avoid lots of conditionals, I would like to do something similar to numpy's array [broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html).

This PR allows to wrap a view into a higher dim array, in such a way that it is "replicated" along the new dimensions. E.g., one can take a 1d view `x` representing a column, and replicated it in a 2d matrix array `A`, in such a way that `A(i,j) = x(j)` for all `i`. This, of course, does not increase storage requirement, and does not copy any data. It simply "hides" the slicing of "extruded" dimensions.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
May be needed in EAMxx.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a unit test.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
