### PR TITLE
Fix error due to expired temporary usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ extern/yaml-cpp/
 
 # Our util ekat_fetch_tpl util uses these lock files to avoid race conditions
 extern/.*.lock
+
+# Directory created by CACTS testing framework
+ctest-build

--- a/src/core/ekat_units.hpp
+++ b/src/core/ekat_units.hpp
@@ -58,9 +58,11 @@ public:
   // No default
   Units () = delete;
 
-  // Construct a non-dimensional quantity
+  // Construct a Non-dimensional quantity
   constexpr Units (const ScalingFactor& scaling)
-   : Units(0,0,0,0,0,0,0,scaling,scaling.string_repr<UNITS_MAX_STR_LEN>().data())
+   : m_scaling (scaling)
+   , m_units {0,0,0,0,0,0,0}
+   , m_string_repr {scaling.string_repr<UNITS_MAX_STR_LEN>()}
   {
     // Nothing to do here
   }
@@ -196,9 +198,9 @@ private:
     // 1. Calculate required length upfront
     const bool comp1 = composite(lhs);
     const bool comp2 = composite(rhs);
-    
-    const size_t total_len = lhs.size() + rhs.size() + 
-                             (comp1 ? 2 : 0) + (comp2 ? 2 : 0) + 
+
+    const size_t total_len = lhs.size() + rhs.size() +
+                             (comp1 ? 2 : 0) + (comp2 ? 2 : 0) +
                              (sep != '\0' ? 1 : 0);
     // Trigger a compiler error if the name is too long.
     assert (total_len<UNITS_MAX_STR_LEN);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Intel compiler (sometimes) caught an issue with a recent change in Units framework, namely the usage of some expired temporary object. Apparently gcc/clang do allow this (somehow), but Intel sometimes doesn't. Intel is right here.

This PR addresses that nano bug.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
