### PR TITLE
Add more support for packed operations

### DIFF
--- a/src/pack/ekat_pack.hpp
+++ b/src/pack/ekat_pack.hpp
@@ -159,12 +159,12 @@ bool operator == (const Mask<n>& m1, const Mask<n>& m2) {
 #define ekat_pack_gen_assign_op_p(op)                       \
   KOKKOS_FORCEINLINE_FUNCTION                               \
   Pack& operator op (const Pack& a) {                       \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i]; \
     return *this;                                           \
   }                                                         \
   KOKKOS_FORCEINLINE_FUNCTION                               \
   Pack& operator op (const volatile Pack& a) {              \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i]; \
     return *this;                                           \
   }                                                         \
   template<typename S>                                      \
@@ -175,7 +175,7 @@ bool operator == (const Mask<n>& m1, const Mask<n>& m2) {
     Pack&                                                   \
   >                                                         \
   operator op (const volatile Pack<S,n>& a) {               \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i]; \
     return *this;                                           \
   }                                                         \
   template<typename S>                                      \
@@ -193,11 +193,11 @@ bool operator == (const Mask<n>& m1, const Mask<n>& m2) {
   std::enable_if_t<                                         \
     std::is_constructible<scalar,S>::value>                 \
   operator op (const Pack<S,n>& a) volatile {               \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i]; \
   }                                                         \
   KOKKOS_FORCEINLINE_FUNCTION                               \
   void operator op (const volatile Pack& a) volatile {      \
-    vector_simd for (int i = 0; i < n; ++i) d[i] op a.d[i]; \
+    vector_simd for (int i = 0; i < n; ++i) d[i] op a[i]; \
   }
 #define ekat_pack_gen_assign_op_s(op)                       \
   template<typename S>                                      \
@@ -417,9 +417,6 @@ using OnlyPackReturn = typename std::enable_if<PackType::packtag,ReturnType>::ty
 // Specialize IsPack for Pack type
 template<typename T, int N>
 struct IsPack<Pack<T,N>> : std::true_type {};
-
-// Later, we might support type promotion. For now, caller must explicitly
-// promote a pack's scalar type in mixed-type arithmetic.
 
 #define ekat_pack_gen_bin_op_pp(op)                                   \
   template <typename T, typename S, int n>                              \

--- a/tests/pack/pack.cpp
+++ b/tests/pack/pack.cpp
@@ -538,7 +538,7 @@ TEST_CASE("pack_update") {
 
 TEST_CASE("different_scalar_types")
 {
-  constexpr int N = 2;
+  constexpr int N = EKAT_TEST_PACK_SIZE;
   using pr_t  = ekat::Pack<Real,N>;
   using ppr_t = ekat::Pack<pr_t,N>;
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
I am trying to use ekat::Pack in Homme inside an LDRD project, since it seems to offer a bit more capabilities in terms of packing/unpacking and packs operations. The only thing that is not really working is when I add Pack<T,N> and Pack<S,N>, where T is implicitly constructible from S. In my case, T=Sacado<double,N>, and S=double.

Templating some of the pack ops overloads seem to make things work. Of course, I guard the template instantiation by ensuring that the type conversion makes sense.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
Added a small unit test.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
