### PR TITLE
Adding support for Apple Silicon (without MPI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ endif()
 
 # MPI CONFIG OPTIONS. Defaults are set for generic MPI desktop.
 if (EKAT_ENABLE_MPI)
+  if (APPLE)
+    message(FATAL_ERROR "EKAT does not support MPI on Apple machines")
+  endif()
   set(EKAT_MPIRUN_EXE "mpiexec" CACHE STRING "The executable name for mpirun")
   set(EKAT_MPI_EXTRA_ARGS "--bind-to core" CACHE STRING "Options for mpirun")
   set(EKAT_MPI_NP_FLAG "--map-by" CACHE STRING "The mpirun flag for designating the total number of ranks")

--- a/src/core/ekat_fpe.cpp
+++ b/src/core/ekat_fpe.cpp
@@ -3,6 +3,26 @@
 #include <cfenv>
 
 #ifndef EKAT_HAVE_FEENABLEEXCEPT
+#ifdef __APPLE__
+// Apple Silicon has a very different floating point environment, which we leave for
+// future exploration.
+
+inline int fegetexcept (void)
+{
+  return 0;
+}
+
+inline int feenableexcept (int excepts)
+{
+  return 0;
+}
+
+inline int fedisableexcept (int excepts)
+{
+  return 0;
+}
+
+#else
 
 // Drop-in replacement of some useful GNU utils (needed on Apple platforms)
 inline int fegetexcept (void)
@@ -44,7 +64,8 @@ inline int fedisableexcept (int excepts)
   return ( fesetenv (&fenv) ? -1 : old_excepts );
 }
 
-#endif // EKAT_NEEDS_FEENABLEEXCEPT
+#endif // #ifndef __APPLE__
+#endif // #ifndef EKAT_HAVE_FEENABLEEXCEPT
 
 namespace ekat {
 

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -45,10 +45,12 @@ EkatCreateUnitTestFromExec(catch_main_invalid_flags regress_fail
 )
 
 # Comm tests
-EkatCreateUnitTest(comm comm.cpp
-  LIBS ekat::Core
-  MPI_RANKS 1 ${EKAT_TEST_MAX_RANKS}
-)
+if (EKAT_ENABLE_MPI)
+  EkatCreateUnitTest(comm comm.cpp
+    LIBS ekat::Core
+    MPI_RANKS 1 ${EKAT_TEST_MAX_RANKS}
+  )
+endif()
 
 # Test units framework
 EkatCreateUnitTest(units units.cpp


### PR DESCRIPTION
This PR stubs out floating point environment logic for Apple Silicon (whose floating point environment is different and complicated and possibly something to be studied in the distant future).

Apple products are supported only without MPI, because some hwloc-related features aren't supported on Apple silicon, and this can produce failures if special steps are not taken. We can follow this up with a PR that adds support for MPI on Macs if there is interest.

Accordingly, I've also disabled the EKAT comm unit test when MPI is disabled.

## Motivation
Some folks like to develop on their laptops. This allows EKAT to be built in a restricted way to support this kind of development. At the very least, mam4xx developers will be able to work on mam4xx's standalone configuration on Macs.

## Testing

The PR doesn't change any testing logic, aside from disabling an MPI-related test when MPI is disabled.
