### PR TITLE
Fix warning that appears lots of times in release builds

### DIFF
--- a/src/core/ekat_units.hpp
+++ b/src/core/ekat_units.hpp
@@ -208,6 +208,7 @@ private:
                              (sep != '\0' ? 1 : 0);
     // Trigger a compiler error if the name is too long.
     assert (total_len<UNITS_MAX_STR_LEN);
+    (void)total_len;
 
     std::array<char, UNITS_MAX_STR_LEN> out = {'\0'};
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
I noticed a zillion of this warning in release builds, so decided to get rid of it.
```
/home/runner/_work/E3SM/E3SM/externals/ekat/src/core/ekat_units.hpp:206:18: warning: unused variable 'total_len' [-Wunused-variable]
6823
  206 |     const size_t total_len = lhs.size() + rhs.size() +
6824
      |                  ^~~~~~~~~
```
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
