### PR TITLE
Use an alias for Kokkos' default view memory trait

### DIFF
--- a/src/kokkos/ekat_kokkos_types.hpp
+++ b/src/kokkos/ekat_kokkos_types.hpp
@@ -44,6 +44,9 @@ using DefaultDevice = Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::Defa
 // A device type to force host execution
 using HostDevice = Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultHostExecutionSpace::memory_space>;
 
+// Alias for Kokkos' default memory trait for views (managed memory, no special properties)
+using ManagedMemoryTrait = Kokkos::MemoryTraits<0>;
+
 template<typename DT, typename... Props>
 using ViewLR = Kokkos::View<DT,Kokkos::LayoutRight,Props...>;
 
@@ -66,42 +69,42 @@ struct KokkosTypes
   template<typename TagType>
   using TeamTagPolicy = Kokkos::TeamPolicy<ExeSpace,TagType>;
 
-  template <typename DataType, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename DataType, typename MemoryTraits = ManagedMemoryTrait>
   using view = Kokkos::View<DataType, Layout, Device, MemoryTraits>;
 
   // left-layout views, may be useful for interacting with fortran
-  template <typename DataType, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename DataType, typename MemoryTraits = ManagedMemoryTrait>
   using lview = Kokkos::View<DataType, Kokkos::LayoutLeft, Device, MemoryTraits>;
 
   // strided-layout views, may be needed in certain subview operations
-  template <typename DataType, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename DataType, typename MemoryTraits = ManagedMemoryTrait>
   using sview = Kokkos::View<DataType, Kokkos::LayoutStride, Device, MemoryTraits>;
 
   // A N-dim view given scalar type and N
-  template<typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template<typename Scalar, int N, typename MemoryTraits = ManagedMemoryTrait>
   using view_ND = view<typename DataND<Scalar,N>::type,MemoryTraits>;
 
   // More verbose cases for N=1,2,3
-  template <typename Scalar, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename Scalar, typename MemoryTraits = ManagedMemoryTrait>
   using view_1d = view<Scalar*,MemoryTraits>;
 
-  template <typename Scalar, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename Scalar, typename MemoryTraits = ManagedMemoryTrait>
   using view_2d = view<Scalar**,MemoryTraits>;
 
-  template <typename Scalar, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename Scalar, typename MemoryTraits = ManagedMemoryTrait>
   using view_3d = view<Scalar***,MemoryTraits>;
 
-  template <typename Scalar, int X, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename Scalar, int X, typename MemoryTraits = ManagedMemoryTrait>
   using view_1d_table = view<const Scalar[X],MemoryTraits>;
 
-  template <typename Scalar, int X, int Y, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename Scalar, int X, int Y, typename MemoryTraits = ManagedMemoryTrait>
   using view_2d_table = view<const Scalar[X][Y],MemoryTraits>;
 
   // Our workspace implementation makes this a useful type
-  template <typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
   using view_1d_ptr_array = Kokkos::Array<Unmanaged<view_1d<Scalar,MemoryTraits> >*, N>;
 
-  template <typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryTraits<0>>
+  template <typename Scalar, int N, typename MemoryTraits = Kokkos::MemoryTraits<Kokkos::Unmanaged>>
   using view_1d_ptr_carray = Kokkos::Array<const Unmanaged<view_1d<Scalar,MemoryTraits> >*, N>;
 };
 


### PR DESCRIPTION
Add an alias for Kokkos' default memory trait (managed memory, no other specializations) since Kokkos deprecated `using MemoryManaged = MemoryTraits<0>`.