### PR TITLE
Remove `-restrict` from icpx CXXFLAGS

### DIFF
--- a/cmake/EkatSetCompilerFlags.cmake
+++ b/cmake/EkatSetCompilerFlags.cmake
@@ -73,12 +73,18 @@ endmacro()
 # Common basic flags (regardless of build type)
 #############################
 macro (SetGeneralFlags)
+  # Fortran compiler-specific flags
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-    SetFlags (FFLAGS "-assume byterecl -ftz" CXXFLAGS -restrict)
+    SetFlags (FFLAGS "-assume byterecl -ftz")
   elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
     SetFlags (FFLAGS "-assume byterecl -ftz")
   elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     SetFlags (FFLAGS -ffree-line-length-none)
+  endif()
+
+  # C++ compiler-specific flags
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    SetFlags (CXXFLAGS -restrict)
   endif()
 endmacro()
 


### PR DESCRIPTION
Remove `-restrict` from icpx CXXFLAGS.

Fixes E3SM-Project/EKAT#412

[BFB]

---
Testing:
- SMS.ne30pg2_EC30to60E2r2.WCYCLXX2010.aurora_oneapi-ifxgpu: no warnings about `-restrict`
