### PR TITLE
Support rank 6 and 7 in scalarize util

### DIFF
--- a/src/pack/ekat_pack_kokkos.hpp
+++ b/src/pack/ekat_pack_kokkos.hpp
@@ -199,7 +199,7 @@ struct ScalarizeHelper<Pack<T,N>>
   {
     using ret_t = Unmanaged<Kokkos::View<data_t<DT>, Props...> >;
     constexpr int rank = Kokkos::View<DT, Props...>::rank;
-    static_assert (rank<=5, "ScalarizeHelper only supports up to rank-5 views.\n");
+    static_assert (rank<=7, "ScalarizeHelper only supports up to rank-7 views.\n");
 
     if constexpr (rank==0) {
       return ret_t(pack2scl(vp.data()));
@@ -217,6 +217,15 @@ struct ScalarizeHelper<Pack<T,N>>
       return ret_t(pack2scl(vp.data()), vp.extent(0), vp.extent(1),
                                         vp.extent(2), vp.extent(3),
                                         vp.extent(4)*N);
+    } else if constexpr (rank==6) {
+      return ret_t(pack2scl(vp.data()), vp.extent(0), vp.extent(1),
+                                        vp.extent(2), vp.extent(3),
+                                        vp.extent(4), vp.extent(5)*N);
+    } else if constexpr (rank==7) {
+      return ret_t(pack2scl(vp.data()), vp.extent(0), vp.extent(1),
+                                        vp.extent(2), vp.extent(3),
+                                        vp.extent(4), vp.extent(5),
+                                        vp.extent(6)*N);
     }
   }
 };


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
There are cases where we would like to use scalarize on a rank-6 view. I also added rank-7 just in case, since the code is small.

Namely, I'm using packs in Hommexx in a fork, and i need to scalarize homme's horiz velocity state, which is a rank-6 view.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
