### PR TITLE
Add empty ctor for ViewBroadcast

### DIFF
--- a/src/kokkos/ekat_view_broadcast.hpp
+++ b/src/kokkos/ekat_view_broadcast.hpp
@@ -22,6 +22,15 @@ public:
   using view_type  = Unmanaged<ToView>;
   using reference_type = typename view_type::reference_type;
 
+  ViewBroadcast () = default;
+
+  template<typename FromView>
+  ViewBroadcast (const FromView& from_v,
+                 const std::vector<int>& extents)
+  {
+    setup(from_v,extents);
+  }
+
   // Broadcast an input view to the type provided by the class template arg
   //  - from_v: view to be broadcasted
   //  - extents: list of extents of the outfacing view (of type ToView).
@@ -29,8 +38,8 @@ public:
   //    that are <=0, which signal that those dimensions' extents will be
   //    retrieved from the input view.
   template<typename FromView>
-  ViewBroadcast (const FromView& from_v,
-                 const std::vector<int>& extents)
+  void setup (const FromView& from_v,
+              const std::vector<int>& extents)
   {
     constexpr int from_rank = FromView::rank();
     constexpr int to_rank = ToView::rank();

--- a/tests/kokkos/view_broadcast.cpp
+++ b/tests/kokkos/view_broadcast.cpp
@@ -45,7 +45,8 @@ TEST_CASE("view_broadcast") {
       SECTION ("along d0") {
         d0 = 4;
         d1 = n;
-        auto b2d = broadcast<view_2d>(orig,{d0,-1});
+        ViewBroadcast<view_2d> b2d;
+        b2d.setup(orig,{d0,-1});
 
         int err = 0;
         auto lambda = KOKKOS_LAMBDA (int idx, int& l_err) {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Sometimes we want to create the object, and defer the initialization until the input view is available, like
```c++
ViewBroadcast<to_view_t> bcasted_v;
if (input1d) {
  bcasted_v.setup(input.get<view_1d<T>>(),input.dims());
} else {
  bcasted_v.setup(input.get<view_2d<T>>(),input.dims());
}
```
with current master, we would have to move the whole code that uses `bcasted_v` into both the if branches,duplicating everything.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I modified one bcasted view in the unit tests to be default-constructed, and setup later.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
