### PR TITLE
Fix a couple of constexpr issue in Units

### DIFF
--- a/src/core/ekat_units.hpp
+++ b/src/core/ekat_units.hpp
@@ -114,7 +114,7 @@ public:
   }
   static constexpr Units invalid () {
     constexpr auto infty = std::numeric_limits<RationalConstant::iType>::max();
-    return ScalingFactor(-infty)*nondimensional();
+    return Units(0,0,0,0,0,0,0,ScalingFactor(infty));
   }
 
   std::string get_si_string () const {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The fcn `operator*(ScalingFactor,Units)` was not really constexpr, as there were non-constexpr fcn calls involved. Also, when creating "invalid" units, the multiplication between `ScalingFactor(-infty)` and `Units::nondimensional()` was giving overflow warnings, so I simplified the fcn.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
