### PR TITLE
Simplify and upgrade implementation of repack utility

### DIFF
--- a/src/pack/ekat_pack_kokkos.hpp
+++ b/src/pack/ekat_pack_kokkos.hpp
@@ -295,6 +295,7 @@ scalarize (const Kokkos::View<ValueT*, Parms...>& v)
 // Turn a View of Pack<T,M>s into a View of Pack<T,N>s,
 // or a View of T into a View of Pack<T,N> (provided T is not a Pack itself)
 template<int N, typename DT, typename... Props>
+KOKKOS_INLINE_FUNCTION
 auto repack (const Kokkos::View<DT,Props...>& src)
 {
   using src_view_t   = Kokkos::View<DT,Props...>;
@@ -315,10 +316,8 @@ auto repack (const Kokkos::View<DT,Props...>& src)
   using dst_view_t = Unmanaged<Kokkos::View<dst_data_type,Props...>>;
   int packed_dim = rank-1;
 
-  EKAT_REQUIRE_MSG (src.extent(packed_dim) % N == 0,
-      "Error! Cannot pack input view, as the pack size does not divide the last dimension.\n"
-      " - last extent: " + std::to_string(src.extent(packed_dim)) + "\n"
-      " - pack size  : " + std::to_string(N) + "\n");
+  EKAT_KERNEL_REQUIRE_MSG (src.extent(packed_dim) % N == 0,
+      "Error! Cannot pack input view, as the pack size does not divide the last dimension.\n");
 
   auto data = src.data();
   auto packed_data = reinterpret_cast<dst_value_t*>(data);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
I randomly came across this fcn and randomly thought of a way to greatly simplify its implementation. Furthermore, it can now also be used to pack a view of scalars, while the original impl of repack required the input view's value type to already be a Pack.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
No further testing needed.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
