### PR TITLE
Add specialization of ScalarTraits for Mask

### DIFF
--- a/src/pack/ekat_pack.hpp
+++ b/src/pack/ekat_pack.hpp
@@ -641,6 +641,24 @@ struct ScalarTraits<Pack<T,N>> {
   static constexpr bool specialized = true;
 };
 
+template<int N>
+struct ScalarTraits<Mask<N>> {
+
+  using inner_traits = ScalarTraits<int>;
+
+  using value_type  = Mask<N>;
+  using scalar_type = typename value_type::type;
+
+  // This seems funky. But write down a pow of 2 and a non-pow of 2 in binary (both positive), and you'll see why it works
+  static_assert (N>0 && ((N & (N-1))==0), "Error! We only support packs with length = 2^n.\n");
+
+  static constexpr bool is_simd = true;
+
+  static constexpr bool is_floating_point = false;
+
+  static constexpr bool specialized = true;
+};
+
 template<typename PackT>
 KOKKOS_INLINE_FUNCTION
 constexpr OnlyPack<PackT> invalid () {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In certain contexts, we ping `ScalarTraits<T>` for some properties of `T`. The default impl of this class requires `T` to be an arithmetic type. `Mask<N>` is semantically simialr to a boolean, while from the impl point of view it is similar to a `Pack<int,N>`. Both these do qualify as valid arithmetic types, so it just makes sense to have a specialization for `Mask<N>` too.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
Needed in EAMxx to allow extracting views of `Mask<N>` from an eamxx `Field` class.