### PR TITLE
Implement pack math function in terms of Kokkos math fcn

### DIFF
--- a/src/pack/ekat_pack_math.hpp
+++ b/src/pack/ekat_pack_math.hpp
@@ -4,44 +4,35 @@
 #include "ekat.hpp"
 #include "ekat_math_utils.hpp"
 
+#include <Kokkos_MathematicalFunctions.hpp>
+
 namespace ekat {
 
-#ifdef __CUDA_ARCH__
-#define ekat_pack_gen_unary_stdfn(fn)               \
+#define ekat_pack_gen_unary_fn(fn)                  \
   template <typename ScalarT, int N>                \
   KOKKOS_INLINE_FUNCTION                            \
   Pack<ScalarT,N> fn (const Pack<ScalarT,N>& p) {   \
     Pack<ScalarT,N> s;                              \
     vector_simd                                     \
     for (int i = 0; i < N; ++i) {                   \
-      s[i] = ::fn(p[i]);                            \
+      s[i] = Kokkos::fn(p[i]);                      \
     }                                               \
     return s;                                       \
   }
-#else
-#define ekat_pack_gen_unary_stdfn(fn)               \
-  template <typename ScalarT, int N>                \
-  KOKKOS_INLINE_FUNCTION                            \
-  Pack<ScalarT,N> fn (const Pack<ScalarT,N>& p) {   \
-    Pack<ScalarT,N> s;                              \
-    vector_simd                                     \
-    for (int i = 0; i < N; ++i) {                   \
-      s[i] = std::fn(p[i]);                         \
-    }                                               \
-    return s;                                       \
-  }
-#endif
 
-ekat_pack_gen_unary_stdfn(abs)
-ekat_pack_gen_unary_stdfn(exp)
-ekat_pack_gen_unary_stdfn(expm1)
-ekat_pack_gen_unary_stdfn(log)
-ekat_pack_gen_unary_stdfn(log10)
-ekat_pack_gen_unary_stdfn(tgamma)
-ekat_pack_gen_unary_stdfn(sqrt)
-ekat_pack_gen_unary_stdfn(cbrt)
-ekat_pack_gen_unary_stdfn(tanh)
-ekat_pack_gen_unary_stdfn(erf)
+ekat_pack_gen_unary_fn(abs)
+ekat_pack_gen_unary_fn(exp)
+ekat_pack_gen_unary_fn(expm1)
+ekat_pack_gen_unary_fn(log)
+ekat_pack_gen_unary_fn(log10)
+ekat_pack_gen_unary_fn(tgamma)
+ekat_pack_gen_unary_fn(sqrt)
+ekat_pack_gen_unary_fn(cbrt)
+ekat_pack_gen_unary_fn(tanh)
+ekat_pack_gen_unary_fn(erf)
+
+// Cleanup the macros we used simply to generate code
+#undef ekat_pack_gen_unary_fn
 
 template <typename PackType> KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<PackType, typename PackType::scalar> min (const PackType& p) {
@@ -159,9 +150,5 @@ OnlyPack<PackType> cube (const PackType& a) {
 }
 
 } // namespace ekat
-
-// Cleanup the macros we used simply to generate code
-#undef ekat_pack_gen_unary_fn
-#undef ekat_pack_gen_unary_stdfn
 
 #endif // EKAT_PACK_MATH_HPP


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
We are observing warnings on CUDA, saying that using `std::xyz` on device is not allowed. Since Kokkos offers portable implementations of these functions, we should implement the pack overloads in terms of the Kokkos math fcns.

## Related Issues

* Closes E3sM-Project/E3SM#8181
* Closes #416 


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
