### PR TITLE
Avoid clash of temp var name in IMPL_THROW

### DIFF
--- a/src/core/ekat_assert.hpp
+++ b/src/core/ekat_assert.hpp
@@ -48,15 +48,15 @@ void throw_exception(const std::string& msg)
 
 // Internal do not call directly.
 #define IMPL_THROW(condition, msg, exception_type)  \
-  do {                                                                \
-    if ( ! (condition) ) {                                            \
-      std::stringstream ss;                                           \
-      ss << msg;                                                      \
-      ss << "\nFAILED CONDITION: '" << #condition  << "'\n\n";        \
-      ss << "BACKTRACE:\n";                                           \
-      ss << EKAT_BACKTRACE << "\n";                                   \
-      ekat::throw_exception<exception_type>(ss.str());                \
-    }                                                                 \
+  do {                                                                  \
+    if ( ! (condition) ) {                                              \
+      std::stringstream ekat_tmp_ss;                                    \
+      ekat_tmp_ss << msg;                                               \
+      ekat_tmp_ss << "\nFAILED CONDITION: '" << #condition  << "'\n\n"; \
+      ekat_tmp_ss << "BACKTRACE:\n";                                    \
+      ekat_tmp_ss << EKAT_BACKTRACE << "\n";                            \
+      ekat::throw_exception<exception_type>(ekat_tmp_ss.str());         \
+    }                                                                   \
   } while(0)
 
 // Define the EKAT_REQUIRE macros for different argument counts

--- a/tests/core/debug_tools_tests.cpp
+++ b/tests/core/debug_tools_tests.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include "ekat_assert.hpp"
+#include "ekat_string_utils.hpp"
 #include "ekat_fpe.hpp"
 
 #include <csignal>
@@ -211,6 +212,19 @@ TEST_CASE ("assert-macros") {
   EKAT_REQUIRE (2>0);
   EKAT_REQUIRE (2>0, "some string");
   EKAT_REQUIRE (2>0, "some string", std::logic_error);
+
+  // Make sure the user msg does not get lost
+  std::stringstream ss;
+  ss << "Things went wrong...\n";
+  ss << "...VERY wrong...\n";
+
+  try {
+    EKAT_ERROR_MSG(ss.str());
+  } catch (std::exception& e) {
+    const auto& what = e.what();
+    auto lines = ekat::split(what,"\nFAILED CONDITION");
+    REQUIRE (lines[0]==ss.str());
+  }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The temp var used inside IMPL_THROW has a name that is TOO likely to shadow other var names. In particular, if someone stuffs an error msg in a stringstream var called `ss`, and calls `EKAT_ERROR_MSG(ss.str())`, the CPP will blindly expand it so that the string `msg` is replaced with `ss.str()`. But since we just declared a LOCAL `ss` var (incidentally, of the same type), shadowing the one at the macro call site, `ss.str()` evaluates to the content of the newly created stringstream, which is empty.

The solution is to use a name that is HIGHLY unlikely to clash with any var that is currently defined at the call site.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This was spotted in E3SM, as reported in E3SM-Project/E3SM#8017.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a new test that checks that the user-provided message is not lost.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
