### PR TITLE
Fix overflow in Units::invalid

### DIFF
--- a/src/core/ekat_units.hpp
+++ b/src/core/ekat_units.hpp
@@ -105,7 +105,7 @@ public:
   }
   static constexpr Units invalid () {
     constexpr auto infty = std::numeric_limits<RationalConstant::iType>::max();
-    return ScalingFactor(-infty)*nondimensional();
+    return Units(0,0,0,0,0,0,0,ScalingFactor(infty));
   }
 
   std::string get_si_string () const {


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
While this would just be a warning in a regular funciton, for constexpr evaluation the compiler must be able to evaluate the fcn without issues (like an overflow). The issue stemmed from the attempt to do -infty*1 (apparently). The solution is to simply build a Units object with infty scaling factor, without using the overloaded `*` operator.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
