### PR TITLE
Fix check in ekat_fetch_content

### DIFF
--- a/cmake/EkatUtils.cmake
+++ b/cmake/EkatUtils.cmake
@@ -169,13 +169,8 @@ function (ekat_fetch_content NAME)
   string(TOUPPER "${NAME}" NAME_UPPER)
   string(REPLACE "-" "_" NAME_SANITIZED "${NAME_UPPER}")
   set(OVERRIDE_VAR "FETCHCONTENT_SOURCE_DIR_${NAME_SANITIZED}")
-  if (DEFINED ${OVERRIDE_VAR})
+  if (${OVERRIDE_VAR})
     set(OVERRIDE_DIR "${${OVERRIDE_VAR}}")
-    if ("${OVERRIDE_DIR}" STREQUAL "")
-      message(FATAL_ERROR
-        "  ${NAME}: ${OVERRIDE_VAR} is defined but empty.\n"
-        "  Please set it to a valid source directory.")
-    endif()
     if (NOT IS_DIRECTORY "${OVERRIDE_DIR}")
       message(FATAL_ERROR
         "  ${NAME}: ${OVERRIDE_VAR} does not point to an existing directory:\n"


### PR DESCRIPTION
The var gets set by CMake in the cache as an advanced one. But if the user did not provide a value for it, on the second run it can be empty, leading to errors:

CMake Error at
/home/runner/e3sm/externals/ekat/cmake/EkatUtils.cmake:175 (message):
    spdlog: FETCHCONTENT_SOURCE_DIR_SPDLOG is defined but empty.
    Please set it to a valid source directory.

<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

The var `FETCHCONTENT_SOURCE_DIR_<PKG>` gets set by CMake in the cache as an advanced one. But if the user did not provide a value for it, on the second run it can be empty, leading to errors:
```
CMake Error at
/home/runner/e3sm/externals/ekat/cmake/EkatUtils.cmake:175 (message):
    spdlog: FETCHCONTENT_SOURCE_DIR_SPDLOG is defined but empty.
    Please set it to a valid source directory.
```

So before using the var, check that it is not empyt
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
