### PR TITLE
Fix template specializations for ScalarizedDataType

### DIFF
--- a/tests/pack/pack_utils.cpp
+++ b/tests/pack/pack_utils.cpp
@@ -72,10 +72,14 @@ TEST_CASE("scalarized_data_type")
   using DT4 = ekat::Pack<double,8>;
   using DT4_s = typename ekat::ScalarizedDataType<DT4>::type;
 
+  using DT5 = const ekat::Pack<double,4>[10][10];
+  using DT5_s = const typename ekat::ScalarizedDataType<DT5>::type;
+
   REQUIRE (std::is_same_v<DT1,DT1_s>);
   REQUIRE (std::is_same_v<DT1,DT2_s>);
   REQUIRE (std::is_same_v<DT3,DT3_s>);
   REQUIRE (std::is_same_v<double[8],DT4_s>);
+  REQUIRE (std::is_same_v<const double[10][40],DT5_s>);
 }
 
 } // namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The specialization for a generic `const DT` is detrimental, as the compiler doesn't know what to pick for something like `const int [10]`, as both the specializations for `T[N]` and `const DT` fit. Moreover, the current specialization for `const DT` did was already covered by the default one, with `T = const T`. What we _really_ need, is a specialization for a const pack.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

 
## Additional Information
I'm adding a unit test to verify this. For example, this is the error I was getting before this PR.
```
/home/lbertag/workdir/libs/ekat/ekat-src/master/tests/pack/pack_utils.cpp:81:61: error: ambiguous template instantiation for 'struct ekat::ScalarizedDataType<const ekat::Pack<double, 4> [10][10]>'
   81 |   using DT5_s = const typename ekat::ScalarizedDataType<DT5>::type;
      |                                                             ^~
In file included from /home/lbertag/workdir/libs/ekat/ekat-src/master/tests/pack/pack_utils.cpp:3:
/home/lbertag/workdir/libs/ekat/ekat-src/master/src/pack/ekat_pack_utils.hpp:135:8: note: candidates are: 'template<class DT> struct ekat::ScalarizedDataType<const DT> [with DT = ekat::Pack<double, 4> [10][10]]'
  135 | struct ScalarizedDataType<const DT> {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/lbertag/workdir/libs/ekat/ekat-src/master/src/pack/ekat_pack_utils.hpp:163:8: note:                 'template<class T, int N> struct ekat::ScalarizedDataType<T [N]> [with T = const ekat::Pack<double, 4> [10]; int N = 10]'
  163 | struct ScalarizedDataType<T[N]> {
```
