### PR TITLE
Fix expressions unit test in single precision

### DIFF
--- a/tests/expression/expressions.cpp
+++ b/tests/expression/expressions.cpp
@@ -43,6 +43,9 @@ void bin_ops (const ViewT& x, const ViewT& y, const ViewT& z)
 template<typename ViewT>
 void math_fcns (const ViewT& x, const ViewT& y, const ViewT& z)
 {
+  auto eps = std::numeric_limits<Real>::epsilon();
+  auto tol = 1e5*eps;
+
   auto xe = expression(x);
   auto ye = expression(y);
   auto expression = 2*exp(-xe)*sin(xe)*log(ye)-sqrt(xe)+pow(ye,2)+pow(3,xe);
@@ -58,7 +61,7 @@ void math_fcns (const ViewT& x, const ViewT& y, const ViewT& z)
     auto z_val = zh.data()[i];
     auto tgt   = 2*std::exp(-x_val)*std::sin(x_val)*std::log(y_val)
                - std::sqrt(x_val) + std::pow(y_val,2) + std::pow(3,x_val);
-    REQUIRE (z_val==Approx(tgt).epsilon(1e-10));
+    REQUIRE_THAT (z_val, Catch::Matchers::WithinRel(tgt,tol));
   }
 }
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
One of the expressions unit tests was using a fixed 1e-10 tolerance, which is too large for single precision. Instead, switch to a tol based off of `std::numeric_limits<T>::epsilon()`.

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I verified that this fixes the expressions unit test when ekat is tested inside eamxx.
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
