### PR TITLE
Include cassert in files that use assert

### DIFF
--- a/src/core/ekat_rational_constant.hpp
+++ b/src/core/ekat_rational_constant.hpp
@@ -3,6 +3,7 @@
 
 #include "ekat_assert.hpp"
 
+#include <cassert>
 #include <stdexcept>
 #include <sstream>
 #include <array>

--- a/src/kokkos/ekat_subview_utils.hpp
+++ b/src/kokkos/ekat_subview_utils.hpp
@@ -4,6 +4,8 @@
 #include "ekat_kokkos_types.hpp"
 #include "ekat_kokkos_meta.hpp"
 
+#include <cassert>
+
 namespace ekat {
 
 // ================ Subviews of several ranks views ======================= //

--- a/src/kokkos/ekat_view_utils.hpp
+++ b/src/kokkos/ekat_view_utils.hpp
@@ -6,6 +6,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <cassert>
+
 namespace ekat {
 
 template<typename DataTypeOut, typename DataTypeIn, typename... Props>


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The `units` headers were using `assert(..)` without including `<cassert>`. Everything works as long as these headers are included _after_ another header that included `<cassert>`, but obv that's not robust. In fact, while testing something units-related in EAMxx, I included `ekat_units.hpp` and got the error
```
/storage/workdir/e3sm/e3sm-src/branch/externals/ekat/src/core/ekat_rational_constant.hpp:86:5: error: there are no arguments to 'assert' that depend on a template parameter, so a declaration of 'assert' must be available [-fpermissive]
```

While at it, I also added the include to a couple of kokkos utils header that explicitly uses `assert(..)`. Most likely, kokkos already pulls in the assert header, but it's healthy to also include it ourselves.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
