### PR TITLE
Fix usage of ScalarTraits in invalid fcn

### DIFF
--- a/src/pack/ekat_pack.hpp
+++ b/src/pack/ekat_pack.hpp
@@ -663,7 +663,7 @@ template<typename PackT>
 KOKKOS_INLINE_FUNCTION
 constexpr OnlyPack<PackT> invalid () {
   using scalar_t = typename ScalarTraits<PackT>::scalar_type;
-  if constexpr (ScalarTraits<PackT>::is_floating_point) {
+  if constexpr (ScalarTraits<scalar_t>::is_floating_point) {
     constexpr auto s = Kokkos::Experimental::quiet_NaN_v<scalar_t>;
     return PackT{s};
   } else {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The version we have in master _should_ work, but likely due to complex and peculiar template nesting, the compiler gets tripped, and does not find `ScalarTraits<PackT>::is_floating_point` (where PackT here is the template type). The error looks like

```
/home/lbertag/workdir/e3sm/e3sm-src/branch/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp:1187:30:   required from here
/home/lbertag/workdir/e3sm/e3sm-src/branch/externals/ekat/src/pack/ekat_pack.hpp:666:38: error: 'is_floating_point' is not a member of 'ekat::ScalarTraits<ekat::Pack<double, 16> >'
  666 |   if constexpr (ScalarTraits<PackT>::is_floating_point) {
      |  
```
which is nonsense, since the `ScalarTraits<PackT>` struct is resolved correctly the very line above (otherwise this fix would not work). Alas, this minor change works, and since `ScalarTraits<scalar_t>::is_floating_point` should yield the same thing as `ScalarTraits<PackT>::is_floating_point`, we can use the former in place of the latter and call it "a fix".

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
