### PR TITLE
Combine rel and abs tol checks for expressions unit tests

### DIFF
--- a/tests/expression/expressions.cpp
+++ b/tests/expression/expressions.cpp
@@ -20,6 +20,9 @@ namespace ekat {
 template<typename ViewT>
 void bin_ops (const ViewT& x, const ViewT& y, const ViewT& z)
 {
+  using Catch::Matchers::WithinAbs;
+  using Catch::Matchers::WithinRel;
+
   auto eps = std::numeric_limits<Real>::epsilon();
   auto tol = 1e5*eps;
   auto xe = expression(x);
@@ -36,13 +39,16 @@ void bin_ops (const ViewT& x, const ViewT& y, const ViewT& z)
     auto y_val = yh.data()[i];
     auto z_val = zh.data()[i];
     auto tgt   = x_val*y_val-1/y_val+2*x_val;
-    REQUIRE_THAT (z_val, Catch::Matchers::WithinRel(tgt,tol));
+    REQUIRE_THAT (z_val, WithinRel(tgt,tol) || WithinAbs(tgt,tol));
   }
 }
 
 template<typename ViewT>
 void math_fcns (const ViewT& x, const ViewT& y, const ViewT& z)
 {
+  using Catch::Matchers::WithinAbs;
+  using Catch::Matchers::WithinRel;
+
   auto eps = std::numeric_limits<Real>::epsilon();
   auto tol = 1e5*eps;
 
@@ -61,7 +67,7 @@ void math_fcns (const ViewT& x, const ViewT& y, const ViewT& z)
     auto z_val = zh.data()[i];
     auto tgt   = 2*std::exp(-x_val)*std::sin(x_val)*std::log(y_val)
                - std::sqrt(x_val) + std::pow(y_val,2) + std::pow(3,x_val);
-    REQUIRE_THAT (z_val, Catch::Matchers::WithinRel(tgt,tol));
+    REQUIRE_THAT (z_val, WithinRel(tgt,tol) || WithinAbs(tgt,tol));
   }
 }
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This should hopefully fix intermittent failures we get on CUDA for the expressions unit tests. They fail when the target and computed values are already small numbers, so that their relative diff is larger than the tolerance (due to rounding), but still small.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
