### PR TITLE
Fix issue when using zip to modify containers

### DIFF
--- a/src/core/ekat_zip.hpp
+++ b/src/core/ekat_zip.hpp
@@ -31,9 +31,9 @@ public:
   ZipIterator (std::tuple<Iterators...> iters) : iterators(iters) {}
 
   // Dereference operator
-  auto operator*() {
+  decltype(auto) operator*() {
     return std::apply([](Iterators... its){
-      return std::make_tuple(*its...);
+      return std::forward_as_tuple(*its...);
     },iterators);
   }
 

--- a/tests/algorithm/CMakeLists.txt
+++ b/tests/algorithm/CMakeLists.txt
@@ -5,14 +5,12 @@ if (EKAT_TEST_DOUBLE_PRECISION)
   EkatCreateUnitTest(lin_interp${DP_POSTFIX}
     SOURCES lin_interp_test.cpp
     LIBS ekat::Algorithm
-    COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC})
 endif()
 if (EKAT_TEST_SINGLE_PRECISION)
   EkatCreateUnitTest(lin_interp${SP_POSTFIX}
     SOURCES lin_interp_test.cpp
     LIBS ekat::Algorithm
-    COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     THREADS 1 ${EKAT_TEST_MAX_THREADS} ${EKAT_TEST_THREAD_INC})
 endif()
 
@@ -23,7 +21,6 @@ if (EKAT_TEST_DOUBLE_PRECISION)
             tridiag_tests_correctness.cpp
             tridiag_tests_performance.cpp
     LIBS ekat::Algorithm
-    COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     THREADS ${EKAT_TEST_MAX_THREADS}
     EXCLUDE_MAIN_CPP)
 endif()
@@ -33,7 +30,6 @@ if (EKAT_TEST_SINGLE_PRECISION)
             tridiag_tests_correctness.cpp
             tridiag_tests_performance.cpp
     LIBS ekat::Algorithm
-    COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     THREADS ${EKAT_TEST_MAX_THREADS}
     EXCLUDE_MAIN_CPP)
 endif()
@@ -57,12 +53,10 @@ endif()
 if (EKAT_TEST_DOUBLE_PRECISION)
   EkatCreateUnitTest(reduction${DP_POSTFIX}
     SOURCES reduction_tests.cpp
-    COMPILER_DEFS EKAT_TEST_DOUBLE_PRECISION
     LIBS ekat::Algorithm)
 endif()
 if (EKAT_TEST_SINGLE_PRECISION)
   EkatCreateUnitTest(reduction${SP_POSTFIX}
     SOURCES reduction_tests.cpp
-    COMPILER_DEFS EKAT_TEST_SINGLE_PRECISION
     LIBS ekat::Algorithm)
 endif()

--- a/tests/core/zip.cpp
+++ b/tests/core/zip.cpp
@@ -22,7 +22,15 @@ TEST_CASE ("ekat_comm","") {
   for (const auto& [i,s] : zip(v1,l1)) {
     REQUIRE (std::to_string(i)==s);
   }
+  int idx = 0;
+  for (auto&& [i,s] : zip(v1,l1)) {
+    i *= -1;
+    s += "_done";
+    REQUIRE (v1[idx]==i);
+    REQUIRE (*std::next(l1.begin(),idx)==s);
+    ++idx;
+  }
 }
 
-} // namespace ekat
 
+} // namespace ekat


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The `zip` function returns a temporary object which is later dereferenced by `operator*` into a temporary tuple. As such, using `auto&` violates C++ rules, as it binds an lvalue ref (the lhs tuple) to an rvalue ref (the rhs tuple). The gold standard solution is to use `auto&&`, together with a minor modification to the `operator*` implementation (which is what happens here).

 The key mod is to ensure that the reference in the tuple is forwarded correctly to the resulting type, as `make_tuple` and the plain `auto` return type would silently cause to return a tuple of T's rather than a tuple of T&'s.
 
 More details: `forward_as_tuple` allows the tuple created in the lambda inside `operator*` to return an actual tuple of T& rather than a tuple of T. The decltype in the function return type prevents this to be (quite misteriously, I agree) decay the generated tuple<T&>&& to tuple<T>. Why I don't quite grasp this last bit myself, I followed gemini suggestion, and verified that without `decltype(auto)`, some aptly crafted containers _can_ fail to return a tuple of refs.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## E3SM Stakeholder Feedback
If a github issue includes feedback from the relevant E3SM stakeholder(s), please link it.  
-->

## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I verified that this fixes the following code that did not compile in eamxx:
```
for (auto& [name,dim] : ekat::zip(names,dims)) {...}
```
where `names` and `dims` where nonconst std vectors. Both the `auto&&` mod in the customer code and this PR are needed to fix the compiler error.

## Additional Information

This is ONLY needed for loops using non-const structured binding. Usage along the line of `for (const auto& [a,b] : ekat::zip(C1,C2))` was already correct (standard compliant, not just "gcc-lucky").