### PR TITLE
Use locks to ensure ONE process at a time attempts to clone TPLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 extern/Catch2/
 extern/spdlog/
 extern/yaml-cpp/
+
+# Our util ekat_fetch_tpl util uses these lock files to avoid race conditions
+extern/.*.lock

--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -146,3 +146,39 @@ function(separate_cut_arguments prefix options oneValueArgs multiValueArgs retur
 
   set(${return_varname} ${result} PARENT_SCOPE)
 endfunction(separate_cut_arguments)
+
+# Utility to avoid race conditions in FetchContent_MakeAvailable
+# when 2+ builds are configuring at the same time
+include(FetchContent)
+function(ekat_make_available NAME GIT_TAG_VALUE)
+  string(TOUPPER "${NAME}" NAME_UPPER)
+  string(REPLACE "-" "_" NAME_SANITIZED "${NAME_UPPER}")
+  set(FC_VAR "FETCHCONTENT_SOURCE_DIR_${NAME_SANITIZED}")
+
+  # 1. Respect existing User/Cache Override
+  if (${FC_VAR})
+    message(STATUS "  Using provided ${NAME} source: ${${FC_VAR}}")
+  else()
+    # 2. Setup the Lock (Using the source tree for multi-user safety)
+    set(LOCK_FILE "${EKAT_SOURCE_DIR}/extern/.${NAME}.lock")
+    file(LOCK "${LOCK_FILE}" GUARD FUNCTION)
+
+    # 3. Verify on-disk state
+    set(TPL_SRC_DIR "${EKAT_SOURCE_DIR}/extern/${NAME}")
+    if(EXISTS "${TPL_SRC_DIR}/.git/index" AND EXISTS "${TPL_SRC_DIR}/.git/HEAD")
+      file(READ "${TPL_SRC_DIR}/.git/HEAD" ON_DISK_SHA)
+      string(STRIP "${ON_DISK_SHA}" ON_DISK_SHA)
+
+      if(ON_DISK_SHA STREQUAL GIT_TAG_VALUE)
+        message(STATUS "  ${NAME}: Source matches required version (${GIT_TAG_VALUE}). Bypassing populate step.")
+        # Promote to CACHE so all sub-projects see the bypass
+        set(${FC_VAR} "${TPL_SRC_DIR}" CACHE PATH "Path to ${NAME} source" FORCE)
+      else()
+        message(STATUS "  ${NAME}: Source version mismatch (found ${ON_DISK_SHA}, expected ${GIT_TAG_VALUE}). Proceeding with populate step.")
+      endif()
+    endif()
+  endif()
+
+  # 4. Finalize
+  FetchContent_MakeAvailable(${NAME})
+endfunction()

--- a/cmake/tpls/EkatBuildCatch2.cmake
+++ b/cmake/tpls/EkatBuildCatch2.cmake
@@ -3,6 +3,8 @@ include (FetchContent)
 
 message (STATUS "  Fetching Catch2 via FetchContent")
 
+set (CATCH2_GIT_TAG 0d70154ddf178cf99bca140669e0618267e51682)
+
 # Do not allow the user to enable these
 set(CATCH_BUILD_TESTING OFF CACHE BOOL "Disable Catch2 internal tests" FORCE)
 set(CATCH_INSTALL_HELPERS OFF CACHE BOOL "Disable Catch2 install" FORCE)
@@ -11,9 +13,47 @@ set(CATCH_INSTALL_DOCS OFF CACHE BOOL "Install documentation alongside library" 
 
 FetchContent_Declare(Catch2
   GIT_REPOSITORY https://github.com/E3SM-Project/Catch2.git
-  GIT_TAG        0d70154ddf178cf99bca140669e0618267e51682
+  GIT_TAG        ${CATCH2_GIT_TAG}
   SOURCE_DIR     ${EKAT_SOURCE_DIR}/extern/Catch2
   BINARY_DIR     ${EKAT_BINARY_DIR}/extern/Catch2
 )
 
-FetchContent_MakeAvailable(Catch2)
+# We must protect the MakeAvailable call with a LOCK,
+# to avoid race condition if building 2+ builds at once
+# We use a function since the lock FUNCTION guard is the safest
+# approach (better than FILE), but needs a function scope
+function (ekat_catch2_fetch_content)
+  if (FETCHCONTENT_SOURCE_DIR_CATCH2)
+    message(STATUS "  Using provided Catch2 source: ${FETCHCONTENT_SOURCE_DIR_CATCH2}")
+  else()
+    # Unique lock per user/path to avoid /tmp permission issues
+    set(U_ID "cmake")
+    if(DEFINED ENV{USER})
+      set(U_ID $ENV{USER})
+    endif()
+    string(REPLACE "/" "_" SANITIZED_PATH "${EKAT_SOURCE_DIR}")
+    set(CATCH2_LOCK_FILE "/tmp/${U_ID}_ekat_catch2_${SANITIZED_PATH}.lock")
+    file (LOCK "${CATCH2_LOCK_FILE}" GUARD FUNCTION)
+
+    if (EXISTS "${EKAT_SOURCE_DIR}/extern/Catch2/.git/index")
+      # Ask Git for the current HEAD commit hash
+      execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY "${EKAT_SOURCE_DIR}/extern/Catch2"
+        OUTPUT_VARIABLE ON_DISK_SHA
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      if (ON_DISK_SHA STREQUAL CATCH2_GIT_TAG)
+        message (STATUS "  Catch2 source dir already populated with correct version. Skipping download.")
+        set(FETCHCONTENT_SOURCE_DIR_CATCH2 "${EKAT_SOURCE_DIR}/extern/Catch2" CACHE PATH "Path to Catch2 source" FORCE)
+      else()
+        message (STATUS "  Catch2 version mismatch (Disk: ${ON_DISK_SHA}, Req: ${CATCH2_GIT_TAG}). Proceeding with update.")
+      endif()
+    endif()
+  endif()
+
+  FetchContent_MakeAvailable(Catch2)
+endfunction()
+
+ekat_catch2_fetch_content()

--- a/cmake/tpls/EkatBuildCatch2.cmake
+++ b/cmake/tpls/EkatBuildCatch2.cmake
@@ -1,5 +1,6 @@
 # Fetch Catch2 (single_include) via FetchContent
 include (FetchContent)
+include (EkatUtils)
 
 message (STATUS "  Fetching Catch2 via FetchContent")
 
@@ -18,42 +19,5 @@ FetchContent_Declare(Catch2
   BINARY_DIR     ${EKAT_BINARY_DIR}/extern/Catch2
 )
 
-# We must protect the MakeAvailable call with a LOCK,
-# to avoid race condition if building 2+ builds at once
-# We use a function since the lock FUNCTION guard is the safest
-# approach (better than FILE), but needs a function scope
-function (ekat_catch2_fetch_content)
-  if (FETCHCONTENT_SOURCE_DIR_CATCH2)
-    message(STATUS "  Using provided Catch2 source: ${FETCHCONTENT_SOURCE_DIR_CATCH2}")
-  else()
-    # Unique lock per user/path to avoid /tmp permission issues
-    set(U_ID "cmake")
-    if(DEFINED ENV{USER})
-      set(U_ID $ENV{USER})
-    endif()
-    string(REPLACE "/" "_" SANITIZED_PATH "${EKAT_SOURCE_DIR}")
-    set(CATCH2_LOCK_FILE "/tmp/${U_ID}_ekat_catch2_${SANITIZED_PATH}.lock")
-    file (LOCK "${CATCH2_LOCK_FILE}" GUARD FUNCTION)
-
-    if (EXISTS "${EKAT_SOURCE_DIR}/extern/Catch2/.git/index")
-      # Ask Git for the current HEAD commit hash
-      execute_process(
-        COMMAND git rev-parse HEAD
-        WORKING_DIRECTORY "${EKAT_SOURCE_DIR}/extern/Catch2"
-        OUTPUT_VARIABLE ON_DISK_SHA
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-      )
-      if (ON_DISK_SHA STREQUAL CATCH2_GIT_TAG)
-        message (STATUS "  Catch2 source dir already populated with correct version. Skipping download.")
-        set(FETCHCONTENT_SOURCE_DIR_CATCH2 "${EKAT_SOURCE_DIR}/extern/Catch2" CACHE PATH "Path to Catch2 source" FORCE)
-      else()
-        message (STATUS "  Catch2 version mismatch (Disk: ${ON_DISK_SHA}, Req: ${CATCH2_GIT_TAG}). Proceeding with update.")
-      endif()
-    endif()
-  endif()
-
-  FetchContent_MakeAvailable(Catch2)
-endfunction()
-
-ekat_catch2_fetch_content()
+# Calls FetchContent_MakeAvailable in a way that avoids race conditions
+ekat_make_available(Catch2 ${CATCH2_GIT_TAG})

--- a/cmake/tpls/EkatBuildSpdlog.cmake
+++ b/cmake/tpls/EkatBuildSpdlog.cmake
@@ -1,5 +1,6 @@
 # Fetch and build spdlog via FetchContent
 include (FetchContent)
+include (EkatUtils)
 
 message (STATUS "  Fetching spdlog via FetchContent")
 
@@ -17,47 +18,9 @@ FetchContent_Declare(spdlog
   BINARY_DIR     ${EKAT_BINARY_DIR}/extern/spdlog
 )
 
-# We must protect the MakeAvailable call with a LOCK,
-# to avoid race condition if building 2+ builds at once
-# We use a function since the lock FUNCTION guard is the safest
-# approach (better than FILE), but needs a function scope
-function (ekat_spdlog_fetch_content)
-  if (FETCHCONTENT_SOURCE_DIR_SPDLOG)
-    message(STATUS "  Using provided spdlog source: ${FETCHCONTENT_SOURCE_DIR_SPDLOG}")
-  else()
-    # Unique lock per user/path to avoid /tmp permission issues
-    set(U_ID "cmake")
-    if(DEFINED ENV{USER})
-      set(U_ID $ENV{USER})
-    endif()
-    string(REPLACE "/" "_" SANITIZED_PATH "${EKAT_SOURCE_DIR}")
-    set(SPDLOG_LOCK_FILE "/tmp/${U_ID}_ekat_spdlog_${SANITIZED_PATH}.lock")
-    file (LOCK "${SPDLOG_LOCK_FILE}" GUARD FUNCTION)
-
-    if (EXISTS "${EKAT_SOURCE_DIR}/extern/spdlog/.git/index")
-      # Ask Git for the current HEAD commit hash
-      execute_process(
-        COMMAND git rev-parse HEAD
-        WORKING_DIRECTORY "${EKAT_SOURCE_DIR}/extern/spdlog"
-        OUTPUT_VARIABLE ON_DISK_SHA
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-      )
-      if (ON_DISK_SHA STREQUAL SPDLOG_GIT_TAG)
-        message (STATUS "  spdlog source dir already populated with correct version. Skipping download.")
-        set(FETCHCONTENT_SOURCE_DIR_SPDLOG "${EKAT_SOURCE_DIR}/extern/spdlog" CACHE PATH "Path to spdlog source" FORCE)
-      else()
-        message (STATUS "  spdlog version mismatch (Disk: ${ON_DISK_SHA}, Req: ${SPDLOG_GIT_TAG}). Proceeding with update.")
-      endif()
-    endif()
-  endif()
-
-  FetchContent_MakeAvailable(spdlog)
-endfunction()
-
-ekat_spdlog_fetch_content()
+# Calls FetchContent_MakeAvailable in a way that avoids race conditions
+ekat_make_available(spdlog ${SPDLOG_GIT_TAG})
 
 if (EKAT_DISABLE_TPL_WARNINGS)
-  include (EkatUtils)
   EkatDisableAllWarning(spdlog)
 endif ()

--- a/cmake/tpls/EkatBuildSpdlog.cmake
+++ b/cmake/tpls/EkatBuildSpdlog.cmake
@@ -3,6 +3,8 @@ include (FetchContent)
 
 message (STATUS "  Fetching spdlog via FetchContent")
 
+set (SPDLOG_GIT_TAG bdd1dff3788ebfe520f48f9ad216c60da6dd8f00)
+
 # We don't want testing or any spdlog executable at all
 option (SPDLOG_BUILD_TESTS "Enable spdlog tests" OFF)
 option (SPDLOG_BUILD_EXAMPLE "Enable spdlog examples" OFF)
@@ -10,12 +12,50 @@ option (SPDLOG_INSTALL "Spdlog install location" ON)
 
 FetchContent_Declare(spdlog
   GIT_REPOSITORY https://github.com/e3sm-project/spdlog.git
-  GIT_TAG        bdd1dff3788ebfe520f48f9ad216c60da6dd8f00
+  GIT_TAG        ${SPDLOG_GIT_TAG}
   SOURCE_DIR     ${EKAT_SOURCE_DIR}/extern/spdlog
   BINARY_DIR     ${EKAT_BINARY_DIR}/extern/spdlog
 )
 
-FetchContent_MakeAvailable(spdlog)
+# We must protect the MakeAvailable call with a LOCK,
+# to avoid race condition if building 2+ builds at once
+# We use a function since the lock FUNCTION guard is the safest
+# approach (better than FILE), but needs a function scope
+function (ekat_spdlog_fetch_content)
+  if (FETCHCONTENT_SOURCE_DIR_SPDLOG)
+    message(STATUS "  Using provided spdlog source: ${FETCHCONTENT_SOURCE_DIR_SPDLOG}")
+  else()
+    # Unique lock per user/path to avoid /tmp permission issues
+    set(U_ID "cmake")
+    if(DEFINED ENV{USER})
+      set(U_ID $ENV{USER})
+    endif()
+    string(REPLACE "/" "_" SANITIZED_PATH "${EKAT_SOURCE_DIR}")
+    set(SPDLOG_LOCK_FILE "/tmp/${U_ID}_ekat_spdlog_${SANITIZED_PATH}.lock")
+    file (LOCK "${SPDLOG_LOCK_FILE}" GUARD FUNCTION)
+
+    if (EXISTS "${EKAT_SOURCE_DIR}/extern/spdlog/.git/index")
+      # Ask Git for the current HEAD commit hash
+      execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY "${EKAT_SOURCE_DIR}/extern/spdlog"
+        OUTPUT_VARIABLE ON_DISK_SHA
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      if (ON_DISK_SHA STREQUAL SPDLOG_GIT_TAG)
+        message (STATUS "  spdlog source dir already populated with correct version. Skipping download.")
+        set(FETCHCONTENT_SOURCE_DIR_SPDLOG "${EKAT_SOURCE_DIR}/extern/spdlog" CACHE PATH "Path to spdlog source" FORCE)
+      else()
+        message (STATUS "  spdlog version mismatch (Disk: ${ON_DISK_SHA}, Req: ${SPDLOG_GIT_TAG}). Proceeding with update.")
+      endif()
+    endif()
+  endif()
+
+  FetchContent_MakeAvailable(spdlog)
+endfunction()
+
+ekat_spdlog_fetch_content()
 
 if (EKAT_DISABLE_TPL_WARNINGS)
   include (EkatUtils)

--- a/cmake/tpls/EkatBuildYamlCpp.cmake
+++ b/cmake/tpls/EkatBuildYamlCpp.cmake
@@ -1,5 +1,6 @@
 # Fetch and build yaml-cpp via FetchContent
 include (FetchContent)
+include (EkatUtils)
 
 message (STATUS "  Fetching yaml-cpp via FetchContent")
 
@@ -16,45 +17,8 @@ FetchContent_Declare(yaml-cpp
   BINARY_DIR     ${EKAT_BINARY_DIR}/extern/yaml-cpp
 )
 
-# We must protect the MakeAvailable call with a LOCK,
-# to avoid race condition if building 2+ builds at once
-# We use a function since the lock FUNCTION guard is the safest
-# approach (better than FILE), but needs a function scope
-function (ekat_yaml_cpp_fetch_content)
-  if (FETCHCONTENT_SOURCE_DIR_YAML_CPP)
-    message(STATUS "  Using provided yaml-cpp source: ${FETCHCONTENT_SOURCE_DIR_YAML_CPP}")
-  else()
-    # Unique lock per user/path to avoid /tmp permission issues
-    set(U_ID "cmake")
-    if(DEFINED ENV{USER})
-      set(U_ID $ENV{USER})
-    endif()
-    string(REPLACE "/" "_" SANITIZED_PATH "${EKAT_SOURCE_DIR}")
-    set(YAML_CPP_LOCK_FILE "/tmp/${U_ID}_ekat_yaml-cpp_${SANITIZED_PATH}.lock")
-    file (LOCK "${YAML_CPP_LOCK_FILE}" GUARD FUNCTION)
-
-    if (EXISTS "${EKAT_SOURCE_DIR}/extern/yaml-cpp/.git/index")
-      # Ask Git for the current HEAD commit hash
-      execute_process(
-        COMMAND git rev-parse HEAD
-        WORKING_DIRECTORY "${EKAT_SOURCE_DIR}/extern/yaml-cpp"
-        OUTPUT_VARIABLE ON_DISK_SHA
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-      )
-      if (ON_DISK_SHA STREQUAL YAML_CPP_GIT_TAG)
-        message (WARNING "  yaml-cpp source dir already populated with correct version. Skipping download.")
-        set(FETCHCONTENT_SOURCE_DIR_YAML_CPP "${EKAT_SOURCE_DIR}/extern/yaml-cpp" CACHE PATH "Path to yaml-cpp source" FORCE)
-      else()
-        message (STATUS "  yaml-cpp version mismatch (Disk: ${ON_DISK_SHA}, Req: ${YAML_CPP_GIT_TAG}). Proceeding with update.")
-      endif()
-    endif()
-  endif()
-
-  FetchContent_MakeAvailable(yaml-cpp)
-endfunction()
-
-ekat_yaml_cpp_fetch_content()
+# Calls FetchContent_MakeAvailable in a way that avoids race conditions
+ekat_make_available(yaml-cpp ${YAML_CPP_GIT_TAG})
 
 if (EKAT_DISABLE_TPL_WARNINGS)
   include (EkatUtils)

--- a/cmake/tpls/EkatBuildYamlCpp.cmake
+++ b/cmake/tpls/EkatBuildYamlCpp.cmake
@@ -3,18 +3,58 @@ include (FetchContent)
 
 message (STATUS "  Fetching yaml-cpp via FetchContent")
 
+set (YAML_CPP_GIT_TAG 95088a0a2b6f2dec0b3e6e59020cdcc0d4f3c658)
+
 # Set options for yamlcpp before adding the subdirectory
 option (YAML_CPP_BUILD_TOOLS "Enable parse tools" OFF)
 option (YAML_CPP_BUILD_TESTS "Enable yaml-cpp tests" OFF)
 
 FetchContent_Declare(yaml-cpp
   GIT_REPOSITORY https://github.com/e3sm-project/yaml-cpp.git
-  GIT_TAG        95088a0a2b6f2dec0b3e6e59020cdcc0d4f3c658
+  GIT_TAG        ${YAML_CPP_GIT_TAG}
   SOURCE_DIR     ${EKAT_SOURCE_DIR}/extern/yaml-cpp
   BINARY_DIR     ${EKAT_BINARY_DIR}/extern/yaml-cpp
 )
 
-FetchContent_MakeAvailable(yaml-cpp)
+# We must protect the MakeAvailable call with a LOCK,
+# to avoid race condition if building 2+ builds at once
+# We use a function since the lock FUNCTION guard is the safest
+# approach (better than FILE), but needs a function scope
+function (ekat_yaml_cpp_fetch_content)
+  if (FETCHCONTENT_SOURCE_DIR_YAML_CPP)
+    message(STATUS "  Using provided yaml-cpp source: ${FETCHCONTENT_SOURCE_DIR_YAML_CPP}")
+  else()
+    # Unique lock per user/path to avoid /tmp permission issues
+    set(U_ID "cmake")
+    if(DEFINED ENV{USER})
+      set(U_ID $ENV{USER})
+    endif()
+    string(REPLACE "/" "_" SANITIZED_PATH "${EKAT_SOURCE_DIR}")
+    set(YAML_CPP_LOCK_FILE "/tmp/${U_ID}_ekat_yaml-cpp_${SANITIZED_PATH}.lock")
+    file (LOCK "${YAML_CPP_LOCK_FILE}" GUARD FUNCTION)
+
+    if (EXISTS "${EKAT_SOURCE_DIR}/extern/yaml-cpp/.git/index")
+      # Ask Git for the current HEAD commit hash
+      execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY "${EKAT_SOURCE_DIR}/extern/yaml-cpp"
+        OUTPUT_VARIABLE ON_DISK_SHA
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      if (ON_DISK_SHA STREQUAL YAML_CPP_GIT_TAG)
+        message (WARNING "  yaml-cpp source dir already populated with correct version. Skipping download.")
+        set(FETCHCONTENT_SOURCE_DIR_YAML_CPP "${EKAT_SOURCE_DIR}/extern/yaml-cpp" CACHE PATH "Path to yaml-cpp source" FORCE)
+      else()
+        message (STATUS "  yaml-cpp version mismatch (Disk: ${ON_DISK_SHA}, Req: ${YAML_CPP_GIT_TAG}). Proceeding with update.")
+      endif()
+    endif()
+  endif()
+
+  FetchContent_MakeAvailable(yaml-cpp)
+endfunction()
+
+ekat_yaml_cpp_fetch_content()
 
 if (EKAT_DISABLE_TPL_WARNINGS)
   include (EkatUtils)


### PR DESCRIPTION
Avoids race conditions since we clone in the src tree

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
E3SM testing exposed a flaw in our FetchContent usage: since we donwload in the source tree, if there are 2+ concurrent builds, they may try to both clone into the same folder at the same time, causing race conditions and git (or cmake soon after) errors.

This PR fixes this, and adds a small configurability upgrade too. Summary:

- use a file LOCK to "serialize" calls to `FetchContent_MakeAvailable`
- after aquiring the lock, but before calling `FetchContent_MakeAvailable`, check if the source dir is populated AND has the correct git sha. If so, set the `FETCHCONTENT_SOURCE_DIR_<PACKAGE>` cmake var. This var is a powerful override of cmake's FetchContent behavior: it tells cmake "don't bother downloading the code, use whatever is in this directory".
- make the `FETCHCONTENT_SOURCE_DIR_<PACKAGE>`  cmake var a CACHE var. While this is not needed to address the core issue, it allows user to try different versions of the tpl without having to change the cmake scripts in EKAT (e.g., updating the `SPDLOG_GIT_TAG` env var), and just pass this var on the cmd line to cmake. A nice feature to have.

Notice that, while this fix was mostly to address race conditions in parallel builds, it also helps users that want to build ekat without access to the network: if the source tree is already populated (with the correct sha), setting the `FETCHCONTENT_SOURCE_DIR_<PACKAGE>`  effectively prevents cmake from having to ping the remote. Without it, according to gemini, even if the folder already contains the correct code, it does still perform a `git fetch`. I am not entirely sold on this, but did not want to spend too much time verifying it, so I'm taking gemini's word for it, and claim this as a side bonus.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This is urgently needed to fix e3sm's dashboard (jenkins is building several cases at once, so this issue is highly important there).
## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I manually verified that with this fix I can build an e3sm test suite with 3 cases in it.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
