### PR TITLE
Add nvidia-grace kokkos machine file

### DIFF
--- a/cmake/machine-files/kokkos/nvidia-grace.cmake
+++ b/cmake/machine-files/kokkos/nvidia-grace.cmake
@@ -1,0 +1,4 @@
+include (${CMAKE_CURRENT_LIST_DIR}/generic.cmake)
+
+# Enable Grace ARM arch in kokkos
+option(Kokkos_ARCH_ARMV9_GRACE "" ON)


### PR DESCRIPTION
Add cmake/machine-files/kokkos/nvidia-grace.cmake, enabling the Kokkos_ARCH_ARMV9_GRACE arch option for NVIDIA Grace (ARM) CPUs. Tested building on vista-gg.
