### PR TITLE
Use SOURCES keyword for source files in EkatCreateUnitTestExec

### DIFF
--- a/cmake/EkatCreateUnitTest.cmake
+++ b/cmake/EkatCreateUnitTest.cmake
@@ -4,6 +4,7 @@ include(EkatUtils) # To check macro args
 set(CUT_EXEC_OPTIONS EXCLUDE_MAIN_CPP USER_DEFINED_TEST_SESSION)
 set(CUT_EXEC_1V_ARGS)
 set(CUT_EXEC_MV_ARGS
+  SOURCES
   INCLUDE_DIRS
   COMPILER_DEFS
   COMPILER_C_DEFS COMPILER_CXX_DEFS COMPILER_F_DEFS
@@ -29,16 +30,16 @@ set(CUT_TEST_MV_ARGS DEP EXE_ARGS MPI_RANKS THREADS LABELS PROPERTIES
 
 # This function takes the following mandatory arguments:
 #    - exec_name: the name of the test executable that will be created.
-#    - exec_srcs: a list of src files for the executable.
-#      Note: no need to include ekat_catch_main.cpp; this macro will add it (if needed).
-# The following optional arguments can be passed as ARG_NAME "ARG_VAL":
+# The following keyword arguments can be passed as ARG_NAME ARG_VAL.
+# Note: all these arguments are optional EXCEPT for the SOURCES arg, which is required.
+#    - SOURCES: a list of src files for the executable.
 #    - INCLUDE_DIRS: a list of directories to add to the include search path
 #    - COMPILE_[C_|CXX_|F_]DEFS: a list of additional (possibly language-specific) defines for the compiler
 #    - COMPILER_[C_|CXX_|F_]FLAGS: a list of additional flags (possibly language-specific) for the compiler
 #    - LIBS: a list of libraries needed by the executable (i.e., libs/targets to link against)
 #    - LIBS_DIRS: a list of directories to add to the linker search path
 #    - LINKER_FLAGS: a list of additional flags for the linker
-function(EkatCreateUnitTestExec exec_name exec_srcs)
+function(EkatCreateUnitTestExec exec_name)
   #---------------------------#
   #   Parse function inputs   #
   #---------------------------#
@@ -58,7 +59,10 @@ function(EkatCreateUnitTestExec exec_name exec_srcs)
   #-------------------------------------------------#
 
   set(target_name ${exec_name})
-  add_executable(${target_name} ${exec_srcs})
+  if (NOT ecute_SOURCES)
+    message (FATAL_ERROR "Target ${target_name} created without specifying the SOURCES arg")
+  endif()
+  add_executable(${target_name} ${ecute_SOURCES})
 
   #---------------------------#
   # Set all target properties #
@@ -78,7 +82,7 @@ function(EkatCreateUnitTestExec exec_name exec_srcs)
     )
 
   # Check if we need a Fortran modules folder
-  foreach (file ${exec_srcs})
+  foreach (file ${ecute_SOURCES})
     get_filename_component(ext ${file} EXT)
     string(REGEX REPLACE "^\\." "" ext ${ext})
 
@@ -429,7 +433,7 @@ endfunction(EkatCreateUnitTestFromExec)
 # This function combines the two above, to create an executable, and use it
 # to create a suite of unit tests. The optional arguments are the union of
 # the optional arguments of the two functions above
-function(EkatCreateUnitTest test_name test_srcs)
+function(EkatCreateUnitTest test_name)
   set(options ${CUT_EXEC_OPTIONS} ${CUT_TEST_OPTIONS})
   set(oneValueArgs ${CUT_EXEC_1V_ARGS} ${CUT_TEST_1V_ARGS})
   set(multiValueArgs ${CUT_EXEC_MV_ARGS} ${CUT_TEST_MV_ARGS})
@@ -443,7 +447,7 @@ function(EkatCreateUnitTest test_name test_srcs)
   #------------------------------#
 
   separate_cut_arguments(ecut "${CUT_EXEC_OPTIONS}" "${CUT_EXEC_1V_ARGS}" "${CUT_EXEC_MV_ARGS}" options_ExecPhase)
-  EkatCreateUnitTestExec("${test_name}" "${test_srcs}" ${options_ExecPhase})
+  EkatCreateUnitTestExec("${test_name}" ${options_ExecPhase})
 
   #------------------------------#
   #      Create Tests Phase      #

--- a/cmake/EkatCreateUnitTestWithAsserts.cmake
+++ b/cmake/EkatCreateUnitTestWithAsserts.cmake
@@ -54,7 +54,7 @@ function(EkatCreateUnitTestWithAsserts test_base_name test_meta_src)
   # stripped, which is *not* supposed to fail
   EkatCreateUnitTest(
     ${test_base_name}
-    ${CMAKE_CURRENT_BINARY_DIR}/${base_src}.cpp
+    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/${base_src}.cpp
     ${ARGN}
   )
 
@@ -69,7 +69,7 @@ function(EkatCreateUnitTestWithAsserts test_base_name test_meta_src)
   foreach (N RANGE 1 ${OUT})
     EkatCreateUnitTest(
       ${test_base_name}_check_assert_${N}
-      ${CMAKE_CURRENT_BINARY_DIR}/${base_src}_${N}.cpp
+      SOURCES ${CMAKE_CURRENT_BINARY_DIR}/${base_src}_${N}.cpp
       WILL_FAIL
       ${ARGN}
     )

--- a/tests/algorithm/CMakeLists.txt
+++ b/tests/algorithm/CMakeLists.txt
@@ -1,39 +1,37 @@
 include(EkatCreateUnitTest)
 
 # Test linear interpolation
-set (LIN_INTERP_SRCS
-  lin_interp_test.cpp
-)
-
 if (EKAT_TEST_DOUBLE_PRECISION)
-  EkatCreateUnitTest(lin_interp${DP_POSTFIX} "${LIN_INTERP_SRCS}"
+  EkatCreateUnitTest(lin_interp${DP_POSTFIX}
+    SOURCES lin_interp_test.cpp
     LIBS ekat::Algorithm
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC})
 endif()
 if (EKAT_TEST_SINGLE_PRECISION)
-  EkatCreateUnitTest(lin_interp${SP_POSTFIX} "${LIN_INTERP_SRCS}"
+  EkatCreateUnitTest(lin_interp${SP_POSTFIX}
+    SOURCES lin_interp_test.cpp
     LIBS ekat::Algorithm
     COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC})
 endif()
 
 # Test tridiag solver
-set (TRIDIAG_SRCS
-  tridiag_tests.cpp
-  tridiag_tests_correctness.cpp
-  tridiag_tests_performance.cpp
-)
-
 if (EKAT_TEST_DOUBLE_PRECISION)
-  EkatCreateUnitTest(tridiag${DP_POSTFIX} "${TRIDIAG_SRCS}"
+  EkatCreateUnitTest(tridiag${DP_POSTFIX}
+    SOURCES tridiag_tests.cpp
+            tridiag_tests_correctness.cpp
+            tridiag_tests_performance.cpp
     LIBS ekat::Algorithm
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     THREADS ${EKAT_TEST_MAX_THREADS}
     EXCLUDE_MAIN_CPP)
 endif()
 if (EKAT_TEST_SINGLE_PRECISION)
-  EkatCreateUnitTest(tridiag${SP_POSTFIX} "${TRIDIAG_SRCS}"
+  EkatCreateUnitTest(tridiag${SP_POSTFIX}
+    SOURCES tridiag_tests.cpp
+            tridiag_tests_correctness.cpp
+            tridiag_tests_performance.cpp
     LIBS ekat::Algorithm
     COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     THREADS ${EKAT_TEST_MAX_THREADS}
@@ -42,25 +40,29 @@ endif()
 
 # Check that the tridiags main returns nonzero if invalid flags are passed
 if (EKAT_TEST_SINGLE_PRECISION)
-  set (invalid_flags_exec tridiag${SP_POSTFIX})
+  EkatCreateUnitTestFromExec(tridiag_invalid_flags tridiag${SP_POSTFIX}
+    EXE_ARGS "--non-existent-flag"
+    LABELS "MustFail"
+    WILL_FAIL
+  )
 else()
-  set (invalid_flags_exec tridiag${DP_POSTFIX})
+  EkatCreateUnitTestFromExec(tridiag_invalid_flags tridiag${DP_POSTFIX}
+    EXE_ARGS "--non-existent-flag"
+    LABELS "MustFail"
+    WILL_FAIL
+  )
 endif()
-
-EkatCreateUnitTestFromExec(tridiag_invalid_flags ${invalid_flags_exec}
-  EXE_ARGS "--non-existent-flag"
-  LABELS "MustFail"
-  WILL_FAIL
-)
 
 # Test reduction utilities
 if (EKAT_TEST_DOUBLE_PRECISION)
-  EkatCreateUnitTest(reduction${DP_POSTFIX} reduction_tests.cpp
+  EkatCreateUnitTest(reduction${DP_POSTFIX}
+    SOURCES reduction_tests.cpp
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     LIBS ekat::Algorithm)
 endif()
 if (EKAT_TEST_SINGLE_PRECISION)
-  EkatCreateUnitTest(reduction${SP_POSTFIX} reduction_tests.cpp
+  EkatCreateUnitTest(reduction${SP_POSTFIX}
+    SOURCES reduction_tests.cpp
     COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     LIBS ekat::Algorithm)
 endif()

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,7 +1,8 @@
 include(EkatCreateUnitTest)
 
 # Test debug tools
-EkatCreateUnitTest(debug_tools debug_tools_tests.cpp
+EkatCreateUnitTest(debug_tools
+  SOURCES debug_tools_tests.cpp
   LIBS ekat::Core)
 
 # Test the framework that checks asserts
@@ -13,7 +14,8 @@ if (EKAT_IS_DEBUG_BUILD)
 endif()
 
 # Ensure that FPE *do* throw when we expect them to
-EkatCreateUnitTestExec (fpe_check "fpe_check.cpp")
+EkatCreateUnitTestExec (fpe_check
+  SOURCES fpe_check.cpp)
 if (EKAT_ENABLE_FPE_DEFAULT_MASK)
   EkatCreateUnitTestFromExec (fpe_check fpe_check
     WILL_FAIL
@@ -23,14 +25,16 @@ else()
 endif()
 
 # Test catch main options
-EkatCreateUnitTest (catch_main_tests catch_main_tests.cpp
+EkatCreateUnitTest (catch_main_tests
+  SOURCES catch_main_tests.cpp
   EXE_ARGS "--args -a 1 --b 2 3 -c=4,5 --d 6,7 -K -foo --bar"
   PROPERTIES PASS_REGULAR_EXPRESSION
   ".*flags: K bar foo, params: a=1, vec_params: a=1 b=2,3 c=4,5 d=6,7")
 
 # Test that failure are indeed spotted. Also, verify that redirection
 # of input is not parsed as test filter, by fwding a file
-EkatCreateUnitTest(regress_fail regress_fail.cpp
+EkatCreateUnitTest(regress_fail
+  SOURCES regress_fail.cpp
   LIBS ekat::Core
   EXE_ARGS " < CTestTestfile.cmake"
   WILL_FAIL
@@ -46,36 +50,44 @@ EkatCreateUnitTestFromExec(catch_main_invalid_flags regress_fail
 
 # Comm tests
 if (EKAT_ENABLE_MPI)
-  EkatCreateUnitTest(comm comm.cpp
+  EkatCreateUnitTest(comm
+    SOURCES comm.cpp
     LIBS ekat::Core
     MPI_RANKS 1 ${EKAT_TEST_MAX_RANKS}
   )
 endif()
 
 # Test units framework
-EkatCreateUnitTest(units units.cpp
+EkatCreateUnitTest(units
+  SOURCES units.cpp
   LIBS ekat::Core)
 
 # Test meta utilities
-EkatCreateUnitTest(meta_utils meta_utils.cpp
+EkatCreateUnitTest(meta_utils
+  SOURCES meta_utils.cpp
   LIBS ekat::Core)
 
 # Test parameter list
-EkatCreateUnitTest(parameter_list parameter_list.cpp
+EkatCreateUnitTest(parameter_list
+  SOURCES parameter_list.cpp
   LIBS ekat::Core)
 
 # Test type traits
-EkatCreateUnitTest(type_traits_utils type_traits_utils.cpp
+EkatCreateUnitTest(type_traits_utils
+  SOURCES type_traits_utils.cpp
   LIBS ekat::Core)
 
 # Test string utilities
-EkatCreateUnitTest(string_utils string_utils.cpp
+EkatCreateUnitTest(string_utils
+  SOURCES string_utils.cpp
   LIBS ekat::Core)
 
 # Test factory
-EkatCreateUnitTest(factory factory.cpp
+EkatCreateUnitTest(factory
+  SOURCES factory.cpp
   LIBS ekat::Core)
 
 # Test zip utility
-EkatCreateUnitTest(zip zip.cpp
+EkatCreateUnitTest(zip
+  SOURCES zip.cpp
   LIBS ekat::Core)

--- a/tests/expression/CMakeLists.txt
+++ b/tests/expression/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(EkatCreateUnitTest)
 
 # Test expression templates
-EkatCreateUnitTest(expressions expressions.cpp
+EkatCreateUnitTest(expressions
+  SOURCES expressions.cpp
   LIBS ekat::Expression)

--- a/tests/kokkos/CMakeLists.txt
+++ b/tests/kokkos/CMakeLists.txt
@@ -1,27 +1,33 @@
 include(EkatCreateUnitTest)
 
 # Test upper_bound
-EkatCreateUnitTest(upper_bound upper_bound.cpp
+EkatCreateUnitTest(upper_bound
+  SOURCES upper_bound.cpp
   LIBS ekat::KokkosUtils)
 
 # Test math utils
-EkatCreateUnitTest(math_utils math_utils.cpp
+EkatCreateUnitTest(math_utils
+  SOURCES math_utils.cpp
   LIBS ekat::KokkosUtils)
 
 # Test view utils
-EkatCreateUnitTest(view_utils view_utils.cpp
+EkatCreateUnitTest(view_utils
+  SOURCES view_utils.cpp
   LIBS ekat::KokkosUtils)
 
 # Test view broadcast
-EkatCreateUnitTest(view_broadcast view_broadcast.cpp
+EkatCreateUnitTest(view_broadcast
+  SOURCES view_broadcast.cpp
   LIBS ekat::KokkosUtils)
 
 # Test subview utils
-EkatCreateUnitTest(subview_utils subview_utils.cpp
+EkatCreateUnitTest(subview_utils
+  SOURCES subview_utils.cpp
   LIBS ekat::KokkosUtils)
 
 # Test team policy utils
-EkatCreateUnitTest(team_policy_utils team_policy_utils.cpp
+EkatCreateUnitTest(team_policy_utils
+  SOURCES team_policy_utils.cpp
   LIBS ekat::KokkosUtils
   PRINT_OMP_AFFINITY
   THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC}
@@ -37,17 +43,20 @@ else ()
   set (thr_inc ${EKAT_TEST_THREAD_INC})
 endif()
 
-EkatCreateUnitTest(workspace_mgr workspace_mgr.cpp
+EkatCreateUnitTest(workspace_mgr
+  SOURCES workspace_mgr.cpp
   LIBS ekat::KokkosUtils
   PRINT_OMP_AFFINITY
   THREADS 1 ${max_thr} ${thr_inc})
 
 if (Kokkos_ENABLE_CUDA AND Kokkos_ENABLE_CUDA_UVM)
   # Test ability to move a kernel to host
-  EkatCreateUnitTest (kernel_on_host kernel_on_host.cpp
+  EkatCreateUnitTest (kernel_on_host
+    SOURCES kernel_on_host.cpp
     LIBS ekat::KokkosUtils)
 endif()
 
 # Test the where construct (for scalar types)
-EkatCreateUnitTest(where where.cpp
+EkatCreateUnitTest(where
+  SOURCES where.cpp
   LIBS ekat::KokkosUtils)

--- a/tests/logging/CMakeLists.txt
+++ b/tests/logging/CMakeLists.txt
@@ -1,10 +1,12 @@
 include(EkatCreateUnitTest)
 
 # Test basic logger capabilities
-EkatCreateUnitTest(serial_file_log serial_file_log_tests.cpp
+EkatCreateUnitTest(serial_file_log
+  SOURCES serial_file_log_tests.cpp
   LIBS ekat::Logging)
 
-EkatCreateUnitTest(mpi_file_log_tests mpi_file_log_tests.cpp
+EkatCreateUnitTest(mpi_file_log_tests
+  SOURCES mpi_file_log_tests.cpp
   LIBS ekat::Logging
   MPI_RANKS 1 ${EKAT_TEST_MAX_RANKS}
   PROPERTIES FAIL_REGULAR_EXPRESSION "rank1"
@@ -22,7 +24,8 @@ foreach(RANK RANGE 1 ${EKAT_TEST_MAX_RANKS})
   endif()
 endforeach()
 
-EkatCreateUnitTest(console_only_log console_only_log_tests.cpp
+EkatCreateUnitTest(console_only_log
+  SOURCES console_only_log_tests.cpp
   LIBS ekat::Logging
   MPI_RANKS ${EKAT_TEST_MAX_RANKS}
   PROPERTIES PASS_REGULAR_EXPRESSION ${pass}

--- a/tests/pack/CMakeLists.txt
+++ b/tests/pack/CMakeLists.txt
@@ -2,36 +2,43 @@ include(EkatCreateUnitTest)
 
 # Test packs
 if (EKAT_TEST_DOUBLE_PRECISION)
-  EkatCreateUnitTest(pack${DP_POSTFIX} pack.cpp
+  EkatCreateUnitTest(pack${DP_POSTFIX}
+    SOURCES pack.cpp
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     LIBS ekat::Pack)
 endif()
 if (EKAT_TEST_SINGLE_PRECISION)
-  EkatCreateUnitTest(pack${SP_POSTFIX} pack.cpp
+  EkatCreateUnitTest(pack${SP_POSTFIX}
+    SOURCES pack.cpp
     COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     LIBS ekat::Pack)
 endif()
 
 # Test pack kokkos utils
 if (EKAT_TEST_DOUBLE_PRECISION)
-  EkatCreateUnitTest(pack_kokkos${DP_POSTFIX} pack_kokkos_utils.cpp
+  EkatCreateUnitTest(pack_kokkos${DP_POSTFIX}
+    SOURCES pack_kokkos_utils.cpp
     COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     LIBS ekat::Pack)
 endif ()
 if (EKAT_TEST_SINGLE_PRECISION)
-  EkatCreateUnitTest(pack_kokkos${SP_POSTFIX} pack_kokkos_utils.cpp
+  EkatCreateUnitTest(pack_kokkos${SP_POSTFIX}
+    SOURCES pack_kokkos_utils.cpp
     COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     LIBS ekat::Pack)
 endif ()
 
 # Test Unmanaged with scalar/pack views (c++)
-EkatCreateUnitTest(unmanaged unmanaged.cpp
+EkatCreateUnitTest(unmanaged
+  SOURCES unmanaged.cpp
   LIBS ekat::Pack)
 
 # Test the where construct
-EkatCreateUnitTest(pack_where pack_where.cpp
+EkatCreateUnitTest(pack_where
+  SOURCES pack_where.cpp
   LIBS ekat::Pack)
 
 # Test pack index arithmetics utils
-EkatCreateUnitTest(pack_utils pack_utils.cpp
+EkatCreateUnitTest(pack_utils
+  SOURCES pack_utils.cpp
   LIBS ekat::Pack)

--- a/tests/parser/CMakeLists.txt
+++ b/tests/parser/CMakeLists.txt
@@ -4,5 +4,6 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                 ${CMAKE_CURRENT_BINARY_DIR}/input.yaml COPYONLY)
 
 # Test yaml parser
-EkatCreateUnitTest(yaml_parser yaml_parser.cpp
+EkatCreateUnitTest(yaml_parser
+  SOURCES yaml_parser.cpp
   LIBS ekat::YamlParser)

--- a/valgrind_support/CMakeLists.txt
+++ b/valgrind_support/CMakeLists.txt
@@ -7,7 +7,8 @@ if (NOT EKAT_VALGRIND_SUPPRESSION_FILE)
     add_executable(mpi_hw mpi_hw.cxx)
     target_link_libraries (mpi_hw PUBLIC MPI::MPI_C)
   endif()
-  EkatCreateUnitTestExec(mpi_valg_catch_test mpi_catch_test.cpp)
+  EkatCreateUnitTestExec(mpi_valg_catch_test
+    SOURCES mpi_catch_test.cpp)
 
   # We know this var was not set so it's safe to FORCE set it.
   set(EKAT_VALGRIND_SUPPRESSION_FILE ${CMAKE_BINARY_DIR}/ekat_gen_valgrind.supp CACHE FILEPATH "" FORCE)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The cmake function EkatCreateUnitTestExec uses a named argument for the source files list. However, I find this a bit error prone compared to the more modern cmake way (based on `cmake_parse_arguments`). In particular, it forces to use quotes to list all source files, and lists are one of the more tricky things in cmake: if you forget to quote, or use a var that expands to 2+ elements, the named argument would only bind to the 1st element, and the rest of the list will be parsed by `cmake_parse_arguments`. Moreover, keywords are much more self-documenting:
```cmake
EkatCreateUnitTestExec (my_test
 "a.cpp;b.cpp;c.cpp"
)
EkatCreateUnitTestExec (my_test
  SOURCES a.cpp b.cpp c.cpp
)
```
To make sure this wasn't just my preference, I googled (and asked our bot friends), and it seems that keywords are in fact preferred over positional args, for readability and maintainability reasons. Let me know if you guys disagree.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
This will require to adapt the eamxx wrapper when we update ekat in e3sm.

<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
