### PR TITLE
Upgrade error macros to handle throw inside stack unwind

### DIFF
--- a/src/core/ekat_assert.hpp
+++ b/src/core/ekat_assert.hpp
@@ -3,6 +3,7 @@
 
 #include <sstream>
 #include <iostream>
+#include <exception>  // For std::uncaught_exceptions
 #include <stdexcept>  // For std::runtime_error
 #include <type_traits>
 
@@ -24,23 +25,39 @@
 #endif
 
 namespace ekat {
+
+// This thread-local var allows to detect if we already printed the warning about
+// being inside a stack unwind, so that we don't print those lines MANY times when
+// SEVERAL errors are hit during stack unwind.
+inline thread_local bool unwind_warning_issued = false;
+
 // To be used in the following macro. We need template so that "if constepxr" can
 // effectively PREVENT the compilation of the wrong branch. Without template indirection,
 // the compiler will attempt to instantiate BOTH branches
 template<typename exception_type>
-void throw_exception(const std::string& msg)
+void throw_exception(const std::string& msg, const std::string& bt) // msg=message, bt=backtrace
 {
+  if (std::uncaught_exceptions()>0) {
+    if (not unwind_warning_issued) {
+      std::cerr << "[EKAT Critical error] Exception thrown while unwinding the stack.\n"
+                << " This error is being suppressed to prevent std::terminate and the\n"
+                << " subsequent loss of the stacktrace from the first exception.\n"
+                << "Suppressed Message: " << msg << std::endl << std::flush;
+      unwind_warning_issued = true;
+    }
+    return;
+  }
+  unwind_warning_issued = false;
   if constexpr (std::is_constructible<exception_type, const std::string&>::value) {
-    throw exception_type(msg);
+    throw exception_type(msg+bt);
   } else if constexpr (std::is_default_constructible<exception_type>::value) {
-    std::cerr << msg << "\n";
+    std::cerr << msg << bt << "\n";
     throw exception_type();
   } else {
-    std::cerr << msg << "\n";
     std::cerr << "Cannot create exception of type\n";
     std::cerr << "       " << typeid(exception_type).name() << "\n";
     std::cerr << "Throwing std::runtime_error instead...\n";
-    throw std::runtime_error(msg);
+    throw std::runtime_error(msg+bt);
   }
 }
 
@@ -48,15 +65,15 @@ void throw_exception(const std::string& msg)
 
 // Internal do not call directly.
 #define IMPL_THROW(condition, msg, exception_type)  \
-  do {                                                                  \
-    if ( ! (condition) ) {                                              \
-      std::stringstream ekat_tmp_ss;                                    \
-      ekat_tmp_ss << msg;                                               \
-      ekat_tmp_ss << "\nFAILED CONDITION: '" << #condition  << "'\n\n"; \
-      ekat_tmp_ss << "BACKTRACE:\n";                                    \
-      ekat_tmp_ss << EKAT_BACKTRACE << "\n";                            \
-      ekat::throw_exception<exception_type>(ekat_tmp_ss.str());         \
-    }                                                                   \
+  do {                                                                            \
+    if ( ! (condition) ) {                                                        \
+      std::stringstream ekat_msg_ss, ekat_tmp_ss;                                 \
+      ekat_msg_ss << msg;                                                         \
+      ekat_tmp_ss << "\nFAILED CONDITION: '" << #condition  << "'\n\n";           \
+      ekat_tmp_ss << "BACKTRACE:\n";                                              \
+      ekat_tmp_ss << EKAT_BACKTRACE << "\n";                                      \
+      ekat::throw_exception<exception_type>(ekat_msg_ss.str(),ekat_tmp_ss.str()); \
+    }                                                                             \
   } while(0)
 
 // Define the EKAT_REQUIRE macros for different argument counts

--- a/tests/core/debug_tools_tests.cpp
+++ b/tests/core/debug_tools_tests.cpp
@@ -227,4 +227,70 @@ TEST_CASE ("assert-macros") {
   }
 }
 
+// helper class to trigger an EKAT check during its destructor
+struct UnwindTrig {
+  bool should_fail;
+  UnwindTrig(bool fail) : should_fail(fail) {}
+  ~UnwindTrig() {
+    // If should_fail is true, this will call ekat::throw_exception.
+    // If this destructor is called during an unwind, throw_exception
+    // should detect std::uncaught_exceptions() > 0 and log/return instead of throw.
+    EKAT_REQUIRE_MSG(!should_fail, "Secondary failure in destructor");
+  }
+};
+
+TEST_CASE("unwind-safety") {
+  printf ("*) testing exception unwind safety...\n");
+
+  SECTION("suppress-secondary-throw") {
+    // This section verifies that if EKAT_REQUIRE fails during an unwind,
+    // it doesn't throw a second exception (which would call std::terminate).
+
+    auto trigger_unwind = []() {
+      // 1. Create an object that will fail its EKAT check in its destructor
+      UnwindTrig guard(true);
+
+      // 2. Throw the "Primary" exception.
+      // This starts the unwind, which calls ~UnwindTrig().
+      EKAT_ERROR_MSG("Primary exception");
+    };
+
+    // If your fix works, REQUIRE_THROWS will catch the "Primary exception".
+    // If it fails, the program will terminate immediately due to the secondary throw.
+    REQUIRE_THROWS_WITH(trigger_unwind(), Catch::Contains("Primary exception"));
+
+    printf("  - Successfully suppressed secondary exception during unwind.\n");
+  }
+
+  SECTION("normal-throw-after-unwind") {
+    // Verify that the 'unwind_warning_issued' flag resets correctly
+    // and we can still throw normally after a previous unwind event.
+    try {
+      UnwindTrig guard(true);
+      throw std::runtime_error("First Unwind");
+    } catch (...) {
+      // Unwind finished
+    }
+
+    // This should still throw normally because std::uncaught_exceptions() is now 0
+    bool threw = false;
+    std::string my_msg = "Post-unwind failure";
+    try {
+      EKAT_REQUIRE_MSG(false, my_msg);
+    } catch (std::runtime_error& e) {
+      threw = true;
+      std::string actual_err = e.what();
+
+      // Verify the message starts correctly.
+      // This ignores the volatile line number at the end of the backtrace.
+      REQUIRE(ekat::starts_with(actual_err, my_msg));
+
+      // You can also verify the failed condition is present
+      REQUIRE(actual_err.find("FAILED CONDITION: 'false'") != std::string::npos);
+    }
+    REQUIRE (threw);
+    printf("  - Correctly reset safety flag after unwind completed.\n");
+  }
+}
+
 } // anonymous namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
When an exception is thrown while the stack is being unwound, the runtime calls std::terminate. This causes the stack (and message) from the original exception to be lost, making debug hard. For instance, during stack unwind, some structures may be cleaned in a way that does not meet "usual" requirements (e.g., all IO files have all been closed). But this should NOT prevent the original error from reaching the screen. The building is on fire, so who cares if a window broke?

This PR adds some logic to the internal `throw_exception` routine, that prevents the exception from being thrown if we can detect that there is already an uncaught exception. It also prints a warning with the curr exception msg (without the stacktrace), but prevents more exception to be printed, to keep the screen poliution to a minimum. The idea is "ok, we're likely about to crash, so I'll let you know ONCE that other stuff went south, just so you know, but won't interfere with the current execution".

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## E3SM Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->
I think this will drastically improve debugging experience in E3SM, where the typical error msg in the logs was
```
[EAMxx] Finalize ...
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error! ScorpioSession::finalize called, but a file is still in use elsewhere.
 - filename: /home/lbertag/workdir/e3sm/e3sm-data/inputdata/atm/cam/topo/USGS-gtopo30_ne2np4pg2_x6t_20230331.nc

FAILED CONDITION: 'it.second.num_customers==0'
```
which is thrown by the shutdown of the scorpio session which we do during the driver cleanup, and which prevented users from seeing the REAL issue that sparked the first exception.

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I added a unit test, and also verified in eamxx that with this branch I _do_ see the original error (instead of the secondary one) when the code crashes.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
