### PR TITLE
Modify nightly build to perform cdash submission to E3SM cdash

### DIFF
--- a/.github/workflows/ghci-snl-testing.yml
+++ b/.github/workflows/ghci-snl-testing.yml
@@ -83,7 +83,13 @@ jobs:
           python3 -m pip install --upgrade --trusted-host pypi.org cacts
       - name: Run tests
         run: |
-          cmd="cacts -m ghci-snl-gnu -t ${{ matrix.build_type }} -r ./"
+          # Determine if the scheduler flag should be included
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            extra_flags="-s"
+          else
+            extra_flags=""
+          fi
+          cmd="cacts -m ghci-snl-gnu -t ${{ matrix.build_type }} -r ./ $extra_flags"
           echo "CACTS call: $cmd"
           $cmd
       - name: Upload files

--- a/cacts.yaml
+++ b/cacts.yaml
@@ -38,6 +38,10 @@
 project:
   name: EKAT
   ctest_error_exceptions: ["error_handler"]
+  cdash:
+    drop_site: "my.cdash.org"
+    drop_location: "/submit.php?project=E3SM"
+    build_prefix: "ekat_"
 
   # NOTE: CACTS will also set project.root_dir at runtime, so you can actually use
   # ${project.root_dir} in the machines/configurations sections


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
EKAT's nightly testing does not submit to cdash. Instead, we test ekat inside of eamxx standalone nightly testing, and submit along with it. This PR makes EKAT take care of its own cdash submission, so we can remove its testing from eamxx nightlies (which was somehow causing a hang for the oneapi job).

<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing
<!---
Please confirm that any classes or functions in EKAT that this PR touches are 
exercised by at least one test.  Please specify which test that is. If the change is
untestable (e.g., documentation), please specify why.
-->
I fired up the ghci-snl container on mappy, and manually ran the cacts testing cmd that the workflow runs.  It successfully submitted to cdash [here](https://my.cdash.org/builds/3636469).
<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->
