### PR TITLE
Fix runner labels for cuda/oneapi jobs

### DIFF
--- a/.github/workflows/ghci-snl-testing.yml
+++ b/.github/workflows/ghci-snl-testing.yml
@@ -112,7 +112,7 @@ jobs:
           github.event.inputs.job_to_run == 'all'
         )
       }}
-    runs-on:  [self-hosted, ghci-snl, cuda, gnu]
+    runs-on:  [self-hosted, ghci-snl, cuda]
     strategy:
       fail-fast: false
       matrix:
@@ -199,7 +199,7 @@ jobs:
           github.event.inputs.job_to_run == 'all'
         )
       }}
-    runs-on:  [self-hosted, ghci-snl-oneapi, oneapi]
+    runs-on:  [self-hosted, ghci-snl, oneapi]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Our runners got updated a few weeks ago, and their labels changed a bit. The CUDA/OneAPI jobs in our workflow were not updated accordingly. This should fix it.
<!---
If applicable, let us know how this pull request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## Additional Information
Anything else we need to know in evaluating this pull request?
 -->

@tcclevenger Once this is merged, you can rebase your C++20 PR on master, and it should finally get tested on those runners too.