### PR TITLE
Make sure boost's stacktrace uses addr2line

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 # Always looking for stacktrace can cause problems when cross compiling
 # Hence, avoid finding boost if user didn't ask for it.
 option (EKAT_ENABLE_BOOST_STACKTRACE "Whether to enable Boost stacktrace" OFF)
+
 if (EKAT_ENABLE_BOOST_STACKTRACE)
   message (STATUS "Looking for boost::stacktrace ...")
   # Stacktrace is available with Boost>=1.65
@@ -77,7 +78,7 @@ endif()
 
 if (EKAT_HAS_STACKTRACE)
   target_link_libraries(ekat_core PUBLIC ${Boost_LIBRARIES})
-  target_compile_definitions(ekat_core PRIVATE EKAT_HAS_STACKTRACE)
+  target_compile_definitions(ekat_core PRIVATE EKAT_HAS_STACKTRACE BOOST_STACKTRACE_USE_ADDR2LINE)
 endif()
 
 if (EKAT_DEFAULT_BFB)


### PR DESCRIPTION
It apparently does not pick it up automatically

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
I enabled the stacktrace to check where my code was failing without firing up gdb, but it was printing function pointers rather than source code lines. I am not sure if this is due to changes in boost since 1.65 (I am using 1.81) or if I was just getting lucky before. Either way, adding this CPP macro seems to fix things.

stacktrace before this PR:
```
   0# 0x0000000000509997 in ./yaml_parser
   1# 0x000000000040CB49 in ./yaml_parser
   2# 0x000000000043B76A in ./yaml_parser
   3# 0x000000000043AADD in ./yaml_parser
   4# 0x000000000043585D in ./yaml_parser
   5# 0x00000000004355E1 in ./yaml_parser
   6# 0x00000000004342A6 in ./yaml_parser
   7# 0x0000000000436F36 in ./yaml_parser
   8# 0x0000000000438143 in ./yaml_parser
   9# 0x0000000000437E95 in ./yaml_parser
  10# 0x000000000044D3A2 in ./yaml_parser
  11# 0x00007F3954E295D0 in /usr/lib64/libc.so.6
  12# __libc_start_main in /usr/lib64/libc.so.6
  13# 0x000000000040C575 in ./yaml_parser
```
stacktrace after this PR:
```
   0# boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::
  frame> >::basic_stacktrace() at /projects/sems/install/rhel9-x86_64/sems/tpl/
  gcc/13.2.0/boost/1.84.0/6ipfnbu/include/boost/stacktrace/stacktrace.hpp:129
   1# (anonymous namespace)::C_A_T_C_H_T_E_S_T_0() at /home/lbertag/workdir/
  libs/ekat/ekat-src/master/tests/parser/yaml_parser.cpp:55 (discriminator 4)
   2# Catch::TestInvokerAsFunction::invoke() const at /home/lbertag/workdir/
  libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.hpp:14329
   3# Catch::TestCase::invoke() const at /home/lbertag/workdir/libs/ekat/ekat-
  src/master/extern/Catch2/single_include/catch2/catch.hpp:14168
   4# Catch::RunContext::invokeActiveTestCase() at /home/lbertag/workdir/libs/
  ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.hpp:13028
   5# Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::
  char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char,
  std::char_traits<char>, std::allocator<char> >&) at /home/lbertag/workdir/
  libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.hpp:13002
   6# Catch::RunContext::runTest(Catch::TestCase const&) at /home/lbertag/
  workdir/libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.
  hpp:12762
   7# Catch::(anonymous namespace)::TestGroup::execute() at /home/lbertag/
  workdir/libs/ekat/ekat-src/master/extern/Catch2/single_include/catch2/catch.
  hpp:13354 (discriminator 2)
   8# Catch::Session::runInternal() at /home/lbertag/workdir/libs/ekat/ekat-
  src/master/extern/Catch2/single_include/catch2/catch.hpp:13562
   9# Catch::Session::run() at /home/lbertag/workdir/libs/ekat/ekat-src/master/
  extern/Catch2/single_include/catch2/catch.hpp:13516 (discriminator 1)
  10# main at /home/lbertag/workdir/libs/ekat/ekat-src/master/src/testing-
  support/ekat_catch_main.cpp:86 (discriminator 1)
  11# 0x00007FF554A295D0 in /usr/lib64/libc.so.6
  12# __libc_start_main in /usr/lib64/libc.so.6
  13# _start in ./yaml_parser
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
