### PR TITLE
Use int instead of long as inner type for Mask

### DIFF
--- a/src/pack/ekat_pack.hpp
+++ b/src/pack/ekat_pack.hpp
@@ -46,7 +46,7 @@ template <int PackSize>
 struct Mask {
   // One tends to think a short boolean type would be useful here (e.g., bool or
   // char), but that is bad for vectorization. int or long are best.
-  typedef long type;
+  typedef int type;
 
   // A tag for this struct for type checking.
   enum { masktag = true };


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
`long` can be 64 bits (virtually always on Linux systems), which is 2x the storage of `int` (32 bits). I had a convo with a chat bot, and it suggested using `int` over `long`.  In general, having masks types with same size of the actual simd type should help (hence, long should be better), but it comes with a) higher storage (2x) and more importantly b) higher register pressure, while the slowdown of int->long type-extension during simd ops takes about 1 cycle.

On a more code-motivated note, in EAMxx we use `int` for data type of `Field` representing "masks". If we use `int` for `ekat::Mask`, then we can reinterpret case views of `int*` into views of `Mask*`, much like when we use `Pack<double,N>` for doubles.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
