### PR TITLE
Update to kokkos5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.18)
 
+# EKAT requires C++20
+set(CMAKE_CXX_STANDARD 20)
+
 set (EKAT_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake CACHE INTERNAL "")
 
 # Do not ignore <PackageName_ROOT> env vars in find_package() calls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,13 @@ if (EKAT_ENABLE_MPI)
   set(EKAT_MPI_THREAD_FLAG "" CACHE STRING "The mpirun flag for designating the number of threads")
 endif()
 
+##############################
+###  KOKKOS CONFIG OPTIONS ###
+##############################
+# FIXME: View usage in Hommexx and EAMxx needs to allow for Kokkos' MDSpan view implementation as the legacy
+#        implementation will go away in the future, unanounced (it's an "impl" option => no deprecation).
+option (Kokkos_ENABLE_IMPL_VIEW_LEGACY "Currently, EKAT is only compatible with Kokkos' legacy view implementation." ON)
+
 ############################################
 ###  COMPILER/OS-SPECIFIC CONFIG OPTIONS ###
 ############################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,13 @@ if (EKAT_ENABLE_MPI)
   set(EKAT_MPI_THREAD_FLAG "" CACHE STRING "The mpirun flag for designating the number of threads")
 endif()
 
+##############################
+###  KOKKOS CONFIG OPTIONS ###
+##############################
+# FIXME: View usage in Hommexx and EAMxx needs to allow for Kokkos' MDSpan view implementation as the legacy
+#        implementation will go away in the future, unanounced (it's an "impl" option => no deprecation).
+option (Kokkos_ENABLE_IMPL_VIEW_LEGACY "Currently, EKAT is only compatible with Kokkos' legacy view implementation." ON)
+
 ############################################
 ###  COMPILER/OS-SPECIFIC CONFIG OPTIONS ###
 ############################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 ###  KOKKOS CONFIG OPTIONS ###
 ##############################
 # FIXME: View usage in Hommexx and EAMxx needs to allow for Kokkos' MDSpan view implementation as the legacy
-#        implementation will go away in the future, unanounced (it's an "impl" option => no deprecation).
+#        implementation will go away in the future, unannounced (it's an "impl" option => no deprecation).
 option (Kokkos_ENABLE_IMPL_VIEW_LEGACY "Currently, EKAT is only compatible with Kokkos' legacy view implementation." ON)
 
 ############################################

--- a/cacts.yaml
+++ b/cacts.yaml
@@ -92,7 +92,6 @@ configurations:
     uses_baselines: False
     on_by_default: True
     cmake_args:
-      CMAKE_CXX_STANDARD: 20
       EKAT_ENABLE_ALL_PACKAGES: True
       EKAT_TEST_THREAD_INC: ${2 if machine.gpu_arch is None else 1}
       EKAT_TEST_MAX_THREADS: ${machine.num_run_res if machine.gpu_arch is None else 1}

--- a/cacts.yaml
+++ b/cacts.yaml
@@ -106,6 +106,7 @@ configurations:
       EKAT_TEST_DOUBLE_PRECISION: True
       EKAT_TEST_SINGLE_PRECISION: True
       EKAT_SKIP_FIND_YAML_CPP: True
+      Kokkos_ENABLE_DEPRECATED_CODE_5: False
 
   debug:
     longname: debug

--- a/cmake/tpls/EkatBuildSpdlog.cmake
+++ b/cmake/tpls/EkatBuildSpdlog.cmake
@@ -4,7 +4,8 @@ include (EkatUtils)
 
 message (STATUS "  Fetching spdlog via FetchContent")
 
-set (SPDLOG_GIT_TAG bdd1dff3788ebfe520f48f9ad216c60da6dd8f00)
+# spdlog version 1.17.0 commit sha
+set (SPDLOG_GIT_TAG 79524ddd08a4ec981b7fea76afd08ee05f83755d)
 
 # We don't want testing or any spdlog executable at all
 option (SPDLOG_BUILD_TESTS "Enable spdlog tests" OFF)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -58,9 +58,6 @@ add_library(ekat_core
   ekat_test_utils.cpp
 )
 
-# EKAT requires c++17 features
-target_compile_features(ekat_core PUBLIC cxx_std_17)
-
 # Add the correct ekat::Comm impl file, depending on whether MPI is ON/OFF.
 if (EKAT_ENABLE_MPI)
   target_sources(ekat_core PRIVATE ekat_comm.cpp)

--- a/src/kokkos/ekat_kokkos_meta.hpp
+++ b/src/kokkos/ekat_kokkos_meta.hpp
@@ -24,7 +24,7 @@ struct MemoryTraitsMask {
 template <typename View>
 using Unmanaged =
   // Provide a full View type specification, augmented with Unmanaged.
-  Kokkos::View<typename View::traits::scalar_array_type,
+  Kokkos::View<typename View::traits::data_type,
                typename View::traits::array_layout,
                typename View::traits::device_type,
                Kokkos::MemoryTraits<

--- a/src/kokkos/ekat_team_policy_utils.hpp
+++ b/src/kokkos/ekat_team_policy_utils.hpp
@@ -72,7 +72,7 @@ struct TeamPolicyFactory<EkatGpuSpace> {
   template<HostOrDevice HD = Device>
   static policy_t<HD>
   get_policy_internal (const int ni, const int nk) {
-    auto nk_impl = HD==Host ? 1 : nk;
+    auto nk_impl = HD==Host or nk == 0 ? 1 : nk; // 0 team size not allowed in Kokkos
     return policy_t<HD>(ni,nk_impl);
   }
 

--- a/src/kokkos/ekat_team_policy_utils.hpp
+++ b/src/kokkos/ekat_team_policy_utils.hpp
@@ -72,7 +72,7 @@ struct TeamPolicyFactory<EkatGpuSpace> {
   template<HostOrDevice HD = Device>
   static policy_t<HD>
   get_policy_internal (const int ni, const int nk) {
-    auto nk_impl = HD==Host or nk == 0 ? 1 : nk; // 0 team size not allowed in Kokkos
+    const int nk_impl = (HD == Host || nk == 0) ? 1 : nk; // 0 team size not allowed in Kokkos
     return policy_t<HD>(ni,nk_impl);
   }
 


### PR DESCRIPTION
Update EKAT to Kokkos 5.0.1.

The most notable change here is the option `Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON`. Right now we need this since EKAT, Hommexx, and EAMxx use legacy features to subview, in particular. This needs to be addressed as, an impl feature, it will disappear w/o deprecation.

## Motivation
This will allow MALI to use updated Trilinos and EAMxx to use modern C++ features.