### PR TITLE
Update HEADERS for expressions

### DIFF
--- a/src/expression/CMakeLists.txt
+++ b/src/expression/CMakeLists.txt
@@ -9,12 +9,13 @@ target_include_directories(ekat_expression INTERFACE
 
 # Set the PUBLIC_HEADER property
 set (HEADERS
-  ekat_expression_meta.hpp
+  ekat_expression_base.hpp
   ekat_expression_binary_op.hpp
-  ekat_expression_compare.hpp
+  ekat_expression_binary_predicate.hpp
   ekat_expression_conditional.hpp
   ekat_expression_eval.hpp
   ekat_expression_math.hpp
+  ekat_expression_traits.hpp
   ekat_expression_view.hpp
 )
 set_target_properties(ekat_expression PROPERTIES PUBLIC_HEADER "${HEADERS}")


### PR DESCRIPTION
PR https://github.com/E3SM-Project/EKAT/pull/439 did not update CMake HEADERS for expressions subdir. This only is an issue in CIME cases where EKAT is being installed.