### PR TITLE
Improve fetch content utility for parallel builds

### DIFF
--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -148,37 +148,90 @@ function(separate_cut_arguments prefix options oneValueArgs multiValueArgs retur
 endfunction(separate_cut_arguments)
 
 # Utility to avoid race conditions in FetchContent_MakeAvailable
-# when 2+ builds are configuring at the same time
-include(FetchContent)
-function(ekat_make_available NAME GIT_TAG_VALUE)
+# when 2+ builds are configuring at the same time. Only the 1st one
+# will actually populate (i.e. clone) the TPL folder, and ONLY if
+# the folder doesn't exist or contains a different version of the code
+function (ekat_fetch_content NAME)
+  # 0.b Check if we already parsed the TPL (if so, we're done)
+  get_property(already_added GLOBAL PROPERTY EKAT_TPL_${NAME}_ADDED)
+  if (already_added)
+    get_property(first_caller GLOBAL PROPERTY EKAT_TPL_${NAME}_CALLER)
+    message(AUTHOR_WARNING
+      "  ${NAME}: This TPL has already been added to the build tree.\n"
+      "  Subsequent calls to ekat_fetch_content(${NAME}) will NOT reconfigure the TPL.\n"
+      "  First added from: ${first_caller}\n"
+      "  If you need to change TPL options, do it at the first call site."
+    )
+    return()
+  endif()
+
+  # 0.b Support the standard CMake override: -DFETCHCONTENT_SOURCE_DIR_<NAME>=/path/to/src
   string(TOUPPER "${NAME}" NAME_UPPER)
   string(REPLACE "-" "_" NAME_SANITIZED "${NAME_UPPER}")
-  set(FC_VAR "FETCHCONTENT_SOURCE_DIR_${NAME_SANITIZED}")
+  set(OVERRIDE_VAR "FETCHCONTENT_SOURCE_DIR_${NAME_SANITIZED}")
+  if (DEFINED ${OVERRIDE_VAR})
+    message(STATUS "  ${NAME}: Using source override from ${${OVERRIDE_VAR}}")
+    # Mark as added and jump straight to the finish
+    add_subdirectory("${${OVERRIDE_VAR}}" "${CMAKE_BINARY_DIR}/externals/${NAME}")
+    set_property(GLOBAL PROPERTY EKAT_TPL_${NAME}_ADDED TRUE)
+    set_property(GLOBAL PROPERTY EKAT_TPL_${NAME}_CALLER "${CMAKE_CURRENT_LIST_FILE}")
+    return()
+  endif()
 
-  # 1. Respect existing User/Cache Override
-  if (${FC_VAR})
-    message(STATUS "  Using provided ${NAME} source: ${${FC_VAR}}")
-  else()
-    # 2. Setup the Lock (Using the source tree for multi-user safety)
-    set(LOCK_FILE "${EKAT_SOURCE_DIR}/extern/.${NAME}.lock")
-    file(LOCK "${LOCK_FILE}" GUARD FUNCTION)
+  # 1. Define the expected arguments
+  set(options "")
+  set(oneValueArgs GIT_REPOSITORY GIT_TAG SOURCE_DIR)
+  set(multiValueArgs "")
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    # 3. Verify on-disk state
-    set(TPL_SRC_DIR "${EKAT_SOURCE_DIR}/extern/${NAME}")
-    if(EXISTS "${TPL_SRC_DIR}/.git/index" AND EXISTS "${TPL_SRC_DIR}/.git/HEAD")
-      file(READ "${TPL_SRC_DIR}/.git/HEAD" ON_DISK_SHA)
-      string(STRIP "${ON_DISK_SHA}" ON_DISK_SHA)
+  # 2. Setup paths and lock (a hidden file in the source dir parent folder)
+  get_filename_component(ABS_SOURCE_DIR "${ARG_SOURCE_DIR}" ABSOLUTE)
+  get_filename_component(PARENT_DIR "${ABS_SOURCE_DIR}" DIRECTORY)
+  set(LOCK_FILE "${PARENT_DIR}/.${NAME}.lock")
 
-      if(ON_DISK_SHA STREQUAL GIT_TAG_VALUE)
-        message(STATUS "  ${NAME}: Source matches required version (${GIT_TAG_VALUE}). Bypassing populate step.")
-        # Promote to CACHE so all sub-projects see the bypass
-        set(${FC_VAR} "${TPL_SRC_DIR}" CACHE PATH "Path to ${NAME} source" FORCE)
-      else()
-        message(STATUS "  ${NAME}: Source version mismatch (found ${ON_DISK_SHA}, expected ${GIT_TAG_VALUE}). Proceeding with populate step.")
-      endif()
+  # 3. Serialized section: lock the shared source area to verify/populate
+  file(LOCK "${LOCK_FILE}" GUARD FUNCTION TIMEOUT 600)
+
+  # 4. Check if we need to populate the TPL source dir
+  set (POPULATE TRUE)
+  if (EXISTS "${ABS_SOURCE_DIR}/.git/index")
+    # Ask Git for the current HEAD commit hash
+    execute_process(
+      COMMAND git rev-parse HEAD
+      WORKING_DIRECTORY ${ABS_SOURCE_DIR}
+      OUTPUT_VARIABLE ON_DISK_SHA
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+    if ("${ON_DISK_SHA}" STREQUAL "${ARG_GIT_TAG}")
+      message (STATUS "  ${NAME} source dir already populated with correct version. Skipping populate...")
+      set (POPULATE FALSE)
+    else()
+      message (STATUS "  ${NAME} source dir already populated but with incorrect version. Calling populate...\n"
+                      "    Found version: ${ON_DISK_SHA}"
+                      "    Expected version: ${ARG_GIT_TAG}")
     endif()
   endif()
 
-  # 4. Finalize
-  FetchContent_MakeAvailable(${NAME})
+  # 5. Populate (if needed)
+  if (POPULATE)
+    # Use FetchContent internally for the one build that 'wins' the lock
+    include(FetchContent)
+    FetchContent_Declare(${NAME}
+        GIT_REPOSITORY ${ARG_GIT_REPOSITORY}
+        GIT_TAG        ${ARG_GIT_TAG}
+        SOURCE_DIR     ${ABS_SOURCE_DIR}
+    )
+
+    # This performs the actual git clone/checkout
+    FetchContent_Populate(${NAME})
+  endif ()
+
+  # We can finally release the lock
+  file(LOCK "${LOCK_FILE}" RELEASE)
+
+  # 6. Parse subfolder, and set global property (so we don't re-add it by mistake)
+  add_subdirectory("${ABS_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/externals/${NAME}")
+  set_property(GLOBAL PROPERTY EKAT_TPL_${NAME}_ADDED TRUE)
+  set_property(GLOBAL PROPERTY EKAT_TPL_${NAME}_CALLER "${CMAKE_CURRENT_LIST_FILE}")
 endfunction()

--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -170,6 +170,18 @@ function (ekat_fetch_content NAME)
   string(REPLACE "-" "_" NAME_SANITIZED "${NAME_UPPER}")
   set(OVERRIDE_VAR "FETCHCONTENT_SOURCE_DIR_${NAME_SANITIZED}")
   if (DEFINED ${OVERRIDE_VAR})
+    set(OVERRIDE_DIR "${${OVERRIDE_VAR}}")
+    if ("${OVERRIDE_DIR}" STREQUAL "")
+      message(FATAL_ERROR
+        "  ${NAME}: ${OVERRIDE_VAR} is defined but empty.\n"
+        "  Please set it to a valid source directory.")
+    endif()
+    if (NOT IS_DIRECTORY "${OVERRIDE_DIR}")
+      message(FATAL_ERROR
+        "  ${NAME}: ${OVERRIDE_VAR} does not point to an existing directory:\n"
+        "  ${OVERRIDE_DIR}")
+    endif()
+
     message(STATUS "  ${NAME}: Using source override from ${${OVERRIDE_VAR}}")
     # Mark as added and jump straight to the finish
     add_subdirectory("${${OVERRIDE_VAR}}" "${CMAKE_BINARY_DIR}/externals/${NAME}")
@@ -183,6 +195,18 @@ function (ekat_fetch_content NAME)
   set(oneValueArgs GIT_REPOSITORY GIT_TAG SOURCE_DIR)
   set(multiValueArgs "")
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Check for unparsed arguments (typos in argument names)
+  if (ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ekat_fetch_content(${NAME}): Unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # Ensure all critical parameters are present
+  foreach(req_var GIT_REPOSITORY GIT_TAG SOURCE_DIR)
+    if (NOT ARG_${req_var})
+      message(FATAL_ERROR "ekat_fetch_content(${NAME}): Missing required argument: ${req_var}")
+    endif()
+  endforeach()
 
   # 2. Setup paths and lock (a hidden file in the source dir parent folder)
   get_filename_component(ABS_SOURCE_DIR "${ARG_SOURCE_DIR}" ABSOLUTE)

--- a/cmake/tpls/EkatBuildCatch2.cmake
+++ b/cmake/tpls/EkatBuildCatch2.cmake
@@ -12,12 +12,9 @@ set(CATCH_INSTALL_HELPERS OFF CACHE BOOL "Disable Catch2 install" FORCE)
 set(CATCH_FORCE_INSTALL ON CACHE BOOL "Force install even if Catch2 is a subproject" FORCE)
 set(CATCH_INSTALL_DOCS OFF CACHE BOOL "Install documentation alongside library" FORCE)
 
-FetchContent_Declare(Catch2
+# If TPL is already present with correct sha simply adds subdir, otherwise uses FetchContent first
+ekat_fetch_content(Catch2
   GIT_REPOSITORY https://github.com/E3SM-Project/Catch2.git
   GIT_TAG        ${CATCH2_GIT_TAG}
   SOURCE_DIR     ${EKAT_SOURCE_DIR}/extern/Catch2
-  BINARY_DIR     ${EKAT_BINARY_DIR}/extern/Catch2
 )
-
-# Calls FetchContent_MakeAvailable in a way that avoids race conditions
-ekat_make_available(Catch2 ${CATCH2_GIT_TAG})

--- a/cmake/tpls/EkatBuildSpdlog.cmake
+++ b/cmake/tpls/EkatBuildSpdlog.cmake
@@ -11,15 +11,12 @@ option (SPDLOG_BUILD_TESTS "Enable spdlog tests" OFF)
 option (SPDLOG_BUILD_EXAMPLE "Enable spdlog examples" OFF)
 option (SPDLOG_INSTALL "Spdlog install location" ON)
 
-FetchContent_Declare(spdlog
+# If TPL is already present with correct sha simply adds subdir, otherwise uses FetchContent first
+ekat_fetch_content(spdlog
   GIT_REPOSITORY https://github.com/e3sm-project/spdlog.git
   GIT_TAG        ${SPDLOG_GIT_TAG}
   SOURCE_DIR     ${EKAT_SOURCE_DIR}/extern/spdlog
-  BINARY_DIR     ${EKAT_BINARY_DIR}/extern/spdlog
 )
-
-# Calls FetchContent_MakeAvailable in a way that avoids race conditions
-ekat_make_available(spdlog ${SPDLOG_GIT_TAG})
 
 if (EKAT_DISABLE_TPL_WARNINGS)
   EkatDisableAllWarning(spdlog)

--- a/cmake/tpls/EkatBuildYamlCpp.cmake
+++ b/cmake/tpls/EkatBuildYamlCpp.cmake
@@ -10,15 +10,12 @@ set (YAML_CPP_GIT_TAG 95088a0a2b6f2dec0b3e6e59020cdcc0d4f3c658)
 option (YAML_CPP_BUILD_TOOLS "Enable parse tools" OFF)
 option (YAML_CPP_BUILD_TESTS "Enable yaml-cpp tests" OFF)
 
-FetchContent_Declare(yaml-cpp
+# If TPL is already present with correct sha simply adds subdir, otherwise uses FetchContent first
+ekat_fetch_content (yaml-cpp
   GIT_REPOSITORY https://github.com/e3sm-project/yaml-cpp.git
   GIT_TAG        ${YAML_CPP_GIT_TAG}
   SOURCE_DIR     ${EKAT_SOURCE_DIR}/extern/yaml-cpp
-  BINARY_DIR     ${EKAT_BINARY_DIR}/extern/yaml-cpp
 )
-
-# Calls FetchContent_MakeAvailable in a way that avoids race conditions
-ekat_make_available(yaml-cpp ${YAML_CPP_GIT_TAG})
 
 if (EKAT_DISABLE_TPL_WARNINGS)
   include (EkatUtils)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The current logic was still not robust enough in parallel builds. The core issue (after digging with a bot) seemed to be the fact that, while we did skip the clone in FC's MakeAvailable by setting `FETCHCONTENT_SOURCE_DIR_<PKG>` for bulds 2,3,..., we were still calling `FetchContent_MakeAvailable`, which does end up touching more files, and messing with the generation phase (somehow).

The new impl only uses the Declare/Populate features of FC, and does NOT use MakeAvailable, but rather simply adds the subdirectory.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
