### PR TITLE
Remove print for default exec space being initialized

### DIFF
--- a/src/kokkos/ekat_kokkos_session.cpp
+++ b/src/kokkos/ekat_kokkos_session.cpp
@@ -50,7 +50,6 @@ std::string kokkos_config_string ()
 {
   std::string cfg;
   cfg += " Default Execution Space name: " + std::string(DefaultDevice::execution_space::name()) + "\n";
-  cfg += " Default Execution Space initialized: " + std::string(DefaultDevice::execution_space::impl_is_initialized() ? "yes" : "no") + "\n";
 
 #ifdef KOKKOS_ENABLE_OPENMP
   int num_host_threads = Kokkos::OpenMP().concurrency();


### PR DESCRIPTION
The static function `impl_is_initialized()` no longer exists in Kokkos develop. Currently there is no backend generic way for querying if the default execution space is initialized, so I decided to remove.

I think if an exec space is not properly initialized the error from Kokkos should be sufficient to debug.

## Motivation
Beginning step for getting the kokkos dev weekly test in EAMxx to pass.
