### PR TITLE
Add zip utility to zip iterators of container-like objects

### DIFF
--- a/src/core/ekat_zip.hpp
+++ b/src/core/ekat_zip.hpp
@@ -1,0 +1,111 @@
+#ifndef EKAT_ZIP_HPP
+#define EKAT_ZIP_HPP
+
+#include <ekat_assert.hpp>
+
+/*
+ * Utilities to zip iterators
+ *
+ * This file defines utilities needed to "zip" iterators, backporting C++23 zip fcn
+ * from the std::views and std::ranges namespaces. This utility allows to do
+ *
+ *   for (auto& [a.b,c] : ekat::zip(c1,c2,c3)) {
+ *     // Use a,b,c
+ *   }
+ *
+ * where c1, c2, and c3 are objects for which std::begin/end/cbegin/cend is well defined
+ * (e.g., any std container, as well as static arrays)
+ */
+
+namespace ekat {
+
+template <typename IteratorsTuple>
+class ZipIterator;
+
+template <typename... Iterators>
+class ZipIterator<std::tuple<Iterators...>> {
+public:
+  static constexpr int N = sizeof...(Iterators);
+
+  ZipIterator () = default;
+  ZipIterator (std::tuple<Iterators...> iters) : iterators(iters) {}
+
+  // Dereference operator
+  auto operator*() {
+    return std::apply([](Iterators... its){
+      return std::make_tuple(*its...);
+    },iterators);
+  }
+
+  // Increment operator
+  ZipIterator& operator++() {
+    auto inc = [](auto&... it) { (++it, ...); };
+    std::apply(inc,iterators);
+    return *this;
+  }
+
+  // Comparison operator
+  bool operator!=(const ZipIterator& other) const {
+    return !equal(std::make_index_sequence<N>{},other);
+  }
+
+private:
+  template <std::size_t... Indices>
+  bool equal (std::index_sequence<Indices...>, const ZipIterator& other) const {
+    return (... && (std::get<Indices>(iterators) == std::get<Indices>(other.iterators)));
+  }
+
+  std::tuple<Iterators...> iterators;
+};
+
+template <typename... Iterators>
+ZipIterator<Iterators...> zip_iterator (std::tuple<Iterators...> iters)
+{
+  return ZipIterator<Iterators...> (iters);
+}
+
+template <typename... Containers>
+class Zip {
+public:
+  static constexpr int N = sizeof...(Containers);
+  static_assert (N>0, "Zip<> is ill-formed.");
+
+  Zip (const std::tuple<Containers&...>& containers)
+   : _begin (std::apply([](auto&...args){return std::make_tuple(std::begin (args)...);},containers))
+   , _end   (std::apply([](auto&...args){return std::make_tuple(std::end   (args)...);},containers))
+   , _cbegin(std::apply([](auto&...args){return std::make_tuple(std::cbegin(args)...);},containers))
+   , _cend  (std::apply([](auto&...args){return std::make_tuple(std::cend  (args)...);},containers))
+  {
+    check_sizes(containers);
+  }
+
+  auto begin  () const { return _begin; }
+  auto end    () const { return _end;   }
+  auto cbegin () const { return _cbegin; }
+  auto cend   () const { return _cend;   }
+
+private:
+  void check_sizes (const std::tuple<Containers&...>& containers) {
+    const auto sz = std::size(std::get<0>(containers));
+
+    bool same = std::apply([&](const auto&...c) { return ((std::size(c)==sz) && ...); }, containers);
+    EKAT_REQUIRE_MSG (same,
+       "[Zip] Error! All containers must have the same size.");
+  }
+
+  ZipIterator<std::tuple<decltype(std::begin (std::declval<Containers>()))...>> _begin;
+  ZipIterator<std::tuple<decltype(std::end   (std::declval<Containers>()))...>> _end;
+  ZipIterator<std::tuple<decltype(std::cbegin(std::declval<Containers>()))...>> _cbegin;
+  ZipIterator<std::tuple<decltype(std::cend  (std::declval<Containers>()))...>> _cend;
+};
+
+
+// Helper function to create a ZipIterator
+template <typename... Containers>
+auto zip(Containers&&... containers) {
+  return Zip<Containers...>(std::forward_as_tuple(containers...));
+}
+
+} // namespace ekat
+
+#endif // EKAT_ZIP_HPP

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -77,3 +77,7 @@ EkatCreateUnitTest(string_utils string_utils.cpp
 # Test factory
 EkatCreateUnitTest(factory factory.cpp
   LIBS ekat::Core)
+
+# Test zip utility
+EkatCreateUnitTest(zip zip.cpp
+  LIBS ekat::Core)

--- a/tests/core/zip.cpp
+++ b/tests/core/zip.cpp
@@ -1,0 +1,28 @@
+#include <catch2/catch.hpp>
+
+#include "ekat_zip.hpp"
+
+#include <vector>
+#include <list>
+#include <string>
+
+namespace ekat {
+
+TEST_CASE ("ekat_comm","") {
+  std::vector<int> v1 = {1,2,3};
+  std::vector<int> v2 = {-1,-2,-3};
+  std::vector<int> v3 = {-1};
+  std::list<std::string> l1 = {"1", "2", "3"};
+
+  REQUIRE_THROWS(zip(v1,v3));
+
+  for (auto [pos,neg] : zip(v1,v2)) {
+    REQUIRE (pos==(-neg));
+  }
+  for (const auto& [i,s] : zip(v1,l1)) {
+    REQUIRE (std::to_string(i)==s);
+  }
+}
+
+} // namespace ekat
+


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Quite a few times I've had to iterate over two containers of the same size, and had to resort to using two iterators or an index. Instead, I want to be able to do it like in python's `for a,b in zip(list1,list2)`. C++23 will allow to do this, but since we don't have C++23 yet, we backport the feature and offer it in ekat. Once ekat will update the required std to C++23, we will deprecate and then remove this utility (like we did for `ekat::any`).

Example usage:
```cpp
std::vector<int> v1 = {...};
std::vector<double> v2 = {...};
std::map<int,double> m;
for (const auto& [idx,val] : ekat::zip(v1,v2)) {
  m[idx] = val;
}
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added small unit test.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
